### PR TITLE
[Feature ]Add Settings entry for MLX ASR models in catalog UI

### DIFF
--- a/Voxt/App/AppDelegate+RecordingSession.swift
+++ b/Voxt/App/AppDelegate+RecordingSession.swift
@@ -461,6 +461,12 @@ extension AppDelegate {
     private func startMLXRecordingSession() {
         let mlx = mlxTranscriber ?? MLXTranscriber(modelManager: mlxModelManager)
         mlxTranscriber = mlx
+        mlx.dictionaryEntryProvider = { [weak self] in
+            guard let self else { return [] }
+            return self.dictionaryStore.activeEntriesForRemoteRequest(
+                activeGroupID: self.activeDictionaryGroupID()
+            )
+        }
         let sessionID = activeRecordingSessionID
         overlayState.statusMessage = ""
         mlx.transcribedText = ""

--- a/Voxt/Meeting/MeetingSegmentTranscribing.swift
+++ b/Voxt/Meeting/MeetingSegmentTranscribing.swift
@@ -161,6 +161,12 @@ final class MeetingMLXSegmentTranscriber: MeetingSegmentTranscribing {
 
     init(modelManager: MLXModelManager) {
         self.mlxTranscriber = MLXTranscriber(modelManager: modelManager)
+        self.mlxTranscriber.dictionaryEntryProvider = {
+            guard let appDelegate = AppDelegate.shared else { return [] }
+            return appDelegate.dictionaryStore.activeEntriesForRemoteRequest(
+                activeGroupID: appDelegate.activeDictionaryGroupID()
+            )
+        }
     }
 
     func transcribe(chunk: BufferedMeetingChunk) async -> MeetingTranscriptSegment? {

--- a/Voxt/Settings/AppPreferenceKey.swift
+++ b/Voxt/Settings/AppPreferenceKey.swift
@@ -194,6 +194,7 @@ enum AppPreferenceKey {
 
     static let asrUserMainLanguageTemplateVariable = "{{USER_MAIN_LANGUAGE}}"
     static let asrUserOtherLanguagesTemplateVariable = "{{USER_OTHER_LANGUAGES}}"
+    static let asrDictionaryTermsTemplateVariable = "{{DICTIONARY_TERMS}}"
 
     static let defaultOpenAIASRHintPrompt = """
         The speaker's primary language is {{USER_MAIN_LANGUAGE}}. Prioritize accurate transcription in that language while preserving mixed-language words, names, product terms, URLs, and code-like text exactly as spoken.

--- a/Voxt/Settings/ModelSettingsCatalogBuilder.swift
+++ b/Voxt/Settings/ModelSettingsCatalogBuilder.swift
@@ -29,6 +29,7 @@ struct ModelCatalogBuilder {
     let downloadModel: (String) -> Void
     let deleteModel: (String) -> Void
     let openMLXModelDirectory: (String) -> Void
+    let presentMLXSettings: (String) -> Void
     let downloadWhisperModel: (String) -> Void
     let deleteWhisperModel: (String) -> Void
     let openWhisperModelDirectory: (String) -> Void
@@ -81,40 +82,44 @@ struct ModelCatalogBuilder {
             let status = modelStatusText(repo)
 
             let primaryAction: ModelTableAction?
-            let secondaryActions: [ModelTableAction]
+            var secondaryActions = [ModelTableAction]()
             if isDownloadingModel(repo) {
                 primaryAction = ModelTableAction(title: localized("Pause")) {
                     mlxModelManager.pauseDownload()
                 }
-                secondaryActions = [
+                secondaryActions.append(
                     ModelTableAction(title: localized("Cancel"), role: .destructive) {
                         mlxModelManager.cancelDownload()
                     }
-                ]
+                )
             } else if mlxModelManager.currentModelRepo == repo, case .paused = mlxModelManager.state {
                 primaryAction = ModelTableAction(title: localized("Continue")) {
                     downloadModel(repo)
                 }
-                secondaryActions = [
+                secondaryActions.append(
                     ModelTableAction(title: localized("Cancel"), role: .destructive) {
                         mlxModelManager.cancelDownload()
                     }
-                ]
+                )
             } else if isInstalled {
                 primaryAction = ModelTableAction(title: localized("Uninstall"), role: .destructive) {
                     deleteModel(repo)
                 }
-                secondaryActions = [
+                secondaryActions.append(
                     ModelTableAction(title: localized("Open Location")) {
                         openMLXModelDirectory(repo)
                     }
-                ]
+                )
             } else {
                 primaryAction = ModelTableAction(title: localized("Install"), isEnabled: !isAnotherModelDownloading(repo)) {
                     downloadModel(repo)
                 }
-                secondaryActions = []
             }
+            secondaryActions.append(
+                ModelTableAction(title: localized("Settings")) {
+                    presentMLXSettings(repo)
+                }
+            )
 
             return ModelCatalogEntry(
                 id: "mlx:\(repo)",

--- a/Voxt/Settings/ModelSettingsView+Sections.swift
+++ b/Voxt/Settings/ModelSettingsView+Sections.swift
@@ -278,6 +278,7 @@ extension ModelSettingsView {
 }
 
 private struct MLXASRConfigurationSheetView: View {
+    private static let contentMaxHeight: CGFloat = 520
     private static let asrLanguageVariables = [
         PromptTemplateVariableDescriptor(
             token: AppPreferenceKey.asrUserMainLanguageTemplateVariable,
@@ -286,6 +287,12 @@ private struct MLXASRConfigurationSheetView: View {
         PromptTemplateVariableDescriptor(
             token: AppPreferenceKey.asrUserOtherLanguagesTemplateVariable,
             tipKey: "Template tip {{USER_OTHER_LANGUAGES}}"
+        )
+    ]
+    private static let qwenContextVariables = asrLanguageVariables + [
+        PromptTemplateVariableDescriptor(
+            token: AppPreferenceKey.asrDictionaryTermsTemplateVariable,
+            tipKey: "Template tip {{DICTIONARY_TERMS}}"
         )
     ]
 
@@ -318,80 +325,88 @@ private struct MLXASRConfigurationSheetView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("MLX ASR Configuration")
-                .font(.title3.weight(.semibold))
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("MLX ASR Configuration")
+                        .font(.title3.weight(.semibold))
 
-            Text(modelTitle)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                    Text(modelTitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Preset")
-                    .font(.subheadline.weight(.medium))
-                SettingsMenuPicker(
-                    selection: Binding(
-                        get: { tuningSettings.preset.rawValue },
-                        set: { rawValue in
-                            guard let preset = LocalASRRecognitionPreset(rawValue: rawValue) else { return }
-                            tuningSettings.preset = preset
-                        }
-                    ),
-                    options: LocalASRRecognitionPreset.allCases.map {
-                        SettingsMenuOption(value: $0.rawValue, title: $0.title)
-                    },
-                    selectedTitle: tuningSettings.preset.title,
-                    width: 220
-                )
-                Text(tuningSettings.preset.summary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Preset")
+                            .font(.subheadline.weight(.medium))
+                        SettingsMenuPicker(
+                            selection: Binding(
+                                get: { tuningSettings.preset.rawValue },
+                                set: { rawValue in
+                                    guard let preset = LocalASRRecognitionPreset(rawValue: rawValue) else { return }
+                                    tuningSettings.preset = preset
+                                }
+                            ),
+                            options: LocalASRRecognitionPreset.allCases.map {
+                                SettingsMenuOption(value: $0.rawValue, title: $0.title)
+                            },
+                            selectedTitle: tuningSettings.preset.title,
+                            width: 220
+                        )
+                        Text(tuningSettings.preset.summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Toggle("Follow User Main Language", isOn: $hintSettings.followsUserMainLanguage)
+                        .toggleStyle(.switch)
+
+                    HStack(alignment: .top, spacing: 16) {
+                        localInfoRow(label: "Primary language", value: mainLanguageSummary)
+                        localInfoRow(label: "Resolved language", value: resolvedLanguage)
+                    }
+
+                    localInfoRow(label: "Other languages", value: secondaryLanguageSummary)
+
+                    if family.supportsContextBias {
+                        Text("Recognition Context")
+                            .font(.subheadline.weight(.medium))
+                        PromptEditorView(text: $tuningSettings.qwenContextBias, height: 110, variables: Self.qwenContextVariables)
+                        Text("Use concise domain terms, names, and product vocabulary to bias Qwen3-ASR toward the right transcription.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if family.supportsPromptBias {
+                        Text("Recognition Prompt")
+                            .font(.subheadline.weight(.medium))
+                        PromptEditorView(text: $tuningSettings.granitePromptBias, height: 110, variables: Self.asrLanguageVariables)
+                        Text("Granite uses prompt-style instructions. Keep it recognition-focused, for example spelling preferences or domain terminology.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if family.supportsITN {
+                        Toggle("Enable ITN", isOn: $tuningSettings.senseVoiceUseITN)
+                            .toggleStyle(.switch)
+                        Text("ITN lets SenseVoice normalize spoken numbers, dates, and similar expressions into written form.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !family.supportsContextBias
+                        && !family.supportsPromptBias
+                        && !family.supportsITN
+                    {
+                        Text("This MLX model family currently uses preset-based chunking and language strategy only. Model-native prompt or context controls are not exposed by this family in Voxt yet.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(20)
             }
+            .frame(maxHeight: Self.contentMaxHeight)
 
-            Toggle("Follow User Main Language", isOn: $hintSettings.followsUserMainLanguage)
-                .toggleStyle(.switch)
-
-            HStack(alignment: .top, spacing: 16) {
-                localInfoRow(label: "Primary language", value: mainLanguageSummary)
-                localInfoRow(label: "Resolved language", value: resolvedLanguage)
-            }
-
-            localInfoRow(label: "Other languages", value: secondaryLanguageSummary)
-
-            if family.supportsContextBias {
-                Text("Recognition Context")
-                    .font(.subheadline.weight(.medium))
-                PromptEditorView(text: $tuningSettings.qwenContextBias, height: 110, variables: Self.asrLanguageVariables)
-                Text("Use concise domain terms, names, and product vocabulary to bias Qwen3-ASR toward the right transcription.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            if family.supportsPromptBias {
-                Text("Recognition Prompt")
-                    .font(.subheadline.weight(.medium))
-                PromptEditorView(text: $tuningSettings.granitePromptBias, height: 110, variables: Self.asrLanguageVariables)
-                Text("Granite uses prompt-style instructions. Keep it recognition-focused, for example spelling preferences or domain terminology.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            if family.supportsITN {
-                Toggle("Enable ITN", isOn: $tuningSettings.senseVoiceUseITN)
-                    .toggleStyle(.switch)
-                Text("ITN lets SenseVoice normalize spoken numbers, dates, and similar expressions into written form.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            if !family.supportsContextBias
-                && !family.supportsPromptBias
-                && !family.supportsITN
-            {
-                Text("This MLX model family currently uses preset-based chunking and language strategy only. Model-native prompt or context controls are not exposed by this family in Voxt yet.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            Divider()
 
             SettingsDialogActionRow {
                 Button("Reset to Default") {
@@ -406,8 +421,8 @@ private struct MLXASRConfigurationSheetView: View {
                 .buttonStyle(SettingsPrimaryButtonStyle())
                 .keyboardShortcut(.defaultAction)
             }
+            .padding(20)
         }
-        .padding(20)
         .frame(width: 520)
     }
 

--- a/Voxt/Settings/ModelSettingsView.swift
+++ b/Voxt/Settings/ModelSettingsView.swift
@@ -193,6 +193,9 @@ struct ModelSettingsView: View {
             downloadModel: downloadModel,
             deleteModel: deleteModel,
             openMLXModelDirectory: openMLXModelDirectory,
+            presentMLXSettings: { repo in
+                activeLocalASRConfigurationTarget = .mlx(repo: repo)
+            },
             downloadWhisperModel: downloadWhisperModel,
             deleteWhisperModel: deleteWhisperModel,
             openWhisperModelDirectory: openWhisperModelDirectory,

--- a/Voxt/Support/ASRHintResolver.swift
+++ b/Voxt/Support/ASRHintResolver.swift
@@ -142,6 +142,7 @@ enum ASRHintResolver {
     static func resolveTemplateVariables(
         in template: String,
         userLanguageCodes: [String],
+        dictionaryTerms: String = "",
         appendOtherLanguagesWhenMissing: Bool = false
     ) -> String {
         let selectedOptions = selectedLanguageOptions(userLanguageCodes)
@@ -151,6 +152,7 @@ enum ASRHintResolver {
             in: template,
             mainLanguage: mainLanguage,
             otherLanguages: otherLanguages,
+            dictionaryTerms: dictionaryTerms,
             appendOtherLanguagesWhenMissing: appendOtherLanguagesWhenMissing
         )
     }
@@ -176,6 +178,7 @@ enum ASRHintResolver {
             in: trimmed,
             mainLanguage: mainLanguage,
             otherLanguages: otherLanguages,
+            dictionaryTerms: "",
             appendOtherLanguagesWhenMissing: true
         )
         let compact = resolved.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -186,6 +189,7 @@ enum ASRHintResolver {
         in template: String,
         mainLanguage: UserMainLanguageOption,
         otherLanguages: [UserMainLanguageOption],
+        dictionaryTerms: String,
         appendOtherLanguagesWhenMissing: Bool
     ) -> String {
         let trimmed = template.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -201,6 +205,10 @@ enum ASRHintResolver {
             .replacingOccurrences(
                 of: AppPreferenceKey.asrUserOtherLanguagesTemplateVariable,
                 with: otherLanguagesSummary
+            )
+            .replacingOccurrences(
+                of: AppPreferenceKey.asrDictionaryTermsTemplateVariable,
+                with: dictionaryTerms.trimmingCharacters(in: .whitespacesAndNewlines)
             )
 
         if appendOtherLanguagesWhenMissing,

--- a/Voxt/Transcription/MLXTranscriber.swift
+++ b/Voxt/Transcription/MLXTranscriber.swift
@@ -160,6 +160,7 @@ class MLXTranscriber: ObservableObject, TranscriberProtocol {
 
     var onTranscriptionFinished: ((String) -> Void)?
     var onPartialTranscription: ((String) -> Void)?
+    var dictionaryEntryProvider: (() -> [DictionaryEntry])?
 
     private let audioEngine = AVAudioEngine()
     private let sampleStore = AudioSampleStore()
@@ -733,7 +734,11 @@ class MLXTranscriber: ObservableObject, TranscriberProtocol {
             ),
             languageHint: languageHint,
             qwenContextBias: mergedBiasText(
-                resolvedBiasTemplate(tuningSettings.qwenContextBias, userLanguageCodes: userLanguageCodes),
+                resolvedBiasTemplate(
+                    tuningSettings.qwenContextBias,
+                    userLanguageCodes: userLanguageCodes,
+                    dictionaryTerms: resolvedDictionaryTermsTemplateValue()
+                ),
                 autoBias: automaticBiases.qwenContextBias
             ),
             granitePromptBias: mergedOptionalBiasText(
@@ -803,6 +808,34 @@ class MLXTranscriber: ObservableObject, TranscriberProtocol {
             userLanguageCodes: userLanguageCodes
         )
         .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func resolvedBiasTemplate(
+        _ template: String,
+        userLanguageCodes: [String],
+        dictionaryTerms: String
+    ) -> String {
+        ASRHintResolver.resolveTemplateVariables(
+            in: template,
+            userLanguageCodes: userLanguageCodes,
+            dictionaryTerms: dictionaryTerms
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func resolvedDictionaryTermsTemplateValue() -> String {
+        let entries = dictionaryEntryProvider?() ?? []
+        var seen = Set<String>()
+        let terms = entries.compactMap { entry -> String? in
+            guard entry.groupID == nil else { return nil }
+            guard entry.replacementTerms.isEmpty else { return nil }
+            let trimmed = entry.term.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let normalized = DictionaryStore.normalizeTerm(trimmed)
+            guard seen.insert(normalized).inserted else { return nil }
+            return trimmed
+        }
+        return terms.joined(separator: "\n")
     }
 
     private func prepareInputSamples(_ samples: [Float], sampleRate: Double) throws -> [Float] {

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -562,6 +562,7 @@
 "Template tip {{RAW_TRANSCRIPTION}}" = "The raw transcription text before enhancement. Use it when you want the prompt to reference the original recognized text.";
 "Template tip {{USER_MAIN_LANGUAGE}}" = "The user's primary spoken language used to guide punctuation, formatting, and language-specific cleanup decisions.";
 "Template tip {{USER_OTHER_LANGUAGES}}" = "Other frequently used spoken languages. Useful when the speaker often mixes languages in one utterance.";
+"Template tip {{DICTIONARY_TERMS}}" = "Active dictionary terms without aliases in the current scope. Useful for injecting concise domain vocabulary into Qwen3-ASR recognition context.";
 "Template tip {{HISTORY_RECORDS}}" = "The serialized history records included in the current dictionary ingestion batch.";
 "Balanced" = "Balanced";
 "Accuracy First" = "Accuracy First";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -560,6 +560,7 @@
 "Template tip {{RAW_TRANSCRIPTION}}" = "強化前の生の文字起こしテキストです。元の認識結果をプロンプト内で参照したいときに使います。";
 "Template tip {{USER_MAIN_LANGUAGE}}" = "句読点、整形、言語固有の不要語除去を判断するときに使う、ユーザーの主要な話し言葉です。";
 "Template tip {{USER_OTHER_LANGUAGES}}" = "その他によく使う話し言葉です。1つの発話内で言語が混ざるケースをモデルに伝えるときに使えます。";
+"Template tip {{DICTIONARY_TERMS}}" = "現在のスコープでエイリアスを持たない有効な辞書用語です。Qwen3-ASR の認識コンテキストに簡潔な用語集として差し込むのに使えます。";
 "Template tip {{HISTORY_RECORDS}}" = "現在の辞書取り込みバッチに含まれる、シリアライズ済みの履歴レコードです。";
 "Balanced" = "バランス";
 "Accuracy First" = "精度優先";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -562,6 +562,7 @@
 "Template tip {{RAW_TRANSCRIPTION}}" = "增强前的原始转录文本。需要在提示词中引用原始识别结果时使用它。";
 "Template tip {{USER_MAIN_LANGUAGE}}" = "用户的主要口语语言。可用于指导标点、格式和语言相关的语气词清理。";
 "Template tip {{USER_OTHER_LANGUAGES}}" = "用户其他常用口语语言。适合用于提示模型处理单次发言中的混合语言内容。";
+"Template tip {{DICTIONARY_TERMS}}" = "当前作用域里没有别名的活跃词典词。适合直接注入到 Qwen3-ASR 的识别上下文中，提供精简术语提示。";
 "Template tip {{HISTORY_RECORDS}}" = "当前这批词典录入任务中序列化后的历史记录内容。";
 "Balanced" = "均衡";
 "Accuracy First" = "准确率优先";


### PR DESCRIPTION
The MLX ASR configuration sheet was already implemented (Recognition Context, preset, ITN) but had no UI entry in the catalog. This adds a Settings action to MLX rows, mirroring Whisper's wiring.