### PR TITLE
Treat MLX model load cancellation distinctly from load failures

### DIFF
--- a/Voxt/Transcription/MLXModelManager.swift
+++ b/Voxt/Transcription/MLXModelManager.swift
@@ -605,7 +605,11 @@ class MLXModelManager: ObservableObject {
         let loadingTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let model = try await Self.loadSTTModel(for: repo)
-            guard !Task.isCancelled else { return }
+            // Throw on cancel so the outer awaiter can tell cancellation apart from
+            // a real load failure — otherwise we leave `loadedModel` unset and
+            // `readyModel(for:)` throws a misleading error that gets cached as
+            // `.error(…)` and wedges every later record attempt.
+            try Task.checkCancellation()
             guard self.loadingRepo == repo else { return }
             self.loadedModel = model
             self.loadedRepo = repo
@@ -621,6 +625,16 @@ class MLXModelManager: ObservableObject {
             let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
             VoxtLog.info("MLX Audio model load completed. repo=\(repo), elapsedMs=\(elapsedMs)")
             return model
+        } catch is CancellationError {
+            self.loadingTask = nil
+            self.loadingRepo = nil
+            // Reset to whatever the on-disk cache implies (`.downloaded` or
+            // `.notDownloaded`) so the next record attempt can retry instead of
+            // staying wedged behind a stale `.error(…)`.
+            checkExistingModel()
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+            VoxtLog.info("MLX Audio model load cancelled. repo=\(repo), elapsedMs=\(elapsedMs)")
+            throw CancellationError()
         } catch {
             self.loadingTask = nil
             self.loadingRepo = nil


### PR DESCRIPTION
Pairs with #79.

## Summary

`MLXModelManager.loadModel()` ran its inner load task with `guard !Task.isCancelled else { return }`. On cancellation the task completed normally, the outer `try await loadingTask.value` returned, and `readyModel(for:)` then threw *"Model load finished without a ready model instance"* — which the surrounding `catch` cached as `.error("Model load failed: …")`. From that point on, `RecordingStartPlanner` treated the engine as unrecoverable, so every later record attempt showed *"MLX model is unavailable"* until the user deleted and re-installed the model.

This PR splits the two paths:

- Inside the loading task, replace `guard !Task.isCancelled else { return }` with `try Task.checkCancellation()` so cancellation propagates as `CancellationError` through `.value`.
- In the outer awaiter, add `catch is CancellationError`: refresh state from the on-disk cache via `checkExistingModel()` (`.downloaded` if the snapshot is intact, `.notDownloaded` otherwise) and rethrow `CancellationError`. The next record attempt retries cleanly.
- Real load errors fall through to the existing `catch` and stay cached as `.error(…)`, behavior unchanged.

The `guard self.loadingRepo == repo else { return }` is left as-is — that path means another `loadModel` call took ownership of the manager state, which isn't a cancellation of this load.

## Why this matters in practice

Most visible on larger MLX models like `mlx-community/FireRedASR2-AED-mlx` (~4.5 GB safetensors). The load window is long enough that a cancel — from `updateModel` while switching models, from `deleteModel`, or from any other `loadingTask?.cancel()` site — has a real chance of landing mid-flight. The user-visible symptom matches the overlay screenshot in #79: the engine wedges into `.error` after a cancel and never recovers.

## Test plan

- [x] Local `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` on macOS 26.5 / Xcode 26.5 — **763 tests, 0 failures, 33 skipped**, `** TEST SUCCEEDED **`. All existing `MLXModelManagerTests` pass.
- [ ] Manual repro (recommended): install FireRedASR2, trigger a load, cancel mid-load (e.g. switch to another MLX model while the spinner is up), then try to record again. Before this PR: shows *"MLX model is unavailable"* permanently. After this PR: state returns to `.downloaded` and the next record attempt re-loads cleanly.

I did **not** add a new unit test specifically exercising the cancellation path — `loadSTTModel` calls into MLX runtime and isn't currently injectable, so a meaningful cancellation test would require either a refactor to take a loader closure or live network. Happy to do either as a follow-up.

Marking Ready for review — local CI is green.
