### PR TITLE
Surface underlying model error in recording start overlay

### DIFF
--- a/Voxt/App/RecordingStartPlanner.swift
+++ b/Voxt/App/RecordingStartPlanner.swift
@@ -3,10 +3,10 @@ import Foundation
 enum RecordingStartBlockReason: Equatable {
     case mlxModelNotInstalled
     case mlxModelDownloading
-    case mlxModelUnavailable
+    case mlxModelUnavailable(detail: String?)
     case whisperModelNotInstalled
     case whisperModelDownloading
-    case whisperModelUnavailable
+    case whisperModelUnavailable(detail: String?)
 
     var userMessage: String {
         switch self {
@@ -14,14 +14,20 @@ enum RecordingStartBlockReason: Equatable {
             return String(localized: "MLX model is not downloaded. Open Settings > Model to install it.")
         case .mlxModelDownloading:
             return String(localized: "MLX model is still downloading. Wait for installation to finish and try again.")
-        case .mlxModelUnavailable:
-            return String(localized: "MLX model is unavailable. Open Settings > Model to fix it.")
+        case .mlxModelUnavailable(let detail):
+            return Self.appendingDetail(
+                base: String(localized: "MLX model is unavailable. Open Settings > Model to fix it."),
+                detail: detail
+            )
         case .whisperModelNotInstalled:
             return String(localized: "Whisper model is not downloaded. Open Settings > Model to install it.")
         case .whisperModelDownloading:
             return String(localized: "Whisper model is still downloading. Wait for installation to finish and try again.")
-        case .whisperModelUnavailable:
-            return String(localized: "Whisper model is unavailable. Open Settings > Model to fix it.")
+        case .whisperModelUnavailable(let detail):
+            return Self.appendingDetail(
+                base: String(localized: "Whisper model is unavailable. Open Settings > Model to fix it."),
+                detail: detail
+            )
         }
     }
 
@@ -31,15 +37,23 @@ enum RecordingStartBlockReason: Equatable {
             return "MLX Audio model is not downloaded."
         case .mlxModelDownloading:
             return "MLX Audio model download is still in progress."
-        case .mlxModelUnavailable:
-            return "MLX Audio model is unavailable."
+        case .mlxModelUnavailable(let detail):
+            return Self.appendingDetail(base: "MLX Audio model is unavailable.", detail: detail)
         case .whisperModelNotInstalled:
             return "Whisper model is not downloaded."
         case .whisperModelDownloading:
             return "Whisper model download is still in progress."
-        case .whisperModelUnavailable:
-            return "Whisper model is unavailable."
+        case .whisperModelUnavailable(let detail):
+            return Self.appendingDetail(base: "Whisper model is unavailable.", detail: detail)
         }
+    }
+
+    private static func appendingDetail(base: String, detail: String?) -> String {
+        guard let detail else { return base }
+        let trimmed = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return base }
+        let prefix = String(localized: "Reason:")
+        return "\(base) \(prefix) \(trimmed)"
     }
 }
 
@@ -53,14 +67,14 @@ enum RecordingStartPlanner {
         case ready
         case notDownloaded
         case downloadingSelectedModel
-        case unavailable
+        case unavailable(detail: String?)
     }
 
     private enum DownloadStatePhase {
         case ready
         case notDownloaded
         case activeDownload
-        case unavailable
+        case unavailable(detail: String?)
     }
 
     static func resolve(
@@ -90,7 +104,7 @@ enum RecordingStartPlanner {
                 ),
                 notInstalledReason: .mlxModelNotInstalled,
                 downloadingReason: .mlxModelDownloading,
-                unavailableReason: .mlxModelUnavailable
+                unavailableReason: { detail in .mlxModelUnavailable(detail: detail) }
             )
         case .whisperKit:
             return decision(
@@ -103,7 +117,7 @@ enum RecordingStartPlanner {
                 ),
                 notInstalledReason: .whisperModelNotInstalled,
                 downloadingReason: .whisperModelDownloading,
-                unavailableReason: .whisperModelUnavailable
+                unavailableReason: { detail in .whisperModelUnavailable(detail: detail) }
             )
         }
     }
