### PR TITLE
Fix database startup WAL setup crash

### DIFF
--- a/Voxt/Support/Persistence/VoxtDatabase.swift
+++ b/Voxt/Support/Persistence/VoxtDatabase.swift
@@ -20,8 +20,10 @@ final class VoxtDatabase: @unchecked Sendable {
             }
 
             dbQueue = try DatabaseQueue(path: resolvedURL.path, configuration: configuration)
-            try dbQueue.write { db in
+            try dbQueue.writeWithoutTransaction { db in
                 try db.execute(sql: "PRAGMA journal_mode = WAL")
+            }
+            try dbQueue.write { db in
                 try db.execute(sql: "PRAGMA foreign_keys = ON")
             }
             try Self.migrator.migrate(dbQueue)


### PR DESCRIPTION
## Summary
- Move SQLite WAL journal mode setup outside the regular GRDB write transaction.
- Keep foreign key enabling in a normal write after WAL mode is configured.

## Why
On first launch after updating, Voxt initializes the local SQLite database and enables WAL mode. Running PRAGMA journal_mode = WAL inside a regular transaction can trigger a SQLite/GRDB assertion in some environments, causing the app to quit immediately on startup.

## Testing
- HotkeySupportTests + HotkeyActionResolverTests passed
- xcodebuild build passed
