### PR TITLE
fix: move feature sidebar Back button to the top

### DIFF
--- a/Voxt/Settings/SettingsView.swift
+++ b/Voxt/Settings/SettingsView.swift
@@ -635,6 +635,12 @@ private struct SettingsSidebar: View {
                     .buttonStyle(SettingsSidebarItemButtonStyle(isActive: tab == selectedTab))
                 }
             } else {
+                Button(action: onReturnToRoot) {
+                    Label(settingsLocalized("Back"), systemImage: "chevron.left")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(SettingsPillButtonStyle())
+
                 ForEach(visibleFeatureTabs) { tab in
                     Button {
                         onSelectFeatureTab(tab)
@@ -755,14 +761,6 @@ private struct SettingsSidebar: View {
                 .frame(maxWidth: .infinity)
                 .disabled(updateBadgeState.isTriggerDisabled)
                 .buttonStyle(SettingsStatusButtonStyle(tint: updateBadgeState.tintColor))
-            }
-
-            if sidebarMode == .feature {
-                Button(action: onReturnToRoot) {
-                    Label(settingsLocalized("Back"), systemImage: "chevron.left")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(SettingsPillButtonStyle())
             }
 
         }


### PR DESCRIPTION
## Summary

When you click the **Feature** entry in the root settings sidebar (it's the third item in the top group), the sidebar swaps to a sub-list of Feature tabs. The Back button was previously rendered at the **bottom** of that sub-list — visually far from where the user just clicked. My intuition kept hunting for Back right where I had clicked Feature, and not finding it there felt off.

Move the Back button to the **top** of the Feature sidebar, immediately above the Feature tabs, so the click that opens Feature and the click that returns share roughly the same vertical region.

## Before / After

Before: `[Feature tabs] … [spacer + status badges] … [Back]`
After:  `[Back] [Feature tabs] … [spacer + status badges]`

No layout container changes, no other behavior changes — just the Back button's position inside the same `VStack`.

## Test plan

- [ ] Build the app and open Settings.
- [ ] Click **Feature** in the sidebar; confirm the Back button now sits at the top of the Feature sub-list.
- [ ] Click **Back**; confirm it returns to the root sidebar as before.
- [ ] Verify the status badges (permissions, microphone, downloading, model setup, update) still render in their positions for the root sidebar — they only show in `.root` mode and are unaffected.

cc @hehehai 🙏 — small UX nit, happy to adjust if you'd rather keep the bottom placement.