@@ -113,7 +127,7 @@ enum RecordingStartPlanner {
         availability: DownloadableModelAvailability,
         notInstalledReason: RecordingStartBlockReason,
         downloadingReason: RecordingStartBlockReason,
-        unavailableReason: RecordingStartBlockReason
+        unavailableReason: (String?) -> RecordingStartBlockReason
     ) -> RecordingStartDecision {
         switch availability {
         case .ready:
@@ -122,8 +136,8 @@ enum RecordingStartPlanner {
             return .blocked(notInstalledReason)
         case .downloadingSelectedModel:
             return .blocked(downloadingReason)
-        case .unavailable:
-            return .blocked(unavailableReason)
+        case .unavailable(let detail):
+            return .blocked(unavailableReason(detail))
         }
     }
 
@@ -208,8 +222,8 @@ enum RecordingStartPlanner {
                 return .downloadingSelectedModel
             }
             return isSelectedModelDownloaded ? .ready : .notDownloaded
-        case .unavailable:
-            return .unavailable
+        case .unavailable(let detail):
+            return .unavailable(detail: detail)
         }
     }
 
@@ -221,8 +235,8 @@ enum RecordingStartPlanner {
             return .notDownloaded
         case .downloading, .paused:
             return .activeDownload
-        case .error:
-            return .unavailable
+        case .error(let message):
+            return .unavailable(detail: message)
         }
     }
 
@@ -234,8 +248,8 @@ enum RecordingStartPlanner {
             return .notDownloaded
         case .downloading, .paused:
             return .activeDownload
-        case .error:
-            return .unavailable
+        case .error(let message):
+            return .unavailable(detail: message)
         }
     }
 

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -344,6 +344,7 @@
 "MLX model is not downloaded. Open Settings > Model to install it." = "MLX model is not downloaded. Open Settings > Model to install it.";
 "MLX model is still downloading. Wait for installation to finish and try again." = "MLX model is still downloading. Wait for installation to finish and try again.";
 "MLX model is unavailable. Open Settings > Model to fix it." = "MLX model is unavailable. Open Settings > Model to fix it.";
+"Reason:" = "Reason:";
 "Whisper (On-device)" = "Whisper (On-device)";
 "Uses WhisperKit speech models running locally. Supports multiple Whisper models and configurable decoding." = "Uses WhisperKit speech models running locally. Supports multiple Whisper models and configurable decoding.";
 "Transcribe" = "Transcribe";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -342,6 +342,7 @@
 "MLX model is not downloaded. Open Settings > Model to install it." = "MLX モデルが未ダウンロードです。設定 > モデルでインストールしてください。";
 "MLX model is unavailable. Open Settings > Model to fix it." = "MLX モデルが利用できません。設定 > モデルで修正してください。";
 "MLX model is still downloading. Wait for installation to finish and try again." = "MLX モデルはまだダウンロード中です。インストール完了後に再試行してください。";
+"Reason:" = "理由：";
 "Whisper (On-device)" = "Whisper オンデバイス";
 "Uses WhisperKit speech models running locally. Supports multiple Whisper models and configurable decoding." = "WhisperKit の音声モデルをローカル実行します。複数の Whisper モデルとデコード設定に対応します。";
 "Transcribe" = "文字起こし";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -344,6 +344,7 @@
 "MLX model is not downloaded. Open Settings > Model to install it." = "MLX 模型尚未下载，请在设置 > 模型中安装。";
 "MLX model is still downloading. Wait for installation to finish and try again." = "MLX 模型仍在下载中，请等待安装完成后再试。";
 "MLX model is unavailable. Open Settings > Model to fix it." = "MLX 模型当前不可用，请在设置 > 模型中修复。";
+"Reason:" = "原因：";
 "Whisper (On-device)" = "Whisper 本地转录";
 "Uses WhisperKit speech models running locally. Supports multiple Whisper models and configurable decoding." = "使用本地 WhisperKit 语音模型，支持多个 Whisper 模型和可配置解码参数。";
 "Transcribe" = "转录";

