### PR TITLE
Add Codex OAuth LLM provider

### DIFF
--- a/Voxt/Settings/RemoteProviderConfigurationSheet+Sections.swift
+++ b/Voxt/Settings/RemoteProviderConfigurationSheet+Sections.swift
@@ -115,13 +115,25 @@ extension RemoteProviderConfigurationSheet {
                 }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text(apiKeyFieldTitle)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                SecureField(apiKeyFieldPlaceholder, text: $apiKey)
-                    .textFieldStyle(.plain)
-                    .settingsFieldSurface(minHeight: 34)
+            if isCodexLLMProvider {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(apiKeyFieldTitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(AppLocalization.localizedString("Voxt uses the local Codex login at ~/.codex/auth.json. Run `codex login` first if the test fails."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(apiKeyFieldTitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    SecureField(apiKeyFieldPlaceholder, text: $apiKey)
+                        .textFieldStyle(.plain)
+                        .settingsFieldSurface(minHeight: 34)
+                }
             }
 
             if let endpointPresetHintText {

--- a/Voxt/Settings/RemoteProviderConfigurationSheet+State.swift
+++ b/Voxt/Settings/RemoteProviderConfigurationSheet+State.swift
@@ -13,18 +13,32 @@ extension RemoteProviderConfigurationSheet {
         llmProviderForPicker == .openAI
     }
 
+    var isCodexLLMProvider: Bool {
+        llmProviderForPicker == .codex
+    }
+
+    var usesOpenAIResponsesOptions: Bool {
+        isOpenAILLMProvider || isCodexLLMProvider
+    }
+
     var showsLargeAdvancedProviderSection: Bool {
         llmProviderForPicker != nil
     }
 
     var apiKeyFieldTitle: String {
-        (llmProviderForPicker?.apiKeyIsOptional == true)
+        if isCodexLLMProvider {
+            return AppLocalization.localizedString("Codex Login")
+        }
+        return (llmProviderForPicker?.apiKeyIsOptional == true)
             ? AppLocalization.localizedString("API Key (Optional)")
             : AppLocalization.localizedString("API Key")
     }
 
     var apiKeyFieldPlaceholder: String {
-        (llmProviderForPicker?.apiKeyIsOptional == true)
+        if isCodexLLMProvider {
+            return AppLocalization.localizedString("Uses ~/.codex/auth.json")
+        }
+        return (llmProviderForPicker?.apiKeyIsOptional == true)
             ? AppLocalization.localizedString("Paste API key (optional)")
             : AppLocalization.localizedString("Paste API key")
     }
@@ -189,7 +203,7 @@ extension RemoteProviderConfigurationSheet {
 
     var generationThinkingEffortMenuOptions: [SettingsMenuOption<String>] {
         let values: [String]
-        if isOpenAILLMProvider {
+        if usesOpenAIResponsesOptions {
             values = OpenAIReasoningEffort.supportedCases(forModel: resolvedModelValue())
                 .filter { $0 != .automatic }
                 .map(\.rawValue)
@@ -234,14 +248,14 @@ extension RemoteProviderConfigurationSheet {
             providerID: configuration.providerID,
             model: resolvedModelValue(),
             endpoint: isDoubaoASRTest ? "" : endpoint.trimmingCharacters(in: .whitespacesAndNewlines),
-            apiKey: isDoubaoASRTest ? "" : apiKey.trimmingCharacters(in: .whitespacesAndNewlines),
+            apiKey: (isDoubaoASRTest || isCodexLLMProvider) ? "" : apiKey.trimmingCharacters(in: .whitespacesAndNewlines),
             appID: appID.trimmingCharacters(in: .whitespacesAndNewlines),
             accessToken: accessToken.trimmingCharacters(in: .whitespacesAndNewlines),
             searchEnabled: (llmProviderForPicker?.supportsHostedSearch == true) ? searchEnabled : false,
             openAIChunkPseudoRealtimeEnabled: isOpenAIASRTest ? openAIChunkPseudoRealtimeEnabled : false,
-            openAIReasoningEffort: isOpenAILLMProvider ? openAIReasoningEffortSnapshot() : OpenAIReasoningEffort.automatic.rawValue,
-            openAITextVerbosity: isOpenAILLMProvider ? openAITextVerbosity : OpenAITextVerbosity.automatic.rawValue,
-            openAIMaxOutputTokens: isOpenAILLMProvider ? parsedOptionalInt(generationMaxOutputTokensText) : nil,
+            openAIReasoningEffort: usesOpenAIResponsesOptions ? openAIReasoningEffortSnapshot() : OpenAIReasoningEffort.automatic.rawValue,
+            openAITextVerbosity: usesOpenAIResponsesOptions ? openAITextVerbosity : OpenAITextVerbosity.automatic.rawValue,
+            openAIMaxOutputTokens: usesOpenAIResponsesOptions ? parsedOptionalInt(generationMaxOutputTokensText) : nil,
             doubaoDictionaryMode: doubaoDictionaryMode,
             doubaoEnableRequestHotwords: doubaoEnableRequestHotwords,
             doubaoEnableRequestCorrections: doubaoEnableRequestCorrections,
@@ -446,6 +460,8 @@ extension RemoteProviderConfigurationSheet {
             return AppLocalization.localizedString("Aliyun API keys are region-specific; use the matching endpoint.")
         case .volcengine:
             return AppLocalization.localizedString("Volcengine models should use the Responses endpoint in the same region as the API key.")
+        case .codex:
+            return AppLocalization.localizedString("Codex uses the ChatGPT subscription backend and local Codex OAuth credentials.")
         default:
             return nil
         }

--- a/Voxt/Settings/RemoteProviderConfigurationSheet.swift
+++ b/Voxt/Settings/RemoteProviderConfigurationSheet.swift
@@ -95,7 +95,7 @@ struct RemoteProviderConfigurationSheet: View {
                         advancedGenerationSettingsSection
                     }
 
-                    if isOpenAILLMProvider {
+                    if usesOpenAIResponsesOptions {
                         openAILLMConfigurationSection
                     }
 

--- a/Voxt/Support/CodexOAuthCredentialProvider.swift
+++ b/Voxt/Support/CodexOAuthCredentialProvider.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+struct CodexOAuthCredentialProvider {
+    struct Credential {
+        let accessToken: String
+        let accountID: String?
+    }
+
+    enum CredentialError: LocalizedError {
+        case authFileNotFound(String)
+        case missingTokens
+        case invalidAuthFile(String)
+        case refreshFailed(Int, String)
+
+        var errorDescription: String? {
+            switch self {
+            case .authFileNotFound(let path):
+                return AppLocalization.format("Codex auth not found at %@. Run `codex login` first.", path)
+            case .missingTokens:
+                return AppLocalization.localizedString("Codex auth.json has no ChatGPT OAuth tokens. Run `codex login` first.")
+            case .invalidAuthFile(let detail):
+                return AppLocalization.format("Invalid Codex auth.json: %@", detail)
+            case .refreshFailed(let status, let body):
+                return AppLocalization.format("Codex token refresh failed (HTTP %d). %@ Run `codex login` again.", status, body)
+            }
+        }
+    }
+
+    private struct AuthFile: Codable {
+        var authMode: String?
+        var openAIAPIKey: String?
+        var tokens: Tokens?
+        var lastRefresh: String?
+
+        enum CodingKeys: String, CodingKey {
+            case authMode = "auth_mode"
+            case openAIAPIKey = "OPENAI_API_KEY"
+            case tokens
+            case lastRefresh = "last_refresh"
+        }
+    }
+
+    private struct Tokens: Codable {
+        var idToken: String?
+        var accessToken: String?
+        var refreshToken: String?
+        var accountID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case idToken = "id_token"
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+            case accountID = "account_id"
+        }
+    }
+
+    private struct RefreshResponse: Codable {
+        var idToken: String?
+        var accessToken: String?
+        var refreshToken: String?
+
+        enum CodingKeys: String, CodingKey {
+            case idToken = "id_token"
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+        }
+    }
+
+    private let fileManager: FileManager
+    private let environment: [String: String]
+    private let refreshURL = URL(string: "https://auth.openai.com/oauth/token")!
+    private let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+    init(
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.fileManager = fileManager
+        self.environment = environment
+    }
+
+    func authorizationHeaders() async throws -> [String: String] {
+        let credential = try await credential()
+        var headers = [
+            "Authorization": "Bearer \(credential.accessToken)",
+            "User-Agent": "codex_cli_rs/0.0.0 (Voxt)",
+            "originator": "codex_cli_rs"
+        ]
+        if let accountID = credential.accountID, !accountID.isEmpty {
+            headers["ChatGPT-Account-ID"] = accountID
+        }
+        return headers
+    }
+
+    func credential() async throws -> Credential {
+        let path = authFilePath()
+        var auth = try readAuthFile(path: path)
+        guard let tokens = auth.tokens,
+              let accessToken = tokens.accessToken,
+              !accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw CredentialError.missingTokens
+        }
+
+        if !isTokenExpired(accessToken, lastRefresh: auth.lastRefresh) {
+            return Credential(
+                accessToken: accessToken,
+                accountID: tokens.accountID ?? chatGPTAccountID(from: accessToken)
+            )
+        }
+
+        guard let refreshToken = tokens.refreshToken,
+              !refreshToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw CredentialError.missingTokens
+        }
+
+        let refreshed = try await refreshTokens(refreshToken: refreshToken)
+        let newAccessToken = refreshed.accessToken ?? accessToken
+        auth.tokens = Tokens(
+            idToken: refreshed.idToken ?? tokens.idToken,
+            accessToken: newAccessToken,
+            refreshToken: refreshed.refreshToken ?? refreshToken,
+            accountID: tokens.accountID
+        )
+        auth.lastRefresh = ISO8601DateFormatter().string(from: Date())
+        try writeAuthFile(auth, path: path)
+
+        return Credential(
+            accessToken: newAccessToken,
+            accountID: auth.tokens?.accountID ?? chatGPTAccountID(from: newAccessToken)
+        )
+    }
+
+    private func authFilePath() -> String {
+        if let codexHome = environment["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !codexHome.isEmpty {
+            return (codexHome as NSString).expandingTildeInPath.appending("/auth.json")
+        }
+        return ("~/.codex/auth.json" as NSString).expandingTildeInPath
+    }
+
+    private func readAuthFile(path: String) throws -> AuthFile {
+        guard fileManager.fileExists(atPath: path) else {
+            throw CredentialError.authFileNotFound(path)
+        }
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            return try JSONDecoder().decode(AuthFile.self, from: data)
+        } catch let error as CredentialError {
+            throw error
+        } catch {
+            throw CredentialError.invalidAuthFile(error.localizedDescription)
+        }
+    }
+
+    private func writeAuthFile(_ auth: AuthFile, path: String) throws {
+        do {
+            let url = URL(fileURLWithPath: path)
+            var object: [String: Any] = [:]
+            if let existingData = try? Data(contentsOf: url),
+               let existingObject = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] {
+                object = existingObject
+            }
+
+            if let authMode = auth.authMode {
+                object["auth_mode"] = authMode
+            }
+            if let openAIAPIKey = auth.openAIAPIKey {
+                object["OPENAI_API_KEY"] = openAIAPIKey
+            }
+            if let tokens = auth.tokens {
+                var tokenObject = object["tokens"] as? [String: Any] ?? [:]
+                if let idToken = tokens.idToken {
+                    tokenObject["id_token"] = idToken
+                }
+                if let accessToken = tokens.accessToken {
+                    tokenObject["access_token"] = accessToken
+                }
+                if let refreshToken = tokens.refreshToken {
+                    tokenObject["refresh_token"] = refreshToken
+                }
+                if let accountID = tokens.accountID {
+                    tokenObject["account_id"] = accountID
+                }
+                object["tokens"] = tokenObject
+            }
+            if let lastRefresh = auth.lastRefresh {
+                object["last_refresh"] = lastRefresh
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+        } catch {
+            throw CredentialError.invalidAuthFile(error.localizedDescription)
+        }
+    }
+
+    private func isTokenExpired(_ accessToken: String, lastRefresh: String?) -> Bool {
+        if let expiration = jwtExpiration(accessToken),
+           expiration <= Date().timeIntervalSince1970 + 60 {
+            return true
+        }
+        guard let lastRefresh else { return false }
+        guard let date = ISO8601DateFormatter().date(from: lastRefresh) else { return false }
+        return Date().timeIntervalSince(date) > 8 * 24 * 60 * 60
+    }
+
+    private func refreshTokens(refreshToken: String) async throws -> RefreshResponse {
+        var request = URLRequest(url: refreshURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 20
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "client_id": clientID,
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken
+        ])
+
+        let (data, response) = try await VoxtNetworkSession.active.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw CredentialError.refreshFailed(-1, "")
+        }
+        guard (200...299).contains(http.statusCode) else {
+            let body = String(data: data.prefix(240), encoding: .utf8) ?? ""
+            throw CredentialError.refreshFailed(http.statusCode, body)
+        }
+        return try JSONDecoder().decode(RefreshResponse.self, from: data)
+    }
+
+    private func jwtExpiration(_ token: String) -> TimeInterval? {
+        guard let payload = jwtPayload(token) else {
+            return nil
+        }
+        if let expiration = payload["exp"] as? TimeInterval {
+            return expiration
+        }
+        if let expiration = payload["exp"] as? NSNumber {
+            return expiration.doubleValue
+        }
+        return nil
+    }
+
+    private func chatGPTAccountID(from token: String) -> String? {
+        guard let payload = jwtPayload(token),
+              let auth = payload["https://api.openai.com/auth"] as? [String: Any],
+              let accountID = auth["chatgpt_account_id"] as? String
+        else {
+            return nil
+        }
+        return accountID
+    }
+
+    private func jwtPayload(_ token: String) -> [String: Any]? {
+        let parts = token.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+        var encoded = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = encoded.count % 4
+        if padding > 0 {
+            encoded += String(repeating: "=", count: 4 - padding)
+        }
+        guard let data = Data(base64Encoded: encoded),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let payload = object as? [String: Any]
+        else {
+            return nil
+        }
+        return payload
+    }
+}

--- a/Voxt/Support/LLMGenerationSettings.swift
+++ b/Voxt/Support/LLMGenerationSettings.swift
@@ -123,7 +123,7 @@ enum LLMProviderCapabilityRegistry {
 
     static func capabilities(for provider: RemoteLLMProvider) -> LLMProviderCapabilities {
         switch provider {
-        case .openAI:
+        case .openAI, .codex:
             return LLMProviderCapabilities(
                 supportsThinkingEffort: true,
                 supportsLogprobs: true,

--- a/Voxt/Support/RemoteLLMRuntimeClient+EndpointSupport.swift
+++ b/Voxt/Support/RemoteLLMRuntimeClient+EndpointSupport.swift
@@ -10,6 +10,8 @@ extension RemoteLLMRuntimeClient {
             return "https://generativelanguage.googleapis.com/v1beta/models"
         case .openAI:
             return "https://api.openai.com/v1/responses"
+        case .codex:
+            return "https://chatgpt.com/backend-api/codex/responses"
         case .ollama:
             return "http://localhost:11434"
         case .omlx:
@@ -93,6 +95,11 @@ extension RemoteLLMRuntimeClient {
             return normalizedResponsesEndpoint(
                 base,
                 defaultPath: "/v1/responses"
+            )
+        case .codex:
+            return normalizedResponsesEndpoint(
+                base,
+                defaultPath: "/responses"
             )
         case .aliyunBailian:
             return normalizedResponsesEndpoint(

--- a/Voxt/Support/RemoteLLMRuntimeClient+MessageSupport.swift
+++ b/Voxt/Support/RemoteLLMRuntimeClient+MessageSupport.swift
@@ -85,7 +85,8 @@ extension RemoteLLMRuntimeClient {
         previousResponseID: String?,
         tuning: RemoteLLMRuntimeClient.GenerationTuning,
         textFormat: [String: Any]?,
-        streamingEnabled: Bool
+        streamingEnabled: Bool,
+        additionalHeaders: [String: String] = [:]
     ) throws -> URLRequest {
         guard let url = URL(string: endpointValue) else {
             throw NSError(
@@ -108,6 +109,9 @@ extension RemoteLLMRuntimeClient {
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
+        for (key, value) in additionalHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
 
         let generationSettings = configuration.effectiveGenerationSettings(provider: provider)
         let maxOutputTokens = generationSettings.maxOutputTokens.map { max(1, $0) } ?? tuning.maxTokens
@@ -117,7 +121,7 @@ extension RemoteLLMRuntimeClient {
             "stream": streamingEnabled,
             "max_output_tokens": maxOutputTokens
         ]
-        if provider != .openAI {
+        if provider != .openAI && provider != .codex {
             payload["temperature"] = tuning.temperature
             payload["top_p"] = tuning.topP
         }
@@ -152,7 +156,7 @@ extension RemoteLLMRuntimeClient {
         )
 
         var textPayload = textFormat ?? [:]
-        if provider == .openAI,
+        if (provider == .openAI || provider == .codex),
            let verbosity = OpenAITextVerbosity.apiValue(
             selection: configuration.openAITextVerbosity,
             model: model
@@ -187,7 +191,7 @@ extension RemoteLLMRuntimeClient {
         settings: LLMGenerationSettings,
         configuration: RemoteProviderConfiguration
     ) -> String? {
-        if provider == .openAI {
+        if provider == .openAI || provider == .codex {
             if settings.thinking.mode == .effort,
                let effort = settings.thinking.effort,
                OpenAIReasoningEffort.apiValue(selection: effort, model: model) != nil {

--- a/Voxt/Support/RemoteLLMRuntimeClient.swift
+++ b/Voxt/Support/RemoteLLMRuntimeClient.swift
@@ -40,6 +40,14 @@ struct RemoteLLMRuntimeClient {
         }
     }
 
+    func authorizationHeaders(
+        provider: RemoteLLMProvider,
+        configuration _: RemoteProviderConfiguration
+    ) async throws -> [String: String] {
+        guard provider == .codex else { return [:] }
+        return try await CodexOAuthCredentialProvider().authorizationHeaders()
+    }
+
     private struct StreamingPartialDeliveryState {
         var lastPublishedAt = Date.distantPast
         var lastPublishedLength = 0
@@ -93,6 +101,9 @@ struct RemoteLLMRuntimeClient {
         let apiKey = configuration.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        for (key, value) in try await authorizationHeaders(provider: provider, configuration: configuration) {
+            request.setValue(value, forHTTPHeaderField: key)
         }
 
         let (_, response) = try await VoxtNetworkSession.active.data(for: request)
@@ -566,6 +577,7 @@ struct RemoteLLMRuntimeClient {
             intent: intent
         ).applying(configuration.effectiveGenerationSettings(provider: provider))
         let shouldAttemptStreaming = onPartialText != nil && supportsStreaming(provider: provider, intent: intent)
+        let authHeaders = try await authorizationHeaders(provider: provider, configuration: configuration)
 
         if shouldAttemptStreaming, let onPartialText {
             do {
@@ -579,7 +591,8 @@ struct RemoteLLMRuntimeClient {
                     previousResponseID: previousResponseID,
                     tuning: tuning,
                     textFormat: textFormat,
-                    streamingEnabled: true
+                    streamingEnabled: true,
+                    additionalHeaders: authHeaders
                 )
                 let requestStartedAt = Date()
                 logRequest(
@@ -618,7 +631,8 @@ struct RemoteLLMRuntimeClient {
             previousResponseID: previousResponseID,
             tuning: tuning,
             textFormat: textFormat,
-            streamingEnabled: false
+            streamingEnabled: false,
+            additionalHeaders: authHeaders
         )
         let requestStartedAt = Date()
         logRequest(

--- a/Voxt/Support/RemoteModelConfiguration.swift
+++ b/Voxt/Support/RemoteModelConfiguration.swift
@@ -85,6 +85,7 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
     case anthropic
     case google
     case openAI
+    case codex
     case ollama
     case omlx
     case deepseek
@@ -101,7 +102,7 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
 
     nonisolated var usesResponsesAPI: Bool {
         switch self {
-        case .openAI, .volcengine, .aliyunBailian:
+        case .openAI, .codex, .volcengine, .aliyunBailian:
             return true
         default:
             return false
@@ -123,7 +124,7 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
 
     nonisolated var apiKeyIsOptional: Bool {
         switch self {
-        case .ollama, .omlx:
+        case .codex, .ollama, .omlx:
             return true
         default:
             return false
@@ -153,6 +154,8 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
             return AppLocalization.localizedString("Google")
         case .openAI:
             return AppLocalization.localizedString("OpenAI")
+        case .codex:
+            return AppLocalization.localizedString("Codex (ChatGPT)")
         case .ollama:
             return AppLocalization.localizedString("Ollama")
         case .omlx:
@@ -186,6 +189,8 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
             return "gemini-2.5-pro"
         case .openAI:
             return "gpt-5.2"
+        case .codex:
+            return "gpt-5.4-mini"
         case .ollama:
             return "qwen2.5"
         case .omlx:
@@ -245,6 +250,13 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
                 RemoteModelOption(id: "gpt-5-pro", title: "GPT-5 pro"),
                 RemoteModelOption(id: "gpt-5-mini", title: "GPT-5 mini"),
                 RemoteModelOption(id: "gpt-5-nano", title: "GPT-5 nano")
+            ]
+        case .codex:
+            return [
+                RemoteModelOption(id: "gpt-5.4-mini", title: "GPT-5.4 Mini"),
+                RemoteModelOption(id: "gpt-5.4", title: "GPT-5.4"),
+                RemoteModelOption(id: "gpt-5.3-codex-spark", title: "GPT-5.3 Codex Spark"),
+                RemoteModelOption(id: "gpt-5.5", title: "GPT-5.5")
             ]
         case .ollama:
             return [
@@ -347,6 +359,8 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
                 RemoteModelOption(id: "gpt-4o-mini", title: "GPT-4o mini"),
                 RemoteModelOption(id: "gpt-4o", title: "GPT-4o")
             ]
+        case .codex:
+            return []
         case .ollama:
             return [
                 RemoteModelOption(id: "qwen2.5", title: "Qwen2.5 7B"),
@@ -426,6 +440,8 @@ enum RemoteLLMProvider: String, CaseIterable, Identifiable {
             return [
                 RemoteModelOption(id: "gpt-4", title: "GPT-4")
             ]
+        case .codex:
+            return []
         case .ollama:
             return [
                 RemoteModelOption(id: "gpt-oss:120b", title: "GPT-OSS 120B"),

--- a/Voxt/Support/RemoteProviderConfiguration.swift
+++ b/Voxt/Support/RemoteProviderConfiguration.swift
@@ -101,6 +101,9 @@ enum OpenAIReasoningEffort: String, CaseIterable, Identifiable {
         if normalized == "gpt-5.2-codex" || normalized.hasPrefix("gpt-5.2-codex-") {
             return [.automatic, .low, .medium, .high, .xhigh]
         }
+        if normalized == "gpt-5.3-codex-spark" || normalized.hasPrefix("gpt-5.3-codex-spark-") {
+            return [.automatic, .none, .low, .medium, .high]
+        }
         if normalized == "gpt-5.1-codex-max" || normalized.hasPrefix("gpt-5.1-codex-max-") {
             return [.automatic, .none, .medium, .high, .xhigh]
         }

--- a/Voxt/Support/RemoteProviderConfigurationPolicy.swift
+++ b/Voxt/Support/RemoteProviderConfigurationPolicy.swift
@@ -169,6 +169,10 @@ enum RemoteProviderConfigurationPolicy {
                 return [
                     RemoteEndpointPreset(id: "volcengine-llm-cn-beijing", title: AppLocalization.localizedString("Beijing"), url: "https://ark.cn-beijing.volces.com/api/v3/responses")
                 ]
+            case .codex:
+                return [
+                    RemoteEndpointPreset(id: "codex-chatgpt", title: AppLocalization.localizedString("ChatGPT Codex"), url: "https://chatgpt.com/backend-api/codex/responses")
+                ]
             default:
                 return []
             }

--- a/Voxt/Support/RemoteProviderConnectivityTester.swift
+++ b/Voxt/Support/RemoteProviderConnectivityTester.swift
@@ -423,9 +423,14 @@ struct RemoteProviderConnectivityTester {
             }
             headers["Authorization"] = "Bearer \(configuration.apiKey)"
             return try await testMiniMaxReachability(endpoint: endpoint, headers: headers, model: model)
-        case .openAI, .ollama, .omlx, .deepseek, .openrouter, .grok, .zai, .volcengine, .kimi, .lmStudio, .aliyunBailian:
+        case .openAI, .codex, .ollama, .omlx, .deepseek, .openrouter, .grok, .zai, .volcengine, .kimi, .lmStudio, .aliyunBailian:
             if !configuration.apiKey.isEmpty {
                 headers["Authorization"] = "Bearer \(configuration.apiKey)"
+            }
+            if provider == .codex {
+                for (key, value) in try await CodexOAuthCredentialProvider().authorizationHeaders() {
+                    headers[key] = value
+                }
             }
             if provider.usesResponsesAPI {
                 return try await testResponsesReachability(

--- a/VoxtTests/RemoteLLMRuntimeClientStreamingTests.swift
+++ b/VoxtTests/RemoteLLMRuntimeClientStreamingTests.swift
@@ -649,6 +649,41 @@ final class RemoteLLMRuntimeClientStreamingTests: XCTestCase {
         XCTAssertEqual(format["type"] as? String, "json_object")
     }
 
+    func testMakeResponsesRequestAppliesCodexOAuthHeaders() throws {
+        let client = RemoteLLMRuntimeClient()
+        let request = try client.makeResponsesRequest(
+            provider: .codex,
+            endpointValue: "https://chatgpt.com/backend-api/codex/responses",
+            model: "gpt-5.3-codex-spark",
+            systemPrompt: "",
+            inputPayload: "ping",
+            configuration: RemoteProviderConfiguration(
+                providerID: RemoteLLMProvider.codex.rawValue,
+                model: "gpt-5.3-codex-spark",
+                endpoint: "",
+                apiKey: ""
+            ),
+            previousResponseID: nil,
+            tuning: .init(maxTokens: 512, temperature: 0.2, topP: 0.9),
+            textFormat: nil,
+            streamingEnabled: false,
+            additionalHeaders: [
+                "Authorization": "Bearer codex-token",
+                "originator": "codex_cli_rs",
+                "ChatGPT-Account-ID": "acct_123"
+            ]
+        )
+
+        let body = try XCTUnwrap(request.httpBody)
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer codex-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "originator"), "codex_cli_rs")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ChatGPT-Account-ID"), "acct_123")
+        XCTAssertNil(object["temperature"])
+        XCTAssertNil(object["top_p"])
+    }
+
     func testMakeResponsesRequestUsesJSONAcceptHeaderWhenNonStreaming() throws {
         let client = RemoteLLMRuntimeClient()
         let request = try client.makeResponsesRequest(

--- a/VoxtTests/RemoteModelConfigurationTests.swift
+++ b/VoxtTests/RemoteModelConfigurationTests.swift
@@ -235,6 +235,44 @@ final class RemoteModelConfigurationTests: XCTestCase {
         XCTAssertFalse(configuration.isConfigured)
     }
 
+    func testCodexConfigurationUsesLocalLoginAndDoesNotRequireAPIKey() {
+        let configuration = TestFactories.makeRemoteConfiguration(
+            providerID: RemoteLLMProvider.codex.rawValue,
+            model: "gpt-5.4-mini"
+        )
+
+        XCTAssertTrue(configuration.isConfigured)
+        XCTAssertTrue(RemoteLLMProvider.codex.apiKeyIsOptional)
+        XCTAssertTrue(RemoteLLMProvider.codex.usesResponsesAPI)
+    }
+
+    func testCodexCredentialProviderReadsLocalAuthFile() async throws {
+        let directory = try TemporaryDirectory()
+        let token = try makeTestJWT(payload: [
+            "exp": Date().addingTimeInterval(3600).timeIntervalSince1970,
+            "https://api.openai.com/auth": [
+                "chatgpt_account_id": "acct_test"
+            ]
+        ])
+        let authURL = directory.url.appendingPathComponent("auth.json")
+        let authData = try JSONSerialization.data(withJSONObject: [
+            "auth_mode": "chatgpt",
+            "tokens": [
+                "access_token": token,
+                "refresh_token": "refresh-token"
+            ]
+        ])
+        try authData.write(to: authURL)
+
+        let headers = try await CodexOAuthCredentialProvider(
+            environment: ["CODEX_HOME": directory.url.path]
+        ).authorizationHeaders()
+
+        XCTAssertEqual(headers["Authorization"], "Bearer \(token)")
+        XCTAssertEqual(headers["ChatGPT-Account-ID"], "acct_test")
+        XCTAssertEqual(headers["originator"], "codex_cli_rs")
+    }
+
     func testOpenAIModelCatalogUsesOfficialModelIDs() {
         XCTAssertEqual(RemoteLLMProvider.openAI.suggestedModel, "gpt-5.2")
 
@@ -244,6 +282,15 @@ final class RemoteModelConfigurationTests: XCTestCase {
         XCTAssertTrue(ids.contains("gpt-5.1"))
         XCTAssertFalse(ids.contains("gpt-5.5"))
         XCTAssertFalse(ids.contains("gpt-5.4"))
+    }
+
+    func testCodexModelCatalogDefaultsToMini() {
+        XCTAssertEqual(RemoteLLMProvider.codex.suggestedModel, "gpt-5.4-mini")
+
+        let ids = RemoteLLMProvider.codex.modelOptions.map(\.id)
+        XCTAssertEqual(ids.first, "gpt-5.4-mini")
+        XCTAssertTrue(ids.contains("gpt-5.3-codex-spark"))
+        XCTAssertTrue(ids.contains("gpt-5.4"))
     }
 
     func testOpenAIReasoningEffortOptionsFollowModelSupport() {
@@ -263,6 +310,19 @@ final class RemoteModelConfigurationTests: XCTestCase {
             OpenAIReasoningEffort.supportedCases(forModel: "gpt-5"),
             [.automatic, .minimal, .low, .medium, .high]
         )
+    }
+
+    private func makeTestJWT(payload: [String: Any]) throws -> String {
+        let headerData = try JSONSerialization.data(withJSONObject: ["alg": "none", "typ": "JWT"])
+        let payloadData = try JSONSerialization.data(withJSONObject: payload)
+        return "\(base64URLEncoded(headerData)).\(base64URLEncoded(payloadData)).signature"
+    }
+
+    private func base64URLEncoded(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 
     func testLoadSaveRoundTripPreservesOllamaConfigurationFields() {
@@ -346,6 +406,7 @@ final class RemoteModelConfigurationTests: XCTestCase {
 
     func testResponsesProviderCapabilitiesAreConfiguredPerProvider() {
         XCTAssertTrue(RemoteLLMProvider.openAI.usesResponsesAPI)
+        XCTAssertTrue(RemoteLLMProvider.codex.usesResponsesAPI)
         XCTAssertTrue(RemoteLLMProvider.aliyunBailian.usesResponsesAPI)
         XCTAssertTrue(RemoteLLMProvider.volcengine.usesResponsesAPI)
         XCTAssertTrue(RemoteLLMProvider.aliyunBailian.supportsHostedSearch)
@@ -353,6 +414,7 @@ final class RemoteModelConfigurationTests: XCTestCase {
         XCTAssertTrue(RemoteLLMProvider.aliyunBailian.defaultSearchEnabled)
         XCTAssertFalse(RemoteLLMProvider.volcengine.defaultSearchEnabled)
         XCTAssertTrue(RemoteLLMProvider.omlx.apiKeyIsOptional)
+        XCTAssertTrue(RemoteLLMProvider.codex.apiKeyIsOptional)
         XCTAssertFalse(RemoteLLMProvider.omlx.usesResponsesAPI)
     }
 


### PR DESCRIPTION
## Summary
- Add a new `Codex (ChatGPT)` LLM provider that reuses the local Codex OAuth login from `~/.codex/auth.json` instead of requiring a separate API key.
- Route requests to the ChatGPT Codex Responses endpoint with the required Codex-compatible headers and token refresh support.
- Add configuration UI copy, endpoint preset, connectivity testing support, and focused tests for the provider.
- Default the Codex provider model to `gpt-5.4-mini` so it does not assume every user has Pro-only model access.

## Screenshots
- Model list shows the new `Codex (ChatGPT)` remote LLM provider with configured/in-use state.
<img width="753" height="577" alt="Xnip2026-05-14_23-27-57" src="https://github.com/user-attachments/assets/4c26150e-e09c-47d3-b06f-94778bce683c" />

- Configure sheet shows the local Codex login flow, no API key field, Codex endpoint, and successful endpoint/auth routing test.
<img width="726" height="571" alt="Xnip2026-05-14_23-27-46" src="https://github.com/user-attachments/assets/644c9d4c-6ad0-41e7-8692-ea2fefbe2cac" />

## Tests
- `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/RemoteModelConfigurationTests -only-testing:VoxtTests/RemoteLLMRuntimeClientStreamingTests`\n- `xcodebuild build -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`