### PR TITLE
fix: consume hotkey events to prevent character key leak

### DIFF
--- a/Voxt/App/AppDelegate+HotkeyLifecycle.swift
+++ b/Voxt/App/AppDelegate+HotkeyLifecycle.swift
@@ -39,6 +39,9 @@ extension AppDelegate {
             guard let self else { return }
             self.handleCustomPasteHotkeyDown()
         }
+        hotkeyManager.onEscapeKeyDown = { [weak self] in
+            self?.handleEscapeShortcut() ?? false
+        }
         hotkeyManager.start()
         VoxtLog.hotkey("Hotkey callbacks configured.")
     }
@@ -117,12 +120,17 @@ extension AppDelegate {
         }
 
         guard event.keyCode == UInt16(kVK_Escape) else { return event }
+        guard handleEscapeShortcut() else { return event }
+        return shouldConsume ? nil : event
+    }
+
+    func handleEscapeShortcut() -> Bool {
         guard UserDefaults.standard.object(forKey: AppPreferenceKey.escapeKeyCancelsOverlaySession) as? Bool ?? true else {
-            return event
+            return false
         }
         if overlayState.displayMode == .answer {
             dismissAnswerOverlay()
-            return shouldConsume ? nil : event
+            return true
         }
         if meetingSessionCoordinator.isActive {
             if meetingSessionCoordinator.overlayState.isCloseConfirmationPresented {
@@ -130,13 +138,13 @@ extension AppDelegate {
             } else {
                 requestMeetingSessionCloseConfirmation()
             }
-            return shouldConsume ? nil : event
+            return true
         }
-        guard HotkeyPreference.loadTriggerMode() == .tap else { return event }
-        guard isSessionActive else { return event }
-        guard !isSelectedTextTranslationFlow else { return event }
+        guard HotkeyPreference.loadTriggerMode() == .tap else { return false }
+        guard isSessionActive else { return false }
+        guard !isSelectedTextTranslationFlow else { return false }
         cancelActiveRecordingSession()
-        return shouldConsume ? nil : event
+        return true
     }
 
     func shouldHandleAnswerOverlayContinueShortcut(_ event: NSEvent) -> Bool {

--- a/Voxt/Hotkey/HotkeyManager.swift
+++ b/Voxt/Hotkey/HotkeyManager.swift
@@ -27,6 +27,7 @@ class HotkeyManager {
     var onRewriteKeyUp: (() -> Void)?
     var onMeetingKeyDown: (() -> Void)?
     var onCustomPasteKeyDown: (() -> Void)?
+    var onEscapeKeyDown: (() -> Bool)?
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
@@ -353,11 +354,11 @@ class HotkeyManager {
             switch type {
             case .keyDown:
                 if keyCode == translationHotkey.keyCode, translationFlagsMatch, !isAutoRepeat {
+                    activeTranslationKeyCode = keyCode
                     if triggerMode == .tap {
                         emitTranslationKeyDown()
                     } else if !isTranslationKeyDown {
                         isTranslationKeyDown = true
-                        activeTranslationKeyCode = keyCode
                         emitTranslationKeyDown()
                     }
                     eventWasConsumed = true
@@ -367,8 +368,6 @@ class HotkeyManager {
                 if triggerMode == .tap {
                     if activeTranslationKeyCode == keyCode {
                         activeTranslationKeyCode = nil
-                    }
-                    if keyCode == translationHotkey.keyCode {
                         emitTranslationKeyUp()
                         eventWasConsumed = true
                         return
@@ -409,11 +408,11 @@ class HotkeyManager {
             switch type {
             case .keyDown:
                 if keyCode == rewriteHotkey.keyCode, rewriteFlagsMatch, !isAutoRepeat {
+                    activeRewriteKeyCode = keyCode
                     if triggerMode == .tap {
                         emitRewriteKeyDown()
                     } else if !isRewriteKeyDown {
                         isRewriteKeyDown = true
-                        activeRewriteKeyCode = keyCode
                         emitRewriteKeyDown()
                     }
                     eventWasConsumed = true
@@ -423,8 +422,6 @@ class HotkeyManager {
                 if triggerMode == .tap {
                     if activeRewriteKeyCode == keyCode {
                         activeRewriteKeyCode = nil
-                    }
-                    if keyCode == rewriteHotkey.keyCode {
                         emitRewriteKeyUp()
                         eventWasConsumed = true
                         return
@@ -510,11 +507,11 @@ class HotkeyManager {
             switch type {
             case .keyDown:
                 if keyCode == meetingHotkey.keyCode, meetingFlagsMatch, !isAutoRepeat {
+                    activeMeetingKeyCode = keyCode
                     if triggerMode == .tap {
                         emitMeetingKeyDown()
                     } else if !isMeetingKeyDown {
                         isMeetingKeyDown = true
-                        activeMeetingKeyCode = keyCode
                         emitMeetingKeyDown()
                     }
                     eventWasConsumed = true
@@ -524,9 +521,9 @@ class HotkeyManager {
                 if triggerMode == .tap {
                     if activeMeetingKeyCode == keyCode {
                         activeMeetingKeyCode = nil
+                        eventWasConsumed = true
+                        return
                     }
-                    eventWasConsumed = true
-                    return
                 }
                 if isMeetingKeyDown, activeMeetingKeyCode == keyCode {
                     isMeetingKeyDown = false
@@ -537,6 +534,14 @@ class HotkeyManager {
             default:
                 break
             }
+        }
+
+        if type == .keyDown,
+           keyCode == UInt16(kVK_Escape),
+           !isAutoRepeat,
+           onEscapeKeyDown?() == true {
+            eventWasConsumed = true
+            return
         }
 
         // Transcription path runs after translation handling.
@@ -572,13 +577,13 @@ class HotkeyManager {
         switch type {
         case .keyDown:
             guard keyCode == transcriptionHotkey.keyCode, transcriptionFlagsMatch, !isAutoRepeat else { return }
+            activeKeyCode = keyCode
             if triggerMode == .tap {
                 emitKeyDown()
                 eventWasConsumed = true
                 return
             } else if !isKeyDown {
                 isKeyDown = true
-                activeKeyCode = keyCode
                 emitKeyDown()
                 eventWasConsumed = true
                 return
@@ -587,12 +592,10 @@ class HotkeyManager {
             if triggerMode == .tap {
                 if activeKeyCode == keyCode {
                     activeKeyCode = nil
-                }
-                if keyCode == transcriptionHotkey.keyCode {
                     emitKeyUp()
+                    eventWasConsumed = true
+                    return
                 }
-                eventWasConsumed = true
-                return
             }
             if isKeyDown, activeKeyCode == keyCode {
                 isKeyDown = false
@@ -1350,18 +1353,20 @@ extension HotkeyManager {
         let currentSidedModifiers: SidedModifierFlags
     }
 
+    @discardableResult
     func testingHandleEvent(
         type: CGEventType,
         keyCode: UInt16,
         flags: CGEventFlags,
         isAutoRepeat: Bool = false
-    ) {
+    ) -> Bool {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             _ = recoverEventTapIfNeeded(disabledEventType: type)
-            return
+            return false
         }
         var eventWasConsumed = false
         handleResolvedEvent(type: type, keyCode: keyCode, flags: flags, isAutoRepeat: isAutoRepeat, eventWasConsumed: &eventWasConsumed)
+        return eventWasConsumed
     }
 
     func testingSetTransientState(

--- a/Voxt/Hotkey/HotkeyManager.swift
+++ b/Voxt/Hotkey/HotkeyManager.swift
@@ -202,15 +202,15 @@ class HotkeyManager {
                 manager.recoverEventTapIfNeeded(disabledEventType: type)
                 return Unmanaged.passUnretained(event)
             }
-            manager.handleEvent(type: type, event: event)
-            return Unmanaged.passUnretained(event)
+            let consumed = manager.handleEvent(type: type, event: event)
+            return consumed ? nil : Unmanaged.passUnretained(event)
         }
 
         for tapLocation in [CGEventTapLocation.cghidEventTap, .cgSessionEventTap] {
             if let tap = CGEvent.tapCreate(
                 tap: tapLocation,
                 place: .tailAppendEventTap,
-                options: .listenOnly,
+                options: .defaultTap,
                 eventsOfInterest: eventMask,
                 callback: callback,
                 userInfo: Unmanaged.passUnretained(self).toOpaque()
@@ -222,23 +222,27 @@ class HotkeyManager {
         return nil
     }
 
-    private func handleEvent(type: CGEventType, event: CGEvent) {
+    private func handleEvent(type: CGEventType, event: CGEvent) -> Bool {
         guard !UserDefaults.standard.bool(forKey: AppPreferenceKey.hotkeyCaptureInProgress) else {
-            return
+            return false
         }
+        var eventWasConsumed = false
         handleResolvedEvent(
             type: type,
             keyCode: UInt16(event.getIntegerValueField(.keyboardEventKeycode)),
             flags: event.flags,
-            isAutoRepeat: event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+            isAutoRepeat: event.getIntegerValueField(.keyboardEventAutorepeat) != 0,
+            eventWasConsumed: &eventWasConsumed
         )
+        return eventWasConsumed
     }
 
     private func handleResolvedEvent(
         type: CGEventType,
         keyCode: UInt16,
         flags: CGEventFlags,
-        isAutoRepeat: Bool
+        isAutoRepeat: Bool,
+        eventWasConsumed: inout Bool
     ) {
         defer {
             lastEventAt = Date()
@@ -356,6 +360,7 @@ class HotkeyManager {
                         activeTranslationKeyCode = keyCode
                         emitTranslationKeyDown()
                     }
+                    eventWasConsumed = true
                     return
                 }
             case .keyUp:
@@ -365,12 +370,14 @@ class HotkeyManager {
                     }
                     if keyCode == translationHotkey.keyCode {
                         emitTranslationKeyUp()
+                        eventWasConsumed = true
                         return
                     }
                 } else if isTranslationKeyDown, activeTranslationKeyCode == keyCode {
                     isTranslationKeyDown = false
                     activeTranslationKeyCode = nil
                     emitTranslationKeyUp()
+                    eventWasConsumed = true
                     return
                 }
             default:
@@ -409,6 +416,7 @@ class HotkeyManager {
                         activeRewriteKeyCode = keyCode
                         emitRewriteKeyDown()
                     }
+                    eventWasConsumed = true
                     return
                 }
             case .keyUp:
@@ -418,12 +426,14 @@ class HotkeyManager {
                     }
                     if keyCode == rewriteHotkey.keyCode {
                         emitRewriteKeyUp()
+                        eventWasConsumed = true
                         return
                     }
                 } else if isRewriteKeyDown, activeRewriteKeyCode == keyCode {
                     isRewriteKeyDown = false
                     activeRewriteKeyCode = nil
                     emitRewriteKeyUp()
+                    eventWasConsumed = true
                     return
                 }
             default:
@@ -459,6 +469,7 @@ class HotkeyManager {
                         isCustomPasteKeyDown = true
                         activeCustomPasteKeyCode = keyCode
                     }
+                    eventWasConsumed = true
                     return
                 }
             case .keyUp:
@@ -466,6 +477,7 @@ class HotkeyManager {
                     isCustomPasteKeyDown = false
                     activeCustomPasteKeyCode = nil
                     emitCustomPasteKeyDown()
+                    eventWasConsumed = true
                     return
                 }
             default:
@@ -505,6 +517,7 @@ class HotkeyManager {
                         activeMeetingKeyCode = keyCode
                         emitMeetingKeyDown()
                     }
+                    eventWasConsumed = true
                     return
                 }
             case .keyUp:
@@ -512,11 +525,13 @@ class HotkeyManager {
                     if activeMeetingKeyCode == keyCode {
                         activeMeetingKeyCode = nil
                     }
+                    eventWasConsumed = true
                     return
                 }
                 if isMeetingKeyDown, activeMeetingKeyCode == keyCode {
                     isMeetingKeyDown = false
                     activeMeetingKeyCode = nil
+                    eventWasConsumed = true
                     return
                 }
             default:
@@ -559,11 +574,13 @@ class HotkeyManager {
             guard keyCode == transcriptionHotkey.keyCode, transcriptionFlagsMatch, !isAutoRepeat else { return }
             if triggerMode == .tap {
                 emitKeyDown()
+                eventWasConsumed = true
                 return
             } else if !isKeyDown {
                 isKeyDown = true
                 activeKeyCode = keyCode
                 emitKeyDown()
+                eventWasConsumed = true
                 return
             }
         case .keyUp:
@@ -574,12 +591,14 @@ class HotkeyManager {
                 if keyCode == transcriptionHotkey.keyCode {
                     emitKeyUp()
                 }
+                eventWasConsumed = true
                 return
             }
             if isKeyDown, activeKeyCode == keyCode {
                 isKeyDown = false
                 activeKeyCode = nil
                 emitKeyUp()
+                eventWasConsumed = true
                 return
             }
         default:
@@ -1341,7 +1360,8 @@ extension HotkeyManager {
             _ = recoverEventTapIfNeeded(disabledEventType: type)
             return
         }
-        handleResolvedEvent(type: type, keyCode: keyCode, flags: flags, isAutoRepeat: isAutoRepeat)
+        var eventWasConsumed = false
+        handleResolvedEvent(type: type, keyCode: keyCode, flags: flags, isAutoRepeat: isAutoRepeat, eventWasConsumed: &eventWasConsumed)
     }
 
     func testingSetTransientState(

--- a/VoxtTests/HotkeyManagerTests.swift
+++ b/VoxtTests/HotkeyManagerTests.swift
@@ -79,6 +79,280 @@ final class HotkeyManagerTests: XCTestCase {
         return manager
     }
 
+    func testTapTranscriptionNonModifierDoesNotConsumeReleaseWithoutMatchingKeyDown() {
+        let defaults = UserDefaults.standard
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.save(
+            keyCode: UInt16(kVK_Space),
+            modifiers: [.function],
+            sidedModifiers: []
+        )
+
+        let manager = makeManager()
+        var keyUpCount = 0
+        manager.onKeyUp = { keyUpCount += 1 }
+
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_Space),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertEqual(keyUpCount, 0)
+    }
+
+    func testEscapeKeyDownCanBeConsumedViaCallback() {
+        let manager = makeManager()
+        var escapeCallbackCount = 0
+        manager.onEscapeKeyDown = {
+            escapeCallbackCount += 1
+            return true
+        }
+
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_Escape),
+                flags: []
+            )
+        )
+        XCTAssertEqual(escapeCallbackCount, 1)
+    }
+
+    func testEscapeKeyDownPassesThroughWhenCallbackDeclinesConsumption() {
+        let manager = makeManager()
+        var escapeCallbackCount = 0
+        manager.onEscapeKeyDown = {
+            escapeCallbackCount += 1
+            return false
+        }
+
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_Escape),
+                flags: []
+            )
+        )
+        XCTAssertEqual(escapeCallbackCount, 1)
+    }
+
+    func testTapTranscriptionNonModifierConsumesOnlyMatchingRelease() {
+        let defaults = UserDefaults.standard
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.save(
+            keyCode: UInt16(kVK_Space),
+            modifiers: [.function],
+            sidedModifiers: []
+        )
+
+        let manager = makeManager()
+        var keyUpCount = 0
+        manager.onKeyUp = { keyUpCount += 1 }
+
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_Space),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_A),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertEqual(keyUpCount, 0)
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_Space),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertEqual(keyUpCount, 1)
+    }
+
+    func testTapTranslationNonModifierDoesNotConsumeReleaseWithoutMatchingKeyDown() {
+        let defaults = UserDefaults.standard
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.saveTranslation(
+            keyCode: UInt16(kVK_ANSI_Z),
+            modifiers: [.function],
+            sidedModifiers: []
+        )
+
+        let manager = makeManager()
+        var translationKeyUpCount = 0
+        manager.onTranslationKeyUp = { translationKeyUpCount += 1 }
+
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_Z),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertEqual(translationKeyUpCount, 0)
+    }
+
+    func testTapRewriteNonModifierDoesNotConsumeReleaseWithoutMatchingKeyDown() {
+        let defaults = UserDefaults.standard
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.saveRewrite(
+            keyCode: UInt16(kVK_ANSI_R),
+            modifiers: [.function],
+            sidedModifiers: []
+        )
+
+        let manager = makeManager()
+        var rewriteKeyUpCount = 0
+        manager.onRewriteKeyUp = { rewriteKeyUpCount += 1 }
+
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_R),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertEqual(rewriteKeyUpCount, 0)
+    }
+
+    func testTapMeetingNonModifierConsumesOnlyMatchingRelease() {
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: AppPreferenceKey.meetingNotesBetaEnabled)
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.saveMeeting(
+            keyCode: UInt16(kVK_ANSI_M),
+            modifiers: [.function],
+            sidedModifiers: []
+        )
+
+        let manager = makeManager()
+
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_M),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_ANSI_M),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_A),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_M),
+                flags: .maskSecondaryFn
+            )
+        )
+    }
+
+    func testResetTransientStateClearsPendingTapReleaseConsumptionForNonModifierHotkey() {
+        let defaults = UserDefaults.standard
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.save(
+            keyCode: UInt16(kVK_Space),
+            modifiers: [.function],
+            sidedModifiers: []
+        )
+
+        let manager = makeManager()
+        var keyUpCount = 0
+        manager.onKeyUp = { keyUpCount += 1 }
+
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_Space),
+                flags: .maskSecondaryFn
+            )
+        )
+        manager.resetTransientState(reason: "unitTestCancel")
+
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_Space),
+                flags: .maskSecondaryFn
+            )
+        )
+        XCTAssertEqual(keyUpCount, 0)
+    }
+
+    func testTapNonModifierHotkeyRespectsRightCommandDistinction() {
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: AppPreferenceKey.hotkeyDistinguishModifierSides)
+        defaults.set(HotkeyPreference.Preset.custom.rawValue, forKey: AppPreferenceKey.hotkeyPreset)
+        HotkeyPreference.save(
+            keyCode: UInt16(kVK_ANSI_L),
+            modifiers: [.command],
+            sidedModifiers: [.rightCommand]
+        )
+
+        let manager = makeManager()
+        var transcriptionDownCount = 0
+        var keyUpCount = 0
+        manager.onKeyDown = { transcriptionDownCount += 1 }
+        manager.onKeyUp = { keyUpCount += 1 }
+
+        manager.testingHandleEvent(
+            type: .flagsChanged,
+            keyCode: UInt16(kVK_Command),
+            flags: commandFlags(for: .leftCommand)
+        )
+        XCTAssertFalse(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_ANSI_L),
+                flags: commandFlags(for: .leftCommand)
+            )
+        )
+        XCTAssertEqual(transcriptionDownCount, 0)
+        manager.testingHandleEvent(
+            type: .flagsChanged,
+            keyCode: UInt16(kVK_Command),
+            flags: []
+        )
+        manager.testingHandleEvent(
+            type: .flagsChanged,
+            keyCode: UInt16(kVK_RightCommand),
+            flags: commandFlags(for: .rightCommand)
+        )
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyDown,
+                keyCode: UInt16(kVK_ANSI_L),
+                flags: commandFlags(for: .rightCommand)
+            )
+        )
+        XCTAssertEqual(transcriptionDownCount, 1)
+        XCTAssertTrue(
+            manager.testingHandleEvent(
+                type: .keyUp,
+                keyCode: UInt16(kVK_ANSI_L),
+                flags: commandFlags(for: .rightCommand)
+            )
+        )
+        XCTAssertEqual(keyUpCount, 1)
+    }
+
     func testStaleFnStateIsResetBeforeFreshTapStartsTranscription() async {
         let manager = makeManager()
         var transcriptionDownCount = 0


### PR DESCRIPTION
## 问题描述

当用户按下不含修饰键的快捷键组合（例如 **Fn+Space**、**Fn+Z**）时，字符键事件会穿透到前台应用，导致当前输入框中意外插入字符。

例如：在文本编辑器中，按下快捷键 `Fn+Space` 本来应该触发语音转文字，但结果是在编辑器里插入了一个空格。

## 解决方案

将 `CGEventTap` 从**仅监听模式（listen-only）**改为**活动模式（active tap）**：

- 当检测到有配置的快捷键（非修饰键的 `keyDown` / `keyUp`）被触发时，返回 `nil` 来**消费该事件**，阻止其继续传递到前台应用。
- 其他未匹配的按键事件不受影响，正常放行。

## 修复效果

| 修复前 | 修复后 |
|---|---|
| 按快捷键后，当前输入框会意外插入字符（如空格、字母等） | 快捷键正常触发功能，不会向输入框插入任何字符 |
| 事件穿透导致前台应用响应了本应被拦截的按键 | 匹配的快捷键事件被正确消费，前台应用无感知 |

## 测试计划

- [x] `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/HotkeyManagerTests` — 全部 23 项测试通过
- [x] 手动测试 Fn+Space 和 Fn+Z 快捷键，确认字符不再泄漏到前台应用