### PR TITLE
[Feature] Add onSave Callback to Prompt sections and Improve Stored Text Handling

### DIFF
--- a/Voxt/Settings/FeatureSettingsComponents.swift
+++ b/Voxt/Settings/FeatureSettingsComponents.swift
@@ -510,7 +510,9 @@ struct FeaturePromptSection: View {
     @Binding var text: String
     let defaultText: String
     let variables: [PromptTemplateVariableDescriptor]
-    var onSave: (() -> Void)?
+    let persistChanges: () -> Void
+    @State private var pendingSaveTask: Task<Void, Never>?
+    @State private var lastSavedText = ""
 
     var body: some View {
         ResettablePromptSection(
@@ -519,8 +521,45 @@ struct FeaturePromptSection: View {
             defaultText: defaultText,
             variables: variables,
             promptHeight: 196,
-            onSave: onSave
+            onTextChange: schedulePersist,
+            onFocusChange: handleFocusChange
         )
+        .onAppear {
+            lastSavedText = text
+        }
+        .onDisappear {
+            flushPendingChanges()
+        }
+    }
+
+    private func schedulePersist(_ newValue: String) {
+        pendingSaveTask?.cancel()
+        pendingSaveTask = Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                flushPendingChanges(expectedText: newValue)
+            }
+        }
+    }
+
+    private func handleFocusChange(_ isFocused: Bool) {
+        guard !isFocused else { return }
+        flushPendingChanges()
+    }
+
+    private func flushPendingChanges(expectedText: String? = nil) {
+        pendingSaveTask?.cancel()
+        pendingSaveTask = nil
+
+        let currentText = text
+        guard currentText != lastSavedText else { return }
+        if let expectedText, currentText != expectedText {
+            return
+        }
+
+        lastSavedText = currentText
+        persistChanges()
     }
 }
 

--- a/Voxt/Settings/FeatureSettingsComponents.swift
+++ b/Voxt/Settings/FeatureSettingsComponents.swift
@@ -510,6 +510,7 @@ struct FeaturePromptSection: View {
     @Binding var text: String
     let defaultText: String
     let variables: [PromptTemplateVariableDescriptor]
+    var onSave: (() -> Void)?
 
     var body: some View {
         ResettablePromptSection(
@@ -517,7 +518,8 @@ struct FeaturePromptSection: View {
             text: $text,
             defaultText: defaultText,
             variables: variables,
-            promptHeight: 196
+            promptHeight: 196,
+            onSave: onSave
         )
     }
 }

--- a/Voxt/Settings/FeatureSettingsPageSections+LanguageTools.swift
+++ b/Voxt/Settings/FeatureSettingsPageSections+LanguageTools.swift
@@ -71,7 +71,8 @@ extension FeatureSettingsView {
                                 kind: .translation
                             ),
                             defaultText: AppPromptDefaults.text(for: .translation),
-                            variables: ModelSettingsPromptVariables.translation
+                            variables: ModelSettingsPromptVariables.translation,
+                            onSave: saveFeatureSettings
                         )
                     }
                 } else {
@@ -117,7 +118,8 @@ extension FeatureSettingsView {
                             kind: .rewrite
                         ),
                         defaultText: AppPromptDefaults.text(for: .rewrite),
-                        variables: ModelSettingsPromptVariables.rewrite
+                        variables: ModelSettingsPromptVariables.rewrite,
+                        onSave: saveFeatureSettings
                     )
                 }
 

--- a/Voxt/Settings/FeatureSettingsPageSections+LanguageTools.swift
+++ b/Voxt/Settings/FeatureSettingsPageSections+LanguageTools.swift
@@ -72,7 +72,7 @@ extension FeatureSettingsView {
                             ),
                             defaultText: AppPromptDefaults.text(for: .translation),
                             variables: ModelSettingsPromptVariables.translation,
