### PR TITLE
feat: add microphone menu and gated system audio mute

### DIFF
--- a/Voxt/App/AppDelegate+MenuWindow.swift
+++ b/Voxt/App/AppDelegate+MenuWindow.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import CoreAudio
 
 extension AppDelegate {
     private var feedbackURL: URL {
@@ -16,6 +17,10 @@ extension AppDelegate {
         let reportItem = NSMenuItem(title: AppLocalization.localizedString("Report"), action: #selector(openReportSettings), keyEquivalent: "")
         reportItem.target = self
         menu.addItem(reportItem)
+
+        let microphoneItem = NSMenuItem(title: AppLocalization.localizedString("Microphone"), action: nil, keyEquivalent: "")
+        microphoneItem.submenu = buildMicrophoneMenu()
+        menu.addItem(microphoneItem)
 
         let checkUpdatesItem = NSMenuItem(
             title: AppLocalization.localizedString("Check for Updates…"),
@@ -48,6 +53,49 @@ extension AppDelegate {
         statusItem?.menu = menu
     }
 
+    private func buildMicrophoneMenu() -> NSMenu {
+        let submenu = NSMenu()
+        let devices = AudioInputDeviceManager.availableInputDevices()
+        let resolvedSelectedID = resolvedMenuSelectedInputDeviceID(from: devices)
+
+        for device in devices {
+            let item = NSMenuItem(title: device.name, action: #selector(selectMicrophoneFromMenu(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = Int(device.id)
+            item.state = device.id == resolvedSelectedID ? .on : .off
+            submenu.addItem(item)
+        }
+
+        if submenu.items.isEmpty {
+            let emptyItem = NSMenuItem(title: AppLocalization.localizedString("No microphone available"), action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            submenu.addItem(emptyItem)
+        }
+
+        return submenu
+    }
+
+    private func resolvedMenuSelectedInputDeviceID(from devices: [AudioInputDevice]) -> AudioDeviceID? {
+        if let selectedInputDeviceID,
+           devices.contains(where: { $0.id == selectedInputDeviceID }) {
+            return selectedInputDeviceID
+        }
+
+        if let defaultDeviceID = AudioInputDeviceManager.defaultInputDeviceID(),
+           devices.contains(where: { $0.id == defaultDeviceID }) {
+            UserDefaults.standard.set(Int(defaultDeviceID), forKey: AppPreferenceKey.selectedInputDeviceID)
+            return defaultDeviceID
+        }
+
+        if let first = devices.first {
+            UserDefaults.standard.set(Int(first.id), forKey: AppPreferenceKey.selectedInputDeviceID)
+            return first.id
+        }
+
+        UserDefaults.standard.set(0, forKey: AppPreferenceKey.selectedInputDeviceID)
+        return nil
+    }
+
     @objc private func checkForUpdates() {
         VoxtLog.info("Manual update check triggered from menu.")
         appUpdateManager.checkForUpdates(source: .manual)
@@ -64,6 +112,10 @@ extension AppDelegate {
 
     @objc private func openReportSettings() {
         openSettingsWindow(selectTab: .report)
+    }
+
+    @objc private func selectMicrophoneFromMenu(_ sender: NSMenuItem) {
+        UserDefaults.standard.set(sender.tag, forKey: AppPreferenceKey.selectedInputDeviceID)
     }
 
     func openSettingsWindow(selectTab: SettingsTab?) {

--- a/Voxt/App/AppDelegate+PreferencesAndHistory.swift
+++ b/Voxt/App/AppDelegate+PreferencesAndHistory.swift
@@ -16,6 +16,10 @@ extension AppDelegate {
         defaults.bool(forKey: AppPreferenceKey.interactionSoundsEnabled)
     }
 
+    var muteSystemAudioWhileRecording: Bool {
+        defaults.bool(forKey: AppPreferenceKey.muteSystemAudioWhileRecording)
+    }
+
     var overlayPosition: OverlayPosition {
         enumValue(forKey: AppPreferenceKey.overlayPosition, default: .bottom)
     }

--- a/Voxt/App/AppDelegate+RecordingSession.swift
+++ b/Voxt/App/AppDelegate+RecordingSession.swift
@@ -28,6 +28,7 @@ extension AppDelegate {
         )
 
         applyPreferredInputDevice()
+        overlayState.reset()
         overlayState.statusMessage = ""
 
         if transcriptionEngine == .mlxAudio {
@@ -50,19 +51,34 @@ extension AppDelegate {
         }
 
         isSessionActive = true
+        pendingSystemAudioMuteTask?.cancel()
+        pendingSystemAudioMuteTask = nil
+        overlayWindow.show(
+            state: overlayState,
+            position: overlayPosition
+        )
+
+        let startCapture = { [weak self] in
+            guard let self else { return }
+            if self.transcriptionEngine == .mlxAudio, self.isMLXReady {
+                self.startMLXRecordingSession()
+            } else if self.transcriptionEngine == .remote {
+                self.startRemoteRecordingSession()
+            } else {
+                self.startSpeechRecordingSession()
+            }
+
+            self.startSilenceMonitoringIfNeeded()
+        }
+
+        if muteSystemAudioWhileRecording {
+            _ = systemAudioMuteController.muteSystemAudioIfNeeded()
+        }
         if interactionSoundsEnabled {
             interactionSoundPlayer.playStart()
         }
 
-        if transcriptionEngine == .mlxAudio, isMLXReady {
-            startMLXRecordingSession()
-        } else if transcriptionEngine == .remote {
-            startRemoteRecordingSession()
-        } else {
-            startSpeechRecordingSession()
-        }
-
-        startSilenceMonitoringIfNeeded()
+        startCapture()
     }
 
     func endRecording() {
@@ -74,6 +90,8 @@ extension AppDelegate {
         VoxtLog.info("Recording stop requested.")
 
         cancelActiveRecordingTasks()
+        pendingSystemAudioMuteTask?.cancel()
+        pendingSystemAudioMuteTask = nil
         stopRecordingFallbackTask?.cancel()
         stopRecordingFallbackTask = nil
         recordingStoppedAt = Date()
@@ -111,6 +129,8 @@ extension AppDelegate {
         didCommitSessionOutput = true
 
         cancelSessionControlTasks()
+        pendingSystemAudioMuteTask?.cancel()
+        pendingSystemAudioMuteTask = nil
         recordingStoppedAt = Date()
         overlayState.isCompleting = false
         overlayState.statusMessage = ""
@@ -340,6 +360,7 @@ extension AppDelegate {
 
     private func resetSessionAfterFailedStart() {
         cancelSessionControlTasks()
+        systemAudioMuteController.restoreSystemAudioIfNeeded()
         isSessionActive = false
         isSessionCancellationRequested = false
         didCommitSessionOutput = false

--- a/Voxt/App/AppDelegate+SessionEndFlow.swift
+++ b/Voxt/App/AppDelegate+SessionEndFlow.swift
@@ -14,11 +14,20 @@ extension AppDelegate {
         }
     }
 
+    private struct RestoreSystemAudioStage: SessionEndStage {
+        var name: String { "restoreSystemAudio" }
+
+        func run(delegate: AppDelegate) {
+            delegate.systemAudioMuteController.restoreSystemAudioIfNeeded()
+        }
+    }
+
     private struct PlayEndSoundStage: SessionEndStage {
         var name: String { "playEndSound" }
 
         func run(delegate: AppDelegate) {
-            if delegate.interactionSoundsEnabled {
+            guard delegate.interactionSoundsEnabled else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 delegate.interactionSoundPlayer.playEnd()
             }
         }
@@ -33,6 +42,7 @@ extension AppDelegate {
             delegate.isSelectedTextTranslationFlow = false
             delegate.enhancementContextSnapshot = nil
             delegate.overlayState.isCompleting = false
+            delegate.overlayState.reset()
             delegate.pendingSessionFinishTask = nil
         }
     }
@@ -40,6 +50,7 @@ extension AppDelegate {
     func executeSessionEndPipeline() {
         let stages: [any SessionEndStage] = [
             HideOverlayStage(),
+            RestoreSystemAudioStage(),
             PlayEndSoundStage(),
             ResetSessionStateStage()
         ]

--- a/Voxt/App/VoxtApp.swift
+++ b/Voxt/App/VoxtApp.swift
@@ -108,6 +108,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let historyStore = TranscriptionHistoryStore()
     let appUpdateManager = AppUpdateManager()
     let interactionSoundPlayer = InteractionSoundPlayer()
+    let systemAudioMuteController = SystemAudioMuteController()
 
     let hotkeyManager = HotkeyManager()
     let overlayWindow = RecordingOverlayWindow()
@@ -129,6 +130,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var pauseLLMTask: Task<Void, Never>?
     var overlayReminderTask: Task<Void, Never>?
     var overlayStatusClearTask: Task<Void, Never>?
+    var pendingSystemAudioMuteTask: Task<Void, Never>?
     var lastSignificantAudioAt = Date()
     var didTriggerPauseTranscription = false
     var didTriggerPauseLLM = false
@@ -162,6 +164,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.register(defaults: [
             AppPreferenceKey.interactionSoundsEnabled: true,
             AppPreferenceKey.interactionSoundPreset: InteractionSoundPreset.soft.rawValue,
+            AppPreferenceKey.muteSystemAudioWhileRecording: false,
             AppPreferenceKey.overlayPosition: OverlayPosition.bottom.rawValue,
             AppPreferenceKey.interfaceLanguage: AppInterfaceLanguage.system.rawValue,
             AppPreferenceKey.translationTargetLanguage: TranslationTargetLanguage.english.rawValue,
@@ -289,6 +292,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         appUpdateManager.automaticallyChecksForUpdates = autoCheckForUpdates
         VoxtLog.info("Voxt launch completed. engine=\(transcriptionEngine.rawValue), enhancement=\(enhancementMode.rawValue)")
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        systemAudioMuteController.restoreSystemAudioIfNeeded()
     }
 
     deinit {

--- a/Voxt/Settings/AppPreferenceKey.swift
+++ b/Voxt/Settings/AppPreferenceKey.swift
@@ -35,6 +35,7 @@ enum AppPreferenceKey {
     static let selectedInputDeviceID = "selectedInputDeviceID"
     static let interactionSoundsEnabled = "interactionSoundsEnabled"
     static let interactionSoundPreset = "interactionSoundPreset"
+    static let muteSystemAudioWhileRecording = "muteSystemAudioWhileRecording"
     static let overlayPosition = "overlayPosition"
     static let interfaceLanguage = "interfaceLanguage"
     static let translationTargetLanguage = "translationTargetLanguage"

--- a/Voxt/Settings/GeneralSettingsView.swift
+++ b/Voxt/Settings/GeneralSettingsView.swift
@@ -8,6 +8,7 @@ struct GeneralSettingsView: View {
     @AppStorage(AppPreferenceKey.selectedInputDeviceID) private var selectedInputDeviceIDRaw = 0
     @AppStorage(AppPreferenceKey.interactionSoundsEnabled) private var interactionSoundsEnabled = true
     @AppStorage(AppPreferenceKey.interactionSoundPreset) private var interactionSoundPresetRaw = InteractionSoundPreset.soft.rawValue
+    @AppStorage(AppPreferenceKey.muteSystemAudioWhileRecording) private var muteSystemAudioWhileRecording = false
     @AppStorage(AppPreferenceKey.overlayPosition) private var overlayPositionRaw = OverlayPosition.bottom.rawValue
     @AppStorage(AppPreferenceKey.interfaceLanguage) private var interfaceLanguageRaw = AppInterfaceLanguage.system.rawValue
     @AppStorage(AppPreferenceKey.translationTargetLanguage) private var translationTargetLanguageRaw = TranslationTargetLanguage.english.rawValue
@@ -34,6 +35,7 @@ struct GeneralSettingsView: View {
     @State private var modelStorageDisplayPath = ""
     @State private var modelStorageSelectionError: String?
     @State private var configurationTransferMessage: String?
+    @State private var systemAudioPermissionMessage: String?
 
     private var selectedInputDeviceID: AudioDeviceID {
         AudioDeviceID(selectedInputDeviceIDRaw)
@@ -106,6 +108,17 @@ struct GeneralSettingsView: View {
                     Text("Play a short start chime when recording begins and an end chime when transcription completes.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    Toggle("Mute other media audio while recording", isOn: $muteSystemAudioWhileRecording)
+                    Text("When enabled, Voxt requests system audio recording permission so it can mute other apps' media audio during recording and restore it after transcription completes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let systemAudioPermissionMessage {
+                        Text(systemAudioPermissionMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
 
                     HStack(alignment: .firstTextBaseline) {
                         Text("Sound Preset")
@@ -459,6 +472,24 @@ struct GeneralSettingsView: View {
         }
         .onChange(of: autoCheckForUpdates) { _, newValue in
             appUpdateManager.automaticallyChecksForUpdates = newValue
+        }
+        .onChange(of: muteSystemAudioWhileRecording) { _, newValue in
+            guard newValue else {
+                systemAudioPermissionMessage = nil
+                return
+            }
+
+            let status = SystemAudioCapturePermission.authorizationStatus()
+            if status == .authorized {
+                systemAudioPermissionMessage = nil
+                return
+            }
+
+            SystemAudioCapturePermission.requestAccess { granted in
+                systemAudioPermissionMessage = granted
+                    ? AppLocalization.localizedString("System audio recording permission granted.")
+                    : AppLocalization.localizedString("System audio recording permission is required for this feature. You can grant it in Settings > Permissions.")
+            }
         }
         .onChange(of: interfaceLanguageRaw) { _, _ in
             NotificationCenter.default.post(name: .voxtInterfaceLanguageDidChange, object: nil)

--- a/Voxt/Settings/PermissionsSettingsView.swift
+++ b/Voxt/Settings/PermissionsSettingsView.swift
@@ -12,6 +12,7 @@ struct PermissionsSettingsView: View {
         case speechRecognition
         case accessibility
         case inputMonitoring
+        case systemAudioCapture
 
         var id: String { rawValue }
 
@@ -21,6 +22,7 @@ struct PermissionsSettingsView: View {
             case .speechRecognition: return "speech"
             case .accessibility: return "accessibility"
             case .inputMonitoring: return "inputMonitoring"
+            case .systemAudioCapture: return "systemAudioCapture"
             }
         }
 
@@ -30,6 +32,7 @@ struct PermissionsSettingsView: View {
             case .speechRecognition: return "Speech Recognition Permission"
             case .accessibility: return "Accessibility Permission"
             case .inputMonitoring: return "Input Monitoring Permission"
+            case .systemAudioCapture: return "System Audio Recording Permission"
             }
         }
 
@@ -43,6 +46,8 @@ struct PermissionsSettingsView: View {
                 return "Required to paste transcription text into other apps."
             case .inputMonitoring:
                 return "Required for reliable global modifier hotkeys (such as fn)."
+            case .systemAudioCapture:
+                return "Required only when muting other apps' media audio during recording is enabled."
             }
         }
     }
@@ -100,6 +105,20 @@ struct PermissionsSettingsView: View {
 
     @AppStorage(AppPreferenceKey.appEnhancementEnabled) private var appEnhancementEnabled = false
     @AppStorage(AppPreferenceKey.appBranchCustomBrowsers) private var appBranchCustomBrowsersJSON = "[]"
+    @AppStorage(AppPreferenceKey.muteSystemAudioWhileRecording) private var muteSystemAudioWhileRecording = false
+
+    private var permissionKinds: [PermissionKind] {
+        var kinds: [PermissionKind] = [
+            .microphone,
+            .speechRecognition,
+            .accessibility,
+            .inputMonitoring
+        ]
+        if muteSystemAudioWhileRecording {
+            kinds.append(.systemAudioCapture)
+        }
+        return kinds
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -112,7 +131,7 @@ struct PermissionsSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    ForEach(PermissionKind.allCases) { kind in
+                    ForEach(permissionKinds) { kind in
                         permissionRow(kind)
                     }
                 }
@@ -161,6 +180,9 @@ struct PermissionsSettingsView: View {
             refreshStates()
             loadBrowserTargets()
             refreshBrowserAutomationStates()
+        }
+        .onChange(of: muteSystemAudioWhileRecording) { _, _ in
+            refreshStates()
         }
         .onDisappear {
             stopAllMonitoring()
@@ -261,7 +283,7 @@ struct PermissionsSettingsView: View {
 
     private func refreshStates() {
         var snapshot: [PermissionKind: PermissionState] = [:]
-        for kind in PermissionKind.allCases {
+        for kind in permissionKinds {
             snapshot[kind] = currentState(for: kind)
         }
         states = snapshot
@@ -281,6 +303,8 @@ struct PermissionsSettingsView: View {
                 return CGPreflightListenEventAccess() ? .enabled : .disabled
             }
             return .enabled
+        case .systemAudioCapture:
+            return SystemAudioCapturePermission.authorizationStatus() == .authorized ? .enabled : .disabled
         }
     }
 
@@ -303,6 +327,8 @@ struct PermissionsSettingsView: View {
             if #available(macOS 10.15, *) {
                 _ = CGRequestListenEventAccess()
             }
+        case .systemAudioCapture:
+            SystemAudioCapturePermission.requestAccess()
         }
     }
 
@@ -585,6 +611,9 @@ struct PermissionsSettingsView: View {
             urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
         case .inputMonitoring:
             urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        case .systemAudioCapture:
+            SystemAudioCapturePermission.openSystemSettings()
+            return
         }
 
         if let url = URL(string: urlString) {
@@ -599,7 +628,7 @@ struct PermissionsSettingsView: View {
     }
 
     private func permissionSnapshotText(_ snapshot: [PermissionKind: PermissionState]) -> String {
-        PermissionKind.allCases
+        permissionKinds
             .map { kind in
                 let state = snapshot[kind] ?? .disabled
                 return "\(kind.logKey)=\(state == .enabled ? "on" : "off")"

--- a/Voxt/Settings/SettingsView.swift
+++ b/Voxt/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @ObservedObject var appUpdateManager: AppUpdateManager
     @AppStorage(AppPreferenceKey.interfaceLanguage) private var interfaceLanguageRaw = AppInterfaceLanguage.system.rawValue
     @AppStorage(AppPreferenceKey.appEnhancementEnabled) private var appEnhancementEnabled = false
+    @AppStorage(AppPreferenceKey.muteSystemAudioWhileRecording) private var muteSystemAudioWhileRecording = false
     @State private var selectedTab: SettingsTab
     @State private var hasMissingPermissions = false
     @State private var missingModelConfigurationIssues: [ConfigurationTransferManager.MissingConfigurationIssue] = []
@@ -106,6 +107,9 @@ struct SettingsView: View {
             if !isEnabled, selectedTab == .appEnhancement {
                 selectedTab = .model
             }
+        }
+        .onChange(of: muteSystemAudioWhileRecording) { _, _ in
+            refreshPermissionBadge()
         }
         .alert(
             String(localized: "Update Information"),
@@ -203,12 +207,14 @@ struct SettingsView: View {
         let speechGranted = SFSpeechRecognizer.authorizationStatus() == .authorized
         let accessibilityGranted = AccessibilityPermissionManager.isTrusted()
         let inputMonitoringGranted: Bool
+        let requiresSystemAudioCapture = UserDefaults.standard.bool(forKey: AppPreferenceKey.muteSystemAudioWhileRecording)
+        let systemAudioCaptureGranted = !requiresSystemAudioCapture || SystemAudioCapturePermission.authorizationStatus() == .authorized
         if #available(macOS 10.15, *) {
             inputMonitoringGranted = CGPreflightListenEventAccess()
         } else {
             inputMonitoringGranted = true
         }
-        hasMissingPermissions = !(microphoneGranted && speechGranted && accessibilityGranted && inputMonitoringGranted)
+        hasMissingPermissions = !(microphoneGranted && speechGranted && accessibilityGranted && inputMonitoringGranted && systemAudioCaptureGranted)
     }
 
     private func refreshModelConfigurationBadge() {

--- a/Voxt/Support/ConfigurationTransferManager.swift
+++ b/Voxt/Support/ConfigurationTransferManager.swift
@@ -42,8 +42,10 @@ enum ConfigurationTransferManager {
         var selectedInputDeviceID: Int
         var interactionSoundsEnabled: Bool
         var interactionSoundPreset: String
+        var muteSystemAudioWhileRecording: Bool
         var overlayPosition: String
         var translationTargetLanguage: String
+        var userMainLanguageCodes: [String]
         var translateSelectedTextOnTranslationHotkey: Bool
         var autoCopyWhenNoFocusedInput: Bool
         var launchAtLogin: Bool
@@ -60,6 +62,116 @@ enum ConfigurationTransferManager {
         var customProxyPort: String
         var customProxyUsername: String
         var customProxyPassword: String
+
+        private enum CodingKeys: String, CodingKey {
+            case interfaceLanguage
+            case selectedInputDeviceID
+            case interactionSoundsEnabled
+            case interactionSoundPreset
+            case muteSystemAudioWhileRecording
+            case overlayPosition
+            case translationTargetLanguage
+            case userMainLanguageCodes
+            case translateSelectedTextOnTranslationHotkey
+            case autoCopyWhenNoFocusedInput
+            case launchAtLogin
+            case showInDock
+            case historyEnabled
+            case historyRetentionPeriod
+            case autoCheckForUpdates
+            case hotkeyDebugLoggingEnabled
+            case llmDebugLoggingEnabled
+            case useSystemProxy
+            case networkProxyMode
+            case customProxyScheme
+            case customProxyHost
+            case customProxyPort
+            case customProxyUsername
+            case customProxyPassword
+        }
+
+        init(
+            interfaceLanguage: String,
+            selectedInputDeviceID: Int,
+            interactionSoundsEnabled: Bool,
+            interactionSoundPreset: String,
+            muteSystemAudioWhileRecording: Bool,
+            overlayPosition: String,
+            translationTargetLanguage: String,
+            userMainLanguageCodes: [String],
+            translateSelectedTextOnTranslationHotkey: Bool,
+            autoCopyWhenNoFocusedInput: Bool,
+            launchAtLogin: Bool,
+            showInDock: Bool,
+            historyEnabled: Bool,
+            historyRetentionPeriod: String,
+            autoCheckForUpdates: Bool,
+            hotkeyDebugLoggingEnabled: Bool,
+            llmDebugLoggingEnabled: Bool,
+            useSystemProxy: Bool,
+            networkProxyMode: String,
+            customProxyScheme: String,
+            customProxyHost: String,
+            customProxyPort: String,
+            customProxyUsername: String,
+            customProxyPassword: String
+        ) {
+            self.interfaceLanguage = interfaceLanguage
+            self.selectedInputDeviceID = selectedInputDeviceID
+            self.interactionSoundsEnabled = interactionSoundsEnabled
+            self.interactionSoundPreset = interactionSoundPreset
+            self.muteSystemAudioWhileRecording = muteSystemAudioWhileRecording
+            self.overlayPosition = overlayPosition
+            self.translationTargetLanguage = translationTargetLanguage
+            self.userMainLanguageCodes = sanitizeUserMainLanguageCodes(userMainLanguageCodes)
+            self.translateSelectedTextOnTranslationHotkey = translateSelectedTextOnTranslationHotkey
+            self.autoCopyWhenNoFocusedInput = autoCopyWhenNoFocusedInput
+            self.launchAtLogin = launchAtLogin
+            self.showInDock = showInDock
+            self.historyEnabled = historyEnabled
+            self.historyRetentionPeriod = historyRetentionPeriod
+            self.autoCheckForUpdates = autoCheckForUpdates
+            self.hotkeyDebugLoggingEnabled = hotkeyDebugLoggingEnabled
+            self.llmDebugLoggingEnabled = llmDebugLoggingEnabled
+            self.useSystemProxy = useSystemProxy
+            self.networkProxyMode = networkProxyMode
+            self.customProxyScheme = customProxyScheme
+            self.customProxyHost = customProxyHost
+            self.customProxyPort = customProxyPort
+            self.customProxyUsername = customProxyUsername
+            self.customProxyPassword = customProxyPassword
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            interfaceLanguage = try container.decode(String.self, forKey: .interfaceLanguage)
+            selectedInputDeviceID = try container.decode(Int.self, forKey: .selectedInputDeviceID)
+            interactionSoundsEnabled = try container.decode(Bool.self, forKey: .interactionSoundsEnabled)
+            interactionSoundPreset = try container.decode(String.self, forKey: .interactionSoundPreset)
+            muteSystemAudioWhileRecording = try container.decodeIfPresent(Bool.self, forKey: .muteSystemAudioWhileRecording) ?? false
+            overlayPosition = try container.decode(String.self, forKey: .overlayPosition)
+            translationTargetLanguage = try container.decode(String.self, forKey: .translationTargetLanguage)
+            userMainLanguageCodes = sanitizeUserMainLanguageCodes(
+                try container.decodeIfPresent([String].self, forKey: .userMainLanguageCodes)
+                    ?? defaultUserMainLanguageCodes
+            )
+            translateSelectedTextOnTranslationHotkey = try container.decode(Bool.self, forKey: .translateSelectedTextOnTranslationHotkey)
+            autoCopyWhenNoFocusedInput = try container.decode(Bool.self, forKey: .autoCopyWhenNoFocusedInput)
+            launchAtLogin = try container.decode(Bool.self, forKey: .launchAtLogin)
+            showInDock = try container.decode(Bool.self, forKey: .showInDock)
+            historyEnabled = try container.decode(Bool.self, forKey: .historyEnabled)
+            historyRetentionPeriod = try container.decode(String.self, forKey: .historyRetentionPeriod)
+            autoCheckForUpdates = try container.decode(Bool.self, forKey: .autoCheckForUpdates)
+            hotkeyDebugLoggingEnabled = try container.decode(Bool.self, forKey: .hotkeyDebugLoggingEnabled)
+            llmDebugLoggingEnabled = try container.decode(Bool.self, forKey: .llmDebugLoggingEnabled)
+            useSystemProxy = try container.decode(Bool.self, forKey: .useSystemProxy)
+            networkProxyMode = try container.decode(String.self, forKey: .networkProxyMode)
+            customProxyScheme = try container.decode(String.self, forKey: .customProxyScheme)
+            customProxyHost = try container.decode(String.self, forKey: .customProxyHost)
+            customProxyPort = try container.decode(String.self, forKey: .customProxyPort)
+            customProxyUsername = try container.decode(String.self, forKey: .customProxyUsername)
+            customProxyPassword = try container.decode(String.self, forKey: .customProxyPassword)
+        }
     }
 
     struct ModelSettings: Codable {
@@ -274,8 +386,12 @@ enum ConfigurationTransferManager {
                 selectedInputDeviceID: defaults.integer(forKey: AppPreferenceKey.selectedInputDeviceID),
                 interactionSoundsEnabled: defaults.bool(forKey: AppPreferenceKey.interactionSoundsEnabled),
                 interactionSoundPreset: defaults.string(forKey: AppPreferenceKey.interactionSoundPreset) ?? "",
+                muteSystemAudioWhileRecording: defaults.bool(forKey: AppPreferenceKey.muteSystemAudioWhileRecording),
                 overlayPosition: defaults.string(forKey: AppPreferenceKey.overlayPosition) ?? OverlayPosition.bottom.rawValue,
                 translationTargetLanguage: defaults.string(forKey: AppPreferenceKey.translationTargetLanguage) ?? TranslationTargetLanguage.english.rawValue,
+                userMainLanguageCodes: storedUserMainLanguageCodes(
+                    from: defaults.string(forKey: legacyUserMainLanguageCodesKey)
+                ),
                 translateSelectedTextOnTranslationHotkey: defaults.object(forKey: AppPreferenceKey.translateSelectedTextOnTranslationHotkey) as? Bool ?? true,
                 autoCopyWhenNoFocusedInput: defaults.bool(forKey: AppPreferenceKey.autoCopyWhenNoFocusedInput),
                 launchAtLogin: defaults.bool(forKey: AppPreferenceKey.launchAtLogin),
@@ -346,8 +462,13 @@ enum ConfigurationTransferManager {
         defaults.set(general.selectedInputDeviceID, forKey: AppPreferenceKey.selectedInputDeviceID)
         defaults.set(general.interactionSoundsEnabled, forKey: AppPreferenceKey.interactionSoundsEnabled)
         defaults.set(general.interactionSoundPreset, forKey: AppPreferenceKey.interactionSoundPreset)
+        defaults.set(general.muteSystemAudioWhileRecording, forKey: AppPreferenceKey.muteSystemAudioWhileRecording)
         defaults.set(general.overlayPosition, forKey: AppPreferenceKey.overlayPosition)
         defaults.set(general.translationTargetLanguage, forKey: AppPreferenceKey.translationTargetLanguage)
+        defaults.set(
+            storageValue(for: general.userMainLanguageCodes),
+            forKey: legacyUserMainLanguageCodesKey
+        )
         defaults.set(general.translateSelectedTextOnTranslationHotkey, forKey: AppPreferenceKey.translateSelectedTextOnTranslationHotkey)
         defaults.set(general.autoCopyWhenNoFocusedInput, forKey: AppPreferenceKey.autoCopyWhenNoFocusedInput)
         defaults.set(general.launchAtLogin, forKey: AppPreferenceKey.launchAtLogin)
@@ -478,6 +599,27 @@ enum ConfigurationTransferManager {
             return []
         }
         return urls.map { ExportedBranchURLItem(id: $0.id, pattern: $0.pattern, iconPlaceholder: "url-icon-placeholder") }
+    }
+
+    private static let legacyUserMainLanguageCodesKey = "userMainLanguageCodes"
+    private static let defaultUserMainLanguageCodes = ["en"]
+
+    private static func sanitizeUserMainLanguageCodes(_ codes: [String]) -> [String] {
+        let sanitized = codes
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        let deduplicated = Array(NSOrderedSet(array: sanitized)) as? [String] ?? sanitized
+        return deduplicated.isEmpty ? defaultUserMainLanguageCodes : deduplicated
+    }
+
+    private static func storedUserMainLanguageCodes(from rawValue: String?) -> [String] {
+        guard let rawValue, !rawValue.isEmpty else { return defaultUserMainLanguageCodes }
+        let parts = rawValue.split(separator: ",").map(String.init)
+        return sanitizeUserMainLanguageCodes(parts)
+    }
+
+    private static func storageValue(for codes: [String]) -> String {
+        sanitizeUserMainLanguageCodes(codes).joined(separator: ",")
     }
 
     private static func sanitizeSensitive(_ value: String) -> String {

--- a/Voxt/Support/InteractionSoundPlayer.swift
+++ b/Voxt/Support/InteractionSoundPlayer.swift
@@ -4,19 +4,22 @@ import AppKit
 final class InteractionSoundPlayer {
     private let volume: Float = 0.22
 
-    func playStart() {
+    @discardableResult
+    func playStart() -> TimeInterval {
         let sounds = resolvedSounds(for: currentPreset())
-        play(named: sounds.start)
+        return play(named: sounds.start)
     }
 
-    func playEnd() {
+    @discardableResult
+    func playEnd() -> TimeInterval {
         let sounds = resolvedSounds(for: currentPreset())
-        play(named: sounds.end)
+        return play(named: sounds.end)
     }
 
-    func playPreview(preset: InteractionSoundPreset) {
+    @discardableResult
+    func playPreview(preset: InteractionSoundPreset) -> TimeInterval {
         let sounds = resolvedSounds(for: preset)
-        play(named: sounds.start)
+        return play(named: sounds.start)
     }
 
     private func currentPreset() -> InteractionSoundPreset {
@@ -37,10 +40,11 @@ final class InteractionSoundPlayer {
         }
     }
 
-    private func play(named name: String) {
+    private func play(named name: String) -> TimeInterval {
         let sound = NSSound(named: name) ?? NSSound(named: "Pop") ?? NSSound(named: "Tink")
         sound?.stop()
         sound?.volume = volume
         sound?.play()
+        return sound?.duration ?? 0
     }
 }

--- a/Voxt/Support/SystemAudioCapturePermission.swift
+++ b/Voxt/Support/SystemAudioCapturePermission.swift
@@ -1,0 +1,65 @@
+import Foundation
+import AppKit
+
+enum SystemAudioCaptureAuthorizationStatus: String {
+    case unknown
+    case denied
+    case authorized
+}
+
+enum SystemAudioCapturePermission {
+    static func authorizationStatus() -> SystemAudioCaptureAuthorizationStatus {
+        guard let preflight = preflightSPI else { return .unknown }
+        let result = preflight("kTCCServiceAudioCapture" as CFString, nil)
+        switch result {
+        case 0:
+            return .authorized
+        case 1:
+            return .denied
+        default:
+            return .unknown
+        }
+    }
+
+    static func requestAccess(completion: ((Bool) -> Void)? = nil) {
+        guard let request = requestSPI else {
+            completion?(false)
+            return
+        }
+
+        request("kTCCServiceAudioCapture" as CFString, nil) { granted in
+            DispatchQueue.main.async {
+                completion?(granted)
+            }
+        }
+    }
+
+    static func openSystemSettings() {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.systempreferences") else {
+            return
+        }
+        NSWorkspace.shared.openApplication(at: url, configuration: .init())
+    }
+
+    private typealias PreflightFuncType = @convention(c) (CFString, CFDictionary?) -> Int
+    private typealias RequestFuncType = @convention(c) (CFString, CFDictionary?, @escaping (Bool) -> Void) -> Void
+
+    private static let apiHandle: UnsafeMutableRawPointer? = {
+        let tccPath = "/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC"
+        return dlopen(tccPath, RTLD_NOW)
+    }()
+
+    private static let preflightSPI: PreflightFuncType? = {
+        guard let apiHandle, let funcSym = dlsym(apiHandle, "TCCAccessPreflight") else {
+            return nil
+        }
+        return unsafeBitCast(funcSym, to: PreflightFuncType.self)
+    }()
+
+    private static let requestSPI: RequestFuncType? = {
+        guard let apiHandle, let funcSym = dlsym(apiHandle, "TCCAccessRequest") else {
+            return nil
+        }
+        return unsafeBitCast(funcSym, to: RequestFuncType.self)
+    }()
+}

--- a/Voxt/Support/SystemAudioMuteController.swift
+++ b/Voxt/Support/SystemAudioMuteController.swift
@@ -3,30 +3,116 @@ import CoreAudio
 
 @MainActor
 final class SystemAudioMuteController {
-    private let duckRatio: Float32 = 0.2
-    private let minimumDuckVolume: Float32 = 0.05
+    private struct ProcessTapSession {
+        let tapID: AudioObjectID
+        let aggregateDeviceID: AudioObjectID
+        let ioProcID: AudioDeviceIOProcID
+    }
 
-    private var savedVolume: Float32?
-    private var mutedDeviceID: AudioDeviceID?
+    private var processTapSession: ProcessTapSession?
 
-    func muteSystemAudioIfNeeded() {
-        guard savedVolume == nil else { return }
-        guard let outputDeviceID = defaultOutputDeviceID() else { return }
-        guard let volume = getOutputVolume(deviceID: outputDeviceID) else { return }
+    @discardableResult
+    func muteSystemAudioIfNeeded() -> Bool {
+        if processTapSession != nil {
+            return true
+        }
+        guard SystemAudioCapturePermission.authorizationStatus() == .authorized else {
+            return false
+        }
 
-        let duckedVolume = max(minimumDuckVolume, volume * duckRatio)
-        guard duckedVolume < volume else { return }
-
-        savedVolume = volume
-        mutedDeviceID = outputDeviceID
-        _ = setOutputVolume(deviceID: outputDeviceID, value: duckedVolume)
+        return activateProcessTapMuteIfPossible()
     }
 
     func restoreSystemAudioIfNeeded() {
-        guard let savedVolume, let deviceID = mutedDeviceID else { return }
-        _ = setOutputVolume(deviceID: deviceID, value: savedVolume)
-        self.savedVolume = nil
-        self.mutedDeviceID = nil
+        if let session = processTapSession {
+            AudioDeviceStop(session.aggregateDeviceID, session.ioProcID)
+            AudioDeviceDestroyIOProcID(session.aggregateDeviceID, session.ioProcID)
+            AudioHardwareDestroyAggregateDevice(session.aggregateDeviceID)
+            AudioHardwareDestroyProcessTap(session.tapID)
+            processTapSession = nil
+        }
+    }
+
+    private func activateProcessTapMuteIfPossible() -> Bool {
+        guard let bundleID = Bundle.main.bundleIdentifier,
+              !bundleID.isEmpty,
+              let outputDeviceID = defaultOutputDeviceID(),
+              let outputUID = deviceUID(for: outputDeviceID)
+        else {
+            return false
+        }
+
+        let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+        tapDescription.uuid = UUID()
+        tapDescription.name = "Voxt System Audio Mute"
+        tapDescription.isPrivate = true
+        tapDescription.isProcessRestoreEnabled = true
+        tapDescription.bundleIDs = [bundleID]
+        tapDescription.muteBehavior = .muted
+
+        var tapID = AudioObjectID(kAudioObjectUnknown)
+        let tapCreateStatus = AudioHardwareCreateProcessTap(tapDescription, &tapID)
+        guard tapCreateStatus == noErr, tapID != AudioObjectID(kAudioObjectUnknown) else {
+            return false
+        }
+
+        let aggregateUID = "voxt-process-tap-\(tapDescription.uuid.uuidString)"
+        let aggregateDescription: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "VoxtProcessTap",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceIsStackedKey: false,
+            kAudioAggregateDeviceTapAutoStartKey: true,
+            kAudioAggregateDeviceSubDeviceListKey: [
+                [
+                    kAudioSubDeviceUIDKey: outputUID
+                ]
+            ],
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapDriftCompensationKey: true,
+                    kAudioSubTapUIDKey: tapDescription.uuid.uuidString
+                ]
+            ]
+        ]
+
+        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        let aggregateStatus = AudioHardwareCreateAggregateDevice(aggregateDescription as CFDictionary, &aggregateDeviceID)
+        guard aggregateStatus == noErr, aggregateDeviceID != AudioObjectID(kAudioObjectUnknown) else {
+            AudioHardwareDestroyProcessTap(tapID)
+            return false
+        }
+
+        var ioProcID: AudioDeviceIOProcID?
+        let ioProcStatus = AudioDeviceCreateIOProcIDWithBlock(
+            &ioProcID,
+            aggregateDeviceID,
+            DispatchQueue.global(qos: .userInitiated)
+        ) { _, _, _, _, _ in
+            // The tap remains active while this no-op IOProc is running.
+        }
+
+        guard ioProcStatus == noErr, let ioProcID else {
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            AudioHardwareDestroyProcessTap(tapID)
+            return false
+        }
+
+        let startStatus = AudioDeviceStart(aggregateDeviceID, ioProcID)
+        guard startStatus == noErr else {
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProcID)
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            AudioHardwareDestroyProcessTap(tapID)
+            return false
+        }
+
+        processTapSession = ProcessTapSession(
+            tapID: tapID,
+            aggregateDeviceID: aggregateDeviceID,
+            ioProcID: ioProcID
+        )
+        return true
     }
 
     private func defaultOutputDeviceID() -> AudioDeviceID? {
@@ -50,30 +136,17 @@ final class SystemAudioMuteController {
         return deviceID
     }
 
-    private func getOutputVolume(deviceID: AudioDeviceID) -> Float32? {
+    private func deviceUID(for deviceID: AudioDeviceID) -> String? {
         var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyVolumeScalar,
-            mScope: kAudioDevicePropertyScopeOutput,
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
 
-        var value: Float32 = 0
-        var dataSize = UInt32(MemoryLayout<Float32>.size)
+        var value: CFString = "" as CFString
+        var dataSize = UInt32(MemoryLayout<CFString>.size)
         let status = AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, nil, &dataSize, &value)
         guard status == noErr else { return nil }
-        return value
-    }
-
-    private func setOutputVolume(deviceID: AudioDeviceID, value: Float32) -> Bool {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyVolumeScalar,
-            mScope: kAudioDevicePropertyScopeOutput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        var mutableValue = max(0, min(1, value))
-        let dataSize = UInt32(MemoryLayout<Float32>.size)
-        let status = AudioObjectSetPropertyData(deviceID, &propertyAddress, 0, nil, dataSize, &mutableValue)
-        return status == noErr
+        return value as String
     }
 }

--- a/Voxt/UI/RecordingOverlayWindow.swift
+++ b/Voxt/UI/RecordingOverlayWindow.swift
@@ -57,6 +57,7 @@ class OverlayState: ObservableObject {
 class RecordingOverlayWindow: NSPanel {
 
     private var hostingView: NSHostingView<OverlayContent>?
+    private var visibilityToken: UInt64 = 0
 
     init() {
         super.init(
@@ -76,6 +77,7 @@ class RecordingOverlayWindow: NSPanel {
     }
 
     func show(state: OverlayState, position: OverlayPosition) {
+        visibilityToken &+= 1
         let content = OverlayContent(state: state)
         let hosting = NSHostingView(rootView: content)
         hosting.translatesAutoresizingMaskIntoConstraints = false
@@ -102,11 +104,14 @@ class RecordingOverlayWindow: NSPanel {
     }
 
     func hide(completion: (() -> Void)? = nil) {
+        let token = visibilityToken
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.3
             animator().alphaValue = 0
         }, completionHandler: { [weak self] in
-            self?.orderOut(nil)
+            guard let self else { return }
+            guard token == self.visibilityToken else { return }
+            self.orderOut(nil)
             completion?()
         })
     }

--- a/Voxt/Voxt/Info.plist
+++ b/Voxt/Voxt/Info.plist
@@ -14,6 +14,8 @@
     <string>public.app-category.utilities</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>Voxt needs automation access to read the active browser tab URL for app branch enhancement.</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>Voxt needs system audio access to temporarily mute other apps while recording.</string>
     <key>NSHumanReadableCopyright</key>
     <string></string>
     <key>NSMicrophoneUsageDescription</key>

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -12,6 +12,8 @@
 "Audio" = "Audio";
 "Microphone" = "Microphone";
 "Interaction Sounds" = "Interaction Sounds";
+"Mute system audio while recording" = "Mute system audio while recording";
+"After the start sound plays, Voxt mutes your Mac's current output volume during recording and restores it before the end sound." = "After the start sound plays, Voxt mutes your Mac's current output volume during recording and restores it before the end sound.";
 "Sound Preset" = "Sound Preset";
 "Preview" = "Preview";
 "Try Sound" = "Try Sound";
@@ -77,6 +79,7 @@
 "Apache License 2.0" = "Apache License 2.0";
 "Project" = "Project";
 "Feedback" = "Feedback";
+"No microphone available" = "No microphone available";
 "Author" = "Author";
 "Thanks" = "Thanks";
 "Logs" = "Logs";
@@ -442,3 +445,9 @@
 "Needs Setup" = "Needs Setup";
 "Model needs to be installed." = "Model needs to be installed.";
 "Configuration required." = "Configuration required.";
+"Mute other media audio while recording" = "Mute other media audio while recording";
+"When enabled, Voxt requests system audio recording permission so it can mute other apps' media audio during recording and restore it after transcription completes." = "When enabled, Voxt requests system audio recording permission so it can mute other apps' media audio during recording and restore it after transcription completes.";
+"System audio recording permission granted." = "System audio recording permission granted.";
+"System audio recording permission is required for this feature. You can grant it in Settings > Permissions." = "System audio recording permission is required for this feature. You can grant it in Settings > Permissions.";
+"System Audio Recording Permission" = "System Audio Recording Permission";
+"Required only when muting other apps' media audio during recording is enabled." = "Required only when muting other apps' media audio during recording is enabled.";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -12,6 +12,8 @@
 "Audio" = "オーディオ";
 "Microphone" = "マイク";
 "Interaction Sounds" = "操作音";
+"Mute system audio while recording" = "録音中はシステム音声を消音";
+"After the start sound plays, Voxt mutes your Mac's current output volume during recording and restores it before the end sound." = "開始音の再生後、Voxt は録音中に Mac の現在の出力音量を消音し、終了音の前に元へ戻します。";
 "Sound Preset" = "サウンドプリセット";
 "Preview" = "試聴";
 "Try Sound" = "試聴";
@@ -76,6 +78,7 @@
 "Apache License 2.0" = "Apache 2.0 ライセンス";
 "Project" = "プロジェクト";
 "Author" = "作者";
+"No microphone available" = "利用可能なマイクがありません";
 "Thanks" = "謝辞";
 "Logs" = "ログ";
 "Export Latest Logs (2000)" = "最新ログをエクスポート（2000件）";
@@ -441,4 +444,10 @@
 "Needs Setup" = "要設定";
 "Model needs to be installed." = "モデルをインストールする必要があります。";
 "Configuration required." = "設定の補完が必要です。";
+"Mute other media audio while recording" = "録音中は他アプリのメディア音声をミュートする";
+"When enabled, Voxt requests system audio recording permission so it can mute other apps' media audio during recording and restore it after transcription completes." = "有効にすると、Voxt は録音中に他アプリのメディア音声をミュートし、文字起こし完了後に復元するためのシステム音声録音権限を要求します。";
+"System audio recording permission granted." = "システム音声録音の権限が許可されました。";
+"System audio recording permission is required for this feature. You can grant it in Settings > Permissions." = "この機能にはシステム音声録音の権限が必要です。Settings > Permissions から許可できます。";
+"System Audio Recording Permission" = "システム音声録音の権限";
+"Required only when muting other apps' media audio during recording is enabled." = "録音中に他アプリのメディア音声をミュートする機能を有効にした場合にのみ必要です。";
 "Feedback" = "フィードバック";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -12,6 +12,8 @@
 "Audio" = "音频";
 "Microphone" = "麦克风";
 "Interaction Sounds" = "交互提示音";
+"Mute system audio while recording" = "录制时静音系统音频";
+"After the start sound plays, Voxt mutes your Mac's current output volume during recording and restores it before the end sound." = "开始提示音播放后，Voxt 会在录制期间将 Mac 当前输出音量静音，并在结束提示音前恢复。";
 "Sound Preset" = "提示音预设";
 "Preview" = "预览";
 "Try Sound" = "试听";
@@ -77,6 +79,7 @@
 "Apache License 2.0" = "Apache 2.0 许可证";
 "Project" = "项目";
 "Feedback" = "问题反馈";
+"No microphone available" = "没有可用的麦克风";
 "Author" = "作者";
 "Thanks" = "感谢";
 "Logs" = "日志";
@@ -442,3 +445,9 @@
 "Needs Setup" = "需补全配置";
 "Model needs to be installed." = "模型需要先安装。";
 "Configuration required." = "需要补全配置。";
+"Mute other media audio while recording" = "录制时静音其他媒体音频";
+"When enabled, Voxt requests system audio recording permission so it can mute other apps' media audio during recording and restore it after transcription completes." = "开启后，Voxt 会请求系统音频录制权限，以便在录制期间静音其他应用的媒体音频，并在转录完成后恢复。";
+"System audio recording permission granted." = "系统音频录制权限已授予。";
+"System audio recording permission is required for this feature. You can grant it in Settings > Permissions." = "此功能需要系统音频录制权限。你可以在 设置 > 权限 中授予。";
+"System Audio Recording Permission" = "系统音频录制权限";
+"Required only when muting other apps' media audio during recording is enabled." = "仅当开启“录制时静音其他应用媒体音频”时才需要。";


### PR DESCRIPTION
## Summary
- add tray menu microphone switching plus recording session cleanup to keep overlay and input state stable
- add a General toggle for muting other media audio during recording, backed by system audio capture permission gating and Permissions tab integration
- switch system-audio muting to a Core Audio process-tap path, update config transfer/localization, and add the required audio capture usage description

## Test Plan
- [ ] `xcodebuild -project Voxt.xcodeproj -scheme Voxt -configuration Debug -sdk macosx -derivedDataPath /tmp/voxt-build-20260316-system-audio-permission build CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO` (not completed in this run; build spent the session recompiling heavy `mlx-swift` dependencies)
- [ ] Manually verify tray microphone switching updates the preferred input device for the next recording session
- [ ] Manually verify enabling the mute toggle requests system audio capture permission and conditionally shows the permission row in Settings > Permissions