### PR TITLE
fix: stretch Settings window content to match resized window frame

### DIFF
--- a/Voxt/Settings/SettingsView.swift
+++ b/Voxt/Settings/SettingsView.swift
@@ -99,7 +99,7 @@ struct SettingsView: View {
             .padding(.top, 10)
         }
         .clipShape(RoundedRectangle(cornerRadius: SettingsUIStyle.windowCornerRadius, style: .continuous))
-        .frame(minWidth: 760, minHeight: 560)
+        .frame(minWidth: 760, maxWidth: .infinity, minHeight: 560, maxHeight: .infinity)
         .environment(\.locale, interfaceLanguage.locale)
         .groupBoxStyle(SettingsPanelGroupBoxStyle())
         .id(languageRefreshToken)


### PR DESCRIPTION
## Summary

The Settings window's chrome (rounded corners + tinted background) is drawn by a SwiftUI `RoundedRectangle` inside a transparent `NSWindow` (`isOpaque = false`, `backgroundColor = .clear`). When the window is resized larger, the SwiftUI content does not grow with it: the `RoundedRectangle` stays at its intrinsic minimum size and the rest of the window becomes a transparent gutter that bleeds through to the desktop. Screenshots from the reporter show the rounded chrome stuck in the upper-left while the right side of the resized window is empty / transparent.

## Root cause

`SettingsView`'s root frame at `Voxt/Settings/SettingsView.swift` only set a floor:

```swift
.frame(minWidth: 760, minHeight: 560)
```

The `NSHostingController` wrapper in `AppDelegate+MenuWindow.swift` *does* declare `maxWidth: .infinity, maxHeight: .infinity`, so the host is willing to grow. But without `maxWidth/maxHeight: .infinity` on the inner `SettingsView` frame too, SwiftUI collapses the root to its content's intrinsic size (clamped to the minimum). The window grows; the SwiftUI layer doesn't follow.

## Fix

Add `maxWidth: .infinity, maxHeight: .infinity` to the root frame so the SwiftUI content expands to fill whatever size the window provides:

```swift
.frame(minWidth: 760, maxWidth: .infinity, minHeight: 560, maxHeight: .infinity)
```

One-line change, no behavior change at default size.

## Test plan

- [ ] Open Settings at default size → looks identical to before.
- [ ] Drag the bottom-right corner outward → the rounded chrome and content stretch with the window; no transparent gutter on the right or bottom.
- [ ] Shrink the window down to the 760×560 minimum → still bounded by the existing minimum (`window.contentMinSize` from `AppDelegate+MenuWindow.swift`).
- [ ] Toggle between Normal and Onboarding display modes at a resized size → both follow.