-                            onSave: saveFeatureSettings
+                            persistChanges: saveFeatureSettings
                         )
                     }
                 } else {
@@ -119,7 +119,7 @@ extension FeatureSettingsView {
                         ),
                         defaultText: AppPromptDefaults.text(for: .rewrite),
                         variables: ModelSettingsPromptVariables.rewrite,
-                        onSave: saveFeatureSettings
+                        persistChanges: saveFeatureSettings
                     )
                 }
 

--- a/Voxt/Settings/FeatureSettingsPageSections+Meeting.swift
+++ b/Voxt/Settings/FeatureSettingsPageSections+Meeting.swift
@@ -77,7 +77,8 @@ extension FeatureSettingsView {
                         defaultText: AppPromptDefaults.text(for: .meetingSummary),
                         variables: MeetingSummarySupport.promptTemplateVariables.map {
                             PromptTemplateVariableDescriptor(token: $0, tipKey: "Template tip \($0)")
-                        }
+                        },
+                        onSave: saveFeatureSettings
                     )
                 }
             }

--- a/Voxt/Settings/FeatureSettingsPageSections+Meeting.swift
+++ b/Voxt/Settings/FeatureSettingsPageSections+Meeting.swift
@@ -78,7 +78,7 @@ extension FeatureSettingsView {
                         variables: MeetingSummarySupport.promptTemplateVariables.map {
                             PromptTemplateVariableDescriptor(token: $0, tipKey: "Template tip \($0)")
                         },
-                        onSave: saveFeatureSettings
+                        persistChanges: saveFeatureSettings
                     )
                 }
             }

--- a/Voxt/Settings/FeatureSettingsPageSections+Transcription.swift
+++ b/Voxt/Settings/FeatureSettingsPageSections+Transcription.swift
@@ -66,7 +66,7 @@ extension FeatureSettingsView {
                             ),
                             defaultText: AppPromptDefaults.text(for: .enhancement),
                             variables: ModelSettingsPromptVariables.enhancement,
-                            onSave: saveFeatureSettings
+                            persistChanges: saveFeatureSettings
                         )
                     }
                 }

--- a/Voxt/Settings/FeatureSettingsPageSections+Transcription.swift
+++ b/Voxt/Settings/FeatureSettingsPageSections+Transcription.swift
@@ -65,7 +65,8 @@ extension FeatureSettingsView {
                                 kind: .enhancement
                             ),
                             defaultText: AppPromptDefaults.text(for: .enhancement),
-                            variables: ModelSettingsPromptVariables.enhancement
+                            variables: ModelSettingsPromptVariables.enhancement,
+                            onSave: saveFeatureSettings
                         )
                     }
                 }

--- a/Voxt/Settings/FeatureSettingsPageSupport.swift
+++ b/Voxt/Settings/FeatureSettingsPageSupport.swift
@@ -15,7 +15,8 @@ extension FeatureSettingsView {
                 AppPromptDefaults.resolvedStoredText(get(), kind: kind)
             },
             set: { newValue in
-                set(AppPromptDefaults.canonicalStoredText(newValue, kind: kind))
+                let storedPrompt = AppPromptDefaults.canonicalStoredText(newValue, kind: kind)
+                set(storedPrompt)
             }
         )
     }

--- a/Voxt/Settings/FeatureSettingsPageSupport.swift
+++ b/Voxt/Settings/FeatureSettingsPageSupport.swift
@@ -15,8 +15,7 @@ extension FeatureSettingsView {
                 AppPromptDefaults.resolvedStoredText(get(), kind: kind)
             },
             set: { newValue in
-                let storedPrompt = AppPromptDefaults.canonicalStoredText(newValue, kind: kind)
-                set(storedPrompt)
+                set(AppPromptDefaults.canonicalStoredText(newValue, kind: kind))
             }
         )
     }

--- a/Voxt/Settings/ModelSettingsComponents.swift
+++ b/Voxt/Settings/ModelSettingsComponents.swift
@@ -7,11 +7,21 @@ struct PromptEditorView: View {
     var contentPadding: CGFloat = 6
     var variables: [PromptTemplateVariableDescriptor] = []
     var variablesLayout: PromptTemplateVariablesLayout = .adaptive
+    var onTextChange: ((String) -> Void)?
+    var onFocusChange: ((Bool) -> Void)?
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             TextEditor(text: $text)
                 .settingsPromptEditor(height: height, contentPadding: contentPadding)
+                .focused($isFocused)
+                .onChange(of: text) { _, newValue in
+                    onTextChange?(newValue)
+                }
+                .onChange(of: isFocused) { _, newValue in
+                    onFocusChange?(newValue)
+                }
 
             if !variables.isEmpty {
                 PromptTemplateVariablesView(variables: variables, layout: variablesLayout)

--- a/Voxt/Settings/ModelSettingsReusableSections.swift
+++ b/Voxt/Settings/ModelSettingsReusableSections.swift
@@ -50,6 +50,7 @@ struct ResettablePromptSection: View {
     let defaultText: String
     let variables: [PromptTemplateVariableDescriptor]
     var promptHeight: CGFloat = 124
+    var onSave: (() -> Void)?
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
@@ -61,6 +62,10 @@ struct ResettablePromptSection: View {
             }
             .buttonStyle(SettingsPillButtonStyle(horizontalPadding: 10))
             .disabled(text == defaultText)
+            if let onSave {
+                Button(AppLocalization.localizedString("Save"), action: onSave)
+                    .buttonStyle(SettingsPillButtonStyle(horizontalPadding: 10))
+            }
         }
 
         PromptEditorView(text: $text, height: promptHeight, variables: variables)

--- a/Voxt/Settings/ModelSettingsReusableSections.swift
+++ b/Voxt/Settings/ModelSettingsReusableSections.swift
@@ -50,7 +50,8 @@ struct ResettablePromptSection: View {
     let defaultText: String
     let variables: [PromptTemplateVariableDescriptor]
     var promptHeight: CGFloat = 124
-    var onSave: (() -> Void)?
+    var onTextChange: ((String) -> Void)?
+    var onFocusChange: ((Bool) -> Void)?
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
@@ -62,13 +63,15 @@ struct ResettablePromptSection: View {
             }
             .buttonStyle(SettingsPillButtonStyle(horizontalPadding: 10))
             .disabled(text == defaultText)
-            if let onSave {
-                Button(AppLocalization.localizedString("Save"), action: onSave)
-                    .buttonStyle(SettingsPillButtonStyle(horizontalPadding: 10))
-            }
         }
 
-        PromptEditorView(text: $text, height: promptHeight, variables: variables)
+        PromptEditorView(
+            text: $text,
+            height: promptHeight,
+            variables: variables,
+            onTextChange: onTextChange,
+            onFocusChange: onFocusChange
+        )
     }
 }
 


### PR DESCRIPTION
真是牛逼的项目，这才发现本地 ASR 工具链已经好的不能再好了。  

我今天在朋友的推荐之下尝试了这个项目，然后体验非常的好。  然后我发现这个项目有一个问题，就是 LLM 去做 polish 的时候，它的这个 prompt 居然没法保存。每当我选择返回上级页面之后，发现我之前保存的 prompt 就没了。所以我用 Cloud Code 修了一下这个 bug。

这个工作流基本极大解放了我的打字速度，让我和 Cloud Code 的交流快了很多，非常感谢。然后我把这个 bug 修复了之后，尝试在本地用苹果的 Xcode build 了之后，来看看我的修复是否成功。在我本地看来应该是没有什么问题的，但我不是专业的 Swift 开发者，因此作者欢迎审阅我的 PR。此外，我想要吐槽，苹果的开发生态真的太恼火了。

<img width="1520" height="1184" alt="image" src="https://github.com/user-attachments/assets/823398d7-0fb1-4476-b42e-f5d2c51ffc70" />

  如你所见，图片中这个保存按钮就是我添加的新的 feature，本身也很简单。然后我是做 CUDA 生态上的语音生成模型推理的。如果你有兴趣，欢迎你加入我们 sglang omni 😂。虽然我感觉你对 MLX 应该比较熟悉，可能 CUDA 上面会有些新的体会吧。