### PR TITLE
Fix custom browser permission probe freezes

### DIFF
--- a/Voxt/App/AppDelegate+EnhancementBrowserContext.swift
+++ b/Voxt/App/AppDelegate+EnhancementBrowserContext.swift
@@ -116,12 +116,12 @@ extension AppDelegate {
 
     func scriptsForCustomBrowser(bundleID: String, displayName: String) -> [String] {
         [
-            "tell application id \"\(bundleID)\" to get URL of front document",
-            "tell application id \"\(bundleID)\" to get URL of current tab of front window",
             "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
             "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
-            "tell application \"\(displayName)\" to get URL of front document",
-            "tell application \"\(displayName)\" to get the URL of active tab of front window"
+            "tell application \"\(displayName)\" to get the URL of active tab of front window",
+            "tell application id \"\(bundleID)\" to get URL of front document",
+            "tell application id \"\(bundleID)\" to get URL of current tab of front window",
+            "tell application \"\(displayName)\" to get URL of front document"
         ]
     }
 

--- a/Voxt/Settings/PermissionsSettingsView.swift
+++ b/Voxt/Settings/PermissionsSettingsView.swift
@@ -14,7 +14,7 @@ private func permissionsLocalized(_ key: String) -> String {
 struct PermissionsSettingsView: View {
     let navigationRequest: SettingsNavigationRequest?
 
-    private enum PermissionState: Equatable {
+    private enum PermissionState: Equatable, Sendable {
         case enabled
         case disabled
 
@@ -33,7 +33,7 @@ struct PermissionsSettingsView: View {
         }
     }
 
-    private struct BrowserAutomationTarget: Identifiable, Hashable {
+    private struct BrowserAutomationTarget: Identifiable, Hashable, Sendable {
         let bundleID: String
         let displayName: String
         let scripts: [String]
@@ -42,12 +42,12 @@ struct PermissionsSettingsView: View {
         var id: String { bundleID }
     }
 
-    private struct StoredCustomBrowser: Codable, Hashable {
+    private struct StoredCustomBrowser: Codable, Hashable, Sendable {
         let bundleID: String
         let displayName: String
     }
 
-    private struct ScriptProbeResult {
+    private struct ScriptProbeResult: Sendable {
         let success: Bool
         let permissionDenied: Bool
         let appNotRunning: Bool
@@ -62,6 +62,7 @@ struct PermissionsSettingsView: View {
     @State private var browserAutomationStates: [String: PermissionState] = [:]
     @State private var browserAutomationRequestsInFlight: Set<String> = []
     @State private var browserAutomationTestsInFlight: Set<String> = []
+    @State private var browserAutomationRefreshTask: Task<Void, Never>?
     @State private var browserPickerErrorMessage: String?
     @State private var permissionToastMessage = ""
     @State private var permissionToastDismissTask: Task<Void, Never>?
@@ -180,6 +181,8 @@ struct PermissionsSettingsView: View {
         }
         .onDisappear {
             stopAllMonitoring()
+            browserAutomationRefreshTask?.cancel()
+            browserAutomationRefreshTask = nil
             dismissPermissionToast()
         }
     }
@@ -413,9 +416,11 @@ struct PermissionsSettingsView: View {
 
     private func scriptsForCustomBrowser(bundleID: String, displayName: String) -> [String] {
         [
+            "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
+            "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
+            "tell application \"\(displayName)\" to get the URL of active tab of front window",
             "tell application id \"\(bundleID)\" to get URL of front document",
             "tell application id \"\(bundleID)\" to get URL of current tab of front window",
-            "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
             "tell application \"\(displayName)\" to get URL of front document"
         ]
     }
@@ -506,47 +511,85 @@ struct PermissionsSettingsView: View {
     }
 
     private func refreshBrowserAutomationStates() {
-        for target in browserTargets {
-            browserAutomationStates[target.bundleID] = nonPromptingBrowserAutomationState(target)
+        browserAutomationRefreshTask?.cancel()
+        let targets = browserTargets
+        browserAutomationRefreshTask = Task {
+            let pairs = await Task.detached(priority: .userInitiated) {
+                targets.map { target in
+                    (target.bundleID, Self.nonPromptingBrowserAutomationState(target))
+                }
+            }.value
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                for (bundleID, state) in pairs {
+                    browserAutomationStates[bundleID] = state
+                }
+            }
         }
     }
 
     private func requestBrowserAutomationPermission(_ target: BrowserAutomationTarget) {
         guard !isBrowserAutomationOperationInFlight else { return }
-        if let integrityError = browserTargetIntegrityError(target) {
-            browserAutomationStates[target.bundleID] = .disabled
-            showPermissionToast(integrityError, duration: 5.0)
-            return
-        }
 
         browserAutomationRequestsInFlight.insert(target.bundleID)
 
-        Task { @MainActor in
-            defer { browserAutomationRequestsInFlight.remove(target.bundleID) }
-            let status = automationPermissionStatus(for: target.bundleID, askUserIfNeeded: true)
-            let scriptProbe = isApplicationRunning(bundleID: target.bundleID)
-                ? runAppleScriptCandidates(target.scripts)
-                : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
-            let enabled = scriptProbe.success || (status == noErr && !scriptProbe.permissionDenied)
-            browserAutomationStates[target.bundleID] = enabled ? .enabled : .disabled
-            if enabled {
-                showPermissionToast(AppLocalization.localizedString("Authorization granted."))
-            } else if scriptProbe.appNotRunning {
-                showPermissionToast(AppLocalization.localizedString("Open the browser and try again to complete the authorization check."))
-            } else if scriptProbe.permissionDenied {
-                showPermissionToast(AppLocalization.localizedString("Authorization denied by macOS. Open Automation settings or reset Apple Events permission and try again."), duration: 4.0)
-            } else {
-                showPermissionToast(AppLocalization.localizedString("Authorization not granted."))
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                if let integrityError = Self.browserTargetIntegrityError(target) {
+                    return BrowserAutomationRequestResult(
+                        integrityError: integrityError,
+                        enabled: false,
+                        scriptProbe: nil
+                    )
+                }
+
+                let status = Self.automationPermissionStatus(for: target.bundleID, askUserIfNeeded: true)
+                let scriptProbe = Self.isApplicationRunning(bundleID: target.bundleID)
+                    ? Self.runAppleScriptCandidates(target.scripts)
+                    : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
+                let enabled = scriptProbe.success || (status == noErr && !scriptProbe.permissionDenied)
+                return BrowserAutomationRequestResult(
+                    integrityError: nil,
+                    enabled: enabled,
+                    scriptProbe: scriptProbe
+                )
+            }.value
+
+            await MainActor.run {
+                browserAutomationRequestsInFlight.remove(target.bundleID)
+                if let integrityError = result.integrityError {
+                    browserAutomationStates[target.bundleID] = .disabled
+                    showPermissionToast(integrityError, duration: 5.0)
+                    return
+                }
+
+                guard let scriptProbe = result.scriptProbe else { return }
+                browserAutomationStates[target.bundleID] = result.enabled ? .enabled : .disabled
+                if result.enabled {
+                    showPermissionToast(AppLocalization.localizedString("Authorization granted."))
+                } else if scriptProbe.appNotRunning {
+                    showPermissionToast(AppLocalization.localizedString("Open the browser and try again to complete the authorization check."))
+                } else if scriptProbe.permissionDenied {
+                    showPermissionToast(AppLocalization.localizedString("Authorization denied by macOS. Open Automation settings or reset Apple Events permission and try again."), duration: 4.0)
+                } else {
+                    showPermissionToast(AppLocalization.localizedString("Authorization not granted."))
+                }
             }
         }
     }
 
-    private func nonPromptingBrowserAutomationState(_ target: BrowserAutomationTarget) -> PermissionState {
+    private struct BrowserAutomationRequestResult: Sendable {
+        let integrityError: String?
+        let enabled: Bool
+        let scriptProbe: ScriptProbeResult?
+    }
+
+    private static func nonPromptingBrowserAutomationState(_ target: BrowserAutomationTarget) -> PermissionState {
         let status = automationPermissionStatus(for: target.bundleID, askUserIfNeeded: false)
         return status == noErr ? .enabled : .disabled
     }
 
-    private func automationPermissionStatus(for bundleID: String, askUserIfNeeded: Bool) -> OSStatus {
+    private static func automationPermissionStatus(for bundleID: String, askUserIfNeeded: Bool) -> OSStatus {
         let descriptor = NSAppleEventDescriptor(bundleIdentifier: bundleID)
         guard let aeDesc = descriptor.aeDesc else {
             return OSStatus(errAEEventNotPermitted)
@@ -562,37 +605,55 @@ struct PermissionsSettingsView: View {
 
     private func testBrowserURLRead(_ target: BrowserAutomationTarget) {
         guard !isBrowserAutomationOperationInFlight else { return }
-        if let integrityError = browserTargetIntegrityError(target) {
-            browserAutomationStates[target.bundleID] = .disabled
-            showPermissionToast(integrityError, duration: 5.0)
-            return
-        }
 
         browserAutomationTestsInFlight.insert(target.bundleID)
 
-        Task { @MainActor in
-            defer { browserAutomationTestsInFlight.remove(target.bundleID) }
-            let result = runAppleScriptCandidates(target.scripts)
-            if result.success {
-                browserAutomationStates[target.bundleID] = .enabled
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test succeeded."))
-                return
-            }
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                if let integrityError = Self.browserTargetIntegrityError(target) {
+                    return BrowserAutomationTestResult(integrityError: integrityError, scriptProbe: nil)
+                }
+                return BrowserAutomationTestResult(
+                    integrityError: nil,
+                    scriptProbe: Self.runAppleScriptCandidates(target.scripts)
+                )
+            }.value
 
-            if result.permissionDenied {
-                browserAutomationStates[target.bundleID] = .disabled
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: permission denied."))
-            } else if result.appNotRunning {
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: browser is not running."))
-            } else if let lastErrorCode = result.lastErrorCode {
-                showPermissionToast(AppLocalization.format("Browser URL read test failed (error: %@).", String(lastErrorCode)))
-            } else {
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test failed."))
+            await MainActor.run {
+                browserAutomationTestsInFlight.remove(target.bundleID)
+                if let integrityError = result.integrityError {
+                    browserAutomationStates[target.bundleID] = .disabled
+                    showPermissionToast(integrityError, duration: 5.0)
+                    return
+                }
+
+                guard let scriptProbe = result.scriptProbe else { return }
+                if scriptProbe.success {
+                    browserAutomationStates[target.bundleID] = .enabled
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test succeeded."))
+                    return
+                }
+
+                if scriptProbe.permissionDenied {
+                    browserAutomationStates[target.bundleID] = .disabled
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: permission denied."))
+                } else if scriptProbe.appNotRunning {
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: browser is not running."))
+                } else if let lastErrorCode = scriptProbe.lastErrorCode {
+                    showPermissionToast(AppLocalization.format("Browser URL read test failed (error: %@).", String(lastErrorCode)))
+                } else {
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed."))
+                }
             }
         }
     }
 
-    private func runAppleScriptCandidates(_ scripts: [String]) -> ScriptProbeResult {
+    private struct BrowserAutomationTestResult: Sendable {
+        let integrityError: String?
+        let scriptProbe: ScriptProbeResult?
+    }
+
+    private static func runAppleScriptCandidates(_ scripts: [String]) -> ScriptProbeResult {
         var sawPermissionDenied = false
         var sawAppNotRunning = false
         var lastErrorCode: Int?
@@ -628,12 +689,12 @@ struct PermissionsSettingsView: View {
         )
     }
 
-    private func isApplicationRunning(bundleID: String) -> Bool {
+    private static func isApplicationRunning(bundleID: String) -> Bool {
         NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
             .contains(where: { !$0.isTerminated })
     }
 
-    private func browserTargetIntegrityError(_ target: BrowserAutomationTarget) -> String? {
+    private static func browserTargetIntegrityError(_ target: BrowserAutomationTarget) -> String? {
         guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: target.bundleID) else {
             return AppLocalization.localizedString("Browser app could not be found. Reinstall or add the browser again.")
         }


### PR DESCRIPTION
## Summary

Fixes UI freezes in the Permissions settings when checking browser automation for custom browsers.

## Root Cause

Custom browser URL probing ran synchronously on the main actor. If a browser did not respond to one of the AppleScript URL-read candidates, the script could wait until its timeout and block the SwiftUI settings UI.

The custom browser script order also tried Safari-style `front document` reads before Chrome/Arc-style active-tab reads, which can be slow or unsupported for Chromium-like custom browsers.

## Changes

- Run browser automation state refresh, permission requests, signature checks, and URL-read tests off the main actor.
- Update SwiftUI state and toast messages back on the main actor after probes complete.
- Reorder custom browser AppleScript candidates to try active-tab reads first, then fall back to Safari-style document reads.
- Keep the fix generic without adding browser-specific hardcoded entries.

## Validation

- Verified `git diff --check`.
- Manually confirmed the problematic custom-browser timeout path no longer needs to block the main thread.
- Full `xcodebuild` validation was not run because this machine only has Command Line Tools selected, not full Xcode.