--- a/VoxtTests/RecordingStartPlannerTests.swift
+++ b/VoxtTests/RecordingStartPlannerTests.swift
@@ -19,7 +19,23 @@ final class RecordingStartPlannerTests: XCTestCase {
             whisperModelState: .notDownloaded
         )
 
-        XCTAssertEqual(decision, .blocked(.mlxModelUnavailable))
+        XCTAssertEqual(decision, .blocked(.mlxModelUnavailable(detail: "broken")))
+    }
+
+    func testMLXAudioErrorMessageIncludesUnderlyingDetail() {
+        let detail = "Model load failed: out of memory"
+        let reason = RecordingStartBlockReason.mlxModelUnavailable(detail: detail)
+
+        XCTAssertTrue(reason.userMessage.contains(detail))
+        XCTAssertTrue(reason.userMessage.contains("MLX model is unavailable"))
+        XCTAssertTrue(reason.logDescription.contains(detail))
+    }
+
+    func testMLXAudioErrorMessageOmitsEmptyDetail() {
+        let reason = RecordingStartBlockReason.mlxModelUnavailable(detail: "   ")
+
+        XCTAssertFalse(reason.userMessage.contains("Reason:"))
+        XCTAssertFalse(reason.logDescription.contains("Reason:"))
     }
 
     func testMLXAudioDownloadedStartsWithMLXAudio() {
@@ -117,7 +133,7 @@ final class RecordingStartPlannerTests: XCTestCase {
             whisperModelState: .error("broken")
         )
 
-        XCTAssertEqual(decision, .blocked(.whisperModelUnavailable))
+        XCTAssertEqual(decision, .blocked(.whisperModelUnavailable(detail: "broken")))
     }
 
     func testWhisperDownloadedStartsWithWhisperEngine() {


### PR DESCRIPTION
## Summary

When a local model (MLX Audio or Whisper) ends up in `.error(message)` state, pressing the record hotkey today shows the user a generic toast like:

> MLX model is unavailable. Open Settings > Model to fix it.

…and writes the same generic line to `VoxtLog`. The actual reason captured in the `.error(message)` payload (e.g. `Model load failed: …`, `Download failed: …`) is discarded, so end users and maintainers can't tell whether the model failed to download, failed to verify weights, ran out of memory, etc., without attaching a debugger or reproducing locally.

This PR plumbs that string through:

- `MLXModelManager.ModelState.error(msg)` / `WhisperKitModelManager.ModelState.error(msg)` → `RecordingStartPlanner.DownloadStatePhase.unavailable(detail:)` → `DownloadableModelAvailability.unavailable(detail:)` → `RecordingStartBlockReason.{mlx,whisper}ModelUnavailable(detail:)`.
- `userMessage` and `logDescription` now append `Reason: <detail>` when a non-empty detail is present (and behave exactly as before when it isn't).
- `Reason:` is added to `en` / `zh-Hans` / `ja` `Localizable.strings`.

No behavior change for `.ready`/`.notDownloaded`/`.downloading` phases.

## Why

I hit this debugging FireRed ASR 2 — after install, the load fails and the only signal upstream of the planner is the generic toast, which makes it impossible to triage the FireRed issue from the user side. With this change the user (and the log) will see e.g. `MLX model is unavailable. Open Settings > Model to fix it. Reason: Model load failed: …` — which immediately points at the real root cause.

## Test plan

- [x] Added regression tests in `RecordingStartPlannerTests.swift`:
  - `testMLXAudioErrorBlocksRecordingStart` now asserts the detail is propagated.
  - `testMLXAudioErrorMessageIncludesUnderlyingDetail` asserts both `userMessage` and `logDescription` include the underlying detail.
  - `testMLXAudioErrorMessageOmitsEmptyDetail` asserts whitespace-only details are dropped (no dangling `Reason:` prefix).
  - Whisper error case updated symmetrically.
- [x] Local `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` on macOS 26.5 / Xcode 26.5 — **765 tests, 0 failures, 33 skipped**, `** TEST SUCCEEDED **`. New tests included in the pass count.
- [ ] Manual: install a model, force `.error` state (e.g. delete the safetensors mid-flight), hit the record hotkey, confirm the overlay reads `… Reason: …`.

Marking Ready for review — local CI is green.
