### PR TITLE
Fix custom browser timeout blocking permissions UI

### DIFF
--- a/Voxt/App/AppDelegate+EnhancementBrowserContext.swift
+++ b/Voxt/App/AppDelegate+EnhancementBrowserContext.swift
@@ -115,7 +115,7 @@ extension AppDelegate {
     }
 
     func scriptsForCustomBrowser(bundleID: String, displayName: String) -> [String] {
-        BrowserAutomationScriptBuilder.customBrowserScripts(
+        BrowserAutomationScriptBuilder.customBrowserRuntimeScripts(
             bundleID: bundleID,
             displayName: displayName
         )

--- a/Voxt/App/AppDelegate+EnhancementBrowserContext.swift
+++ b/Voxt/App/AppDelegate+EnhancementBrowserContext.swift
@@ -115,14 +115,10 @@ extension AppDelegate {
     }
 
     func scriptsForCustomBrowser(bundleID: String, displayName: String) -> [String] {
-        [
-            "tell application id \"\(bundleID)\" to get URL of front document",
-            "tell application id \"\(bundleID)\" to get URL of current tab of front window",
-            "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
-            "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
-            "tell application \"\(displayName)\" to get URL of front document",
-            "tell application \"\(displayName)\" to get the URL of active tab of front window"
-        ]
+        BrowserAutomationScriptBuilder.customBrowserScripts(
+            bundleID: bundleID,
+            displayName: displayName
+        )
     }
 
     func runAppleScriptCandidates(_ sources: [String], providerName: String) -> String? {

--- a/Voxt/Settings/PermissionsSettingsView.swift
+++ b/Voxt/Settings/PermissionsSettingsView.swift
@@ -14,7 +14,7 @@ private func permissionsLocalized(_ key: String) -> String {
 struct PermissionsSettingsView: View {
     let navigationRequest: SettingsNavigationRequest?
 
-    private enum PermissionState: Equatable {
+    private enum PermissionState: Equatable, Sendable {
         case enabled
         case disabled
 
@@ -33,7 +33,7 @@ struct PermissionsSettingsView: View {
         }
     }
 
-    private struct BrowserAutomationTarget: Identifiable, Hashable {
+    private struct BrowserAutomationTarget: Identifiable, Hashable, Sendable {
         let bundleID: String
         let displayName: String
         let scripts: [String]
@@ -42,16 +42,22 @@ struct PermissionsSettingsView: View {
         var id: String { bundleID }
     }
 
-    private struct StoredCustomBrowser: Codable, Hashable {
+    private struct StoredCustomBrowser: Codable, Hashable, Sendable {
         let bundleID: String
         let displayName: String
     }
 
-    private struct ScriptProbeResult {
+    private struct ScriptProbeResult: Sendable {
         let success: Bool
         let permissionDenied: Bool
         let appNotRunning: Bool
         let lastErrorCode: Int?
+    }
+
+    private struct BrowserTargetPreflight: Sendable {
+        let appPath: String?
+        let appNotFoundError: String?
+        let isRunning: Bool
     }
 
     @State private var states: [SettingsPermissionKind: PermissionState] = [:]
@@ -62,6 +68,9 @@ struct PermissionsSettingsView: View {
     @State private var browserAutomationStates: [String: PermissionState] = [:]
     @State private var browserAutomationRequestsInFlight: Set<String> = []
     @State private var browserAutomationTestsInFlight: Set<String> = []
+    @State private var browserAutomationRefreshTask: Task<Void, Never>?
+    @State private var browserAutomationRequestTasks: [String: Task<Void, Never>] = [:]
+    @State private var browserAutomationTestTasks: [String: Task<Void, Never>] = [:]
     @State private var browserPickerErrorMessage: String?
     @State private var permissionToastMessage = ""
     @State private var permissionToastDismissTask: Task<Void, Never>?
@@ -180,6 +189,7 @@ struct PermissionsSettingsView: View {
         }
         .onDisappear {
             stopAllMonitoring()
+            cancelBrowserAutomationTasks()
             dismissPermissionToast()
         }
     }
@@ -412,12 +422,10 @@ struct PermissionsSettingsView: View {
     }
 
     private func scriptsForCustomBrowser(bundleID: String, displayName: String) -> [String] {
-        [
-            "tell application id \"\(bundleID)\" to get URL of front document",
-            "tell application id \"\(bundleID)\" to get URL of current tab of front window",
-            "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
-            "tell application \"\(displayName)\" to get URL of front document"
-        ]
+        BrowserAutomationScriptBuilder.customBrowserScripts(
+            bundleID: bundleID,
+            displayName: displayName
+        )
     }
 
     private func loadBrowserTargets() {
@@ -506,47 +514,90 @@ struct PermissionsSettingsView: View {
     }
 
     private func refreshBrowserAutomationStates() {
-        for target in browserTargets {
-            browserAutomationStates[target.bundleID] = nonPromptingBrowserAutomationState(target)
+        browserAutomationRefreshTask?.cancel()
+        let targets = browserTargets
+        browserAutomationRefreshTask = Task {
+            let pairs = await Task.detached(priority: .userInitiated) {
+                targets.map { target in
+                    (target.bundleID, Self.nonPromptingBrowserAutomationState(target))
+                }
+            }.value
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                for (bundleID, state) in pairs {
+                    browserAutomationStates[bundleID] = state
+                }
+            }
         }
     }
 
     private func requestBrowserAutomationPermission(_ target: BrowserAutomationTarget) {
         guard !isBrowserAutomationOperationInFlight else { return }
-        if let integrityError = browserTargetIntegrityError(target) {
-            browserAutomationStates[target.bundleID] = .disabled
-            showPermissionToast(integrityError, duration: 5.0)
-            return
-        }
 
         browserAutomationRequestsInFlight.insert(target.bundleID)
 
-        Task { @MainActor in
-            defer { browserAutomationRequestsInFlight.remove(target.bundleID) }
-            let status = automationPermissionStatus(for: target.bundleID, askUserIfNeeded: true)
-            let scriptProbe = isApplicationRunning(bundleID: target.bundleID)
-                ? runAppleScriptCandidates(target.scripts)
-                : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
-            let enabled = scriptProbe.success || (status == noErr && !scriptProbe.permissionDenied)
-            browserAutomationStates[target.bundleID] = enabled ? .enabled : .disabled
-            if enabled {
-                showPermissionToast(AppLocalization.localizedString("Authorization granted."))
-            } else if scriptProbe.appNotRunning {
-                showPermissionToast(AppLocalization.localizedString("Open the browser and try again to complete the authorization check."))
-            } else if scriptProbe.permissionDenied {
-                showPermissionToast(AppLocalization.localizedString("Authorization denied by macOS. Open Automation settings or reset Apple Events permission and try again."), duration: 4.0)
-            } else {
-                showPermissionToast(AppLocalization.localizedString("Authorization not granted."))
+        let preflight = browserTargetPreflight(target)
+        let task = Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                if let integrityError = preflight.appNotFoundError
+                    ?? Self.browserTargetSignatureIntegrityError(appPath: preflight.appPath) {
+                    return BrowserAutomationRequestResult(
+                        integrityError: integrityError,
+                        enabled: false,
+                        scriptProbe: nil
+                    )
+                }
+
+                let status = Self.automationPermissionStatus(for: target.bundleID, askUserIfNeeded: true)
+                let scriptProbe = preflight.isRunning
+                    ? Self.runAppleScriptCandidates(target.scripts)
+                    : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
+                let enabled = scriptProbe.success || (status == noErr && !scriptProbe.permissionDenied)
+                return BrowserAutomationRequestResult(
+                    integrityError: nil,
+                    enabled: enabled,
+                    scriptProbe: scriptProbe
+                )
+            }.value
+
+            await MainActor.run {
+                guard !Task.isCancelled else { return }
+                browserAutomationRequestTasks.removeValue(forKey: target.bundleID)
+                browserAutomationRequestsInFlight.remove(target.bundleID)
+                if let integrityError = result.integrityError {
+                    browserAutomationStates[target.bundleID] = .disabled
+                    showPermissionToast(integrityError, duration: 5.0)
+                    return
+                }
+
+                guard let scriptProbe = result.scriptProbe else { return }
+                browserAutomationStates[target.bundleID] = result.enabled ? .enabled : .disabled
+                if result.enabled {
+                    showPermissionToast(AppLocalization.localizedString("Authorization granted."))
+                } else if scriptProbe.appNotRunning {
+                    showPermissionToast(AppLocalization.localizedString("Open the browser and try again to complete the authorization check."))
+                } else if scriptProbe.permissionDenied {
+                    showPermissionToast(AppLocalization.localizedString("Authorization denied by macOS. Open Automation settings or reset Apple Events permission and try again."), duration: 4.0)
+                } else {
+                    showPermissionToast(AppLocalization.localizedString("Authorization not granted."))
+                }
             }
         }
+        browserAutomationRequestTasks[target.bundleID] = task
     }
 
-    private func nonPromptingBrowserAutomationState(_ target: BrowserAutomationTarget) -> PermissionState {
+    private struct BrowserAutomationRequestResult: Sendable {
+        let integrityError: String?
+        let enabled: Bool
+        let scriptProbe: ScriptProbeResult?
+    }
+
+    private static func nonPromptingBrowserAutomationState(_ target: BrowserAutomationTarget) -> PermissionState {
         let status = automationPermissionStatus(for: target.bundleID, askUserIfNeeded: false)
         return status == noErr ? .enabled : .disabled
     }
 
-    private func automationPermissionStatus(for bundleID: String, askUserIfNeeded: Bool) -> OSStatus {
+    private static func automationPermissionStatus(for bundleID: String, askUserIfNeeded: Bool) -> OSStatus {
         let descriptor = NSAppleEventDescriptor(bundleIdentifier: bundleID)
         guard let aeDesc = descriptor.aeDesc else {
             return OSStatus(errAEEventNotPermitted)
@@ -562,37 +613,62 @@ struct PermissionsSettingsView: View {
 
     private func testBrowserURLRead(_ target: BrowserAutomationTarget) {
         guard !isBrowserAutomationOperationInFlight else { return }
-        if let integrityError = browserTargetIntegrityError(target) {
-            browserAutomationStates[target.bundleID] = .disabled
-            showPermissionToast(integrityError, duration: 5.0)
-            return
-        }
 
         browserAutomationTestsInFlight.insert(target.bundleID)
 
-        Task { @MainActor in
-            defer { browserAutomationTestsInFlight.remove(target.bundleID) }
-            let result = runAppleScriptCandidates(target.scripts)
-            if result.success {
-                browserAutomationStates[target.bundleID] = .enabled
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test succeeded."))
-                return
-            }
+        let preflight = browserTargetPreflight(target)
+        let task = Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                if let integrityError = preflight.appNotFoundError
+                    ?? Self.browserTargetSignatureIntegrityError(appPath: preflight.appPath) {
+                    return BrowserAutomationTestResult(integrityError: integrityError, scriptProbe: nil)
+                }
+                return BrowserAutomationTestResult(
+                    integrityError: nil,
+                    scriptProbe: preflight.isRunning
+                        ? Self.runAppleScriptCandidates(target.scripts)
+                        : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
+                )
+            }.value
 
-            if result.permissionDenied {
-                browserAutomationStates[target.bundleID] = .disabled
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: permission denied."))
-            } else if result.appNotRunning {
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: browser is not running."))
-            } else if let lastErrorCode = result.lastErrorCode {
-                showPermissionToast(AppLocalization.format("Browser URL read test failed (error: %@).", String(lastErrorCode)))
-            } else {
-                showPermissionToast(AppLocalization.localizedString("Browser URL read test failed."))
+            await MainActor.run {
+                guard !Task.isCancelled else { return }
+                browserAutomationTestTasks.removeValue(forKey: target.bundleID)
+                browserAutomationTestsInFlight.remove(target.bundleID)
+                if let integrityError = result.integrityError {
+                    browserAutomationStates[target.bundleID] = .disabled
+                    showPermissionToast(integrityError, duration: 5.0)
+                    return
+                }
+
+                guard let scriptProbe = result.scriptProbe else { return }
+                if scriptProbe.success {
+                    browserAutomationStates[target.bundleID] = .enabled
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test succeeded."))
+                    return
+                }
+
+                if scriptProbe.permissionDenied {
+                    browserAutomationStates[target.bundleID] = .disabled
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: permission denied."))
+                } else if scriptProbe.appNotRunning {
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: browser is not running."))
+                } else if let lastErrorCode = scriptProbe.lastErrorCode {
+                    showPermissionToast(AppLocalization.format("Browser URL read test failed (error: %@).", String(lastErrorCode)))
+                } else {
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed."))
+                }
             }
         }
+        browserAutomationTestTasks[target.bundleID] = task
     }
 
-    private func runAppleScriptCandidates(_ scripts: [String]) -> ScriptProbeResult {
+    private struct BrowserAutomationTestResult: Sendable {
+        let integrityError: String?
+        let scriptProbe: ScriptProbeResult?
+    }
+
+    private static func runAppleScriptCandidates(_ scripts: [String]) -> ScriptProbeResult {
         var sawPermissionDenied = false
         var sawAppNotRunning = false
         var lastErrorCode: Int?
@@ -628,17 +704,27 @@ struct PermissionsSettingsView: View {
         )
     }
 
+    private func browserTargetPreflight(_ target: BrowserAutomationTarget) -> BrowserTargetPreflight {
+        let appPath = NSWorkspace.shared.urlForApplication(withBundleIdentifier: target.bundleID)?.path
+        BrowserTargetPreflight(
+            appPath: appPath,
+            appNotFoundError: appPath == nil
+                ? AppLocalization.localizedString("Browser app could not be found. Reinstall or add the browser again.")
+                : nil,
+            isRunning: isApplicationRunning(bundleID: target.bundleID)
+        )
+    }
+
     private func isApplicationRunning(bundleID: String) -> Bool {
         NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
             .contains(where: { !$0.isTerminated })
     }
 
-    private func browserTargetIntegrityError(_ target: BrowserAutomationTarget) -> String? {
-        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: target.bundleID) else {
-            return AppLocalization.localizedString("Browser app could not be found. Reinstall or add the browser again.")
-        }
+    private static func browserTargetSignatureIntegrityError(appPath: String?) -> String? {
+        guard let appPath else { return nil }
 
         var staticCode: SecStaticCode?
+        let appURL = URL(fileURLWithPath: appPath)
         let createStatus = SecStaticCodeCreateWithPath(appURL as CFURL, [], &staticCode)
         guard createStatus == errSecSuccess, let staticCode else {
             return AppLocalization.localizedString("Browser app signature could not be verified. Reinstall or update the browser, then request authorization again.")
@@ -650,6 +736,23 @@ struct PermissionsSettingsView: View {
         }
 
         return nil
+    }
+
+    private func cancelBrowserAutomationTasks() {
+        browserAutomationRefreshTask?.cancel()
+        browserAutomationRefreshTask = nil
+
+        for task in browserAutomationRequestTasks.values {
+            task.cancel()
+        }
+        browserAutomationRequestTasks.removeAll()
+        browserAutomationRequestsInFlight.removeAll()
+
+        for task in browserAutomationTestTasks.values {
+            task.cancel()
+        }
+        browserAutomationTestTasks.removeAll()
+        browserAutomationTestsInFlight.removeAll()
     }
 
     private func openSettings(for kind: SettingsPermissionKind) {

--- a/Voxt/Settings/PermissionsSettingsView.swift
+++ b/Voxt/Settings/PermissionsSettingsView.swift
@@ -706,7 +706,7 @@ struct PermissionsSettingsView: View {
 
     private func browserTargetPreflight(_ target: BrowserAutomationTarget) -> BrowserTargetPreflight {
         let appPath = NSWorkspace.shared.urlForApplication(withBundleIdentifier: target.bundleID)?.path
-        BrowserTargetPreflight(
+        return BrowserTargetPreflight(
             appPath: appPath,
             appNotFoundError: appPath == nil
                 ? AppLocalization.localizedString("Browser app could not be found. Reinstall or add the browser again.")

--- a/Voxt/Settings/PermissionsSettingsView.swift
+++ b/Voxt/Settings/PermissionsSettingsView.swift
@@ -60,6 +60,10 @@ struct PermissionsSettingsView: View {
         let isRunning: Bool
     }
 
+    // Remember browsers that have already granted Automation permission so the
+    // Settings UI does not fall back to "disabled" just because the browser is
+    // currently closed. We still prefer a live re-check whenever macOS can give
+    // us a definitive answer.
     private static let knownAuthorizedBrowserBundleIDsStorageKey = "voxt.permissions.knownAuthorizedBrowserBundleIDs"
 
     @State private var states: [SettingsPermissionKind: PermissionState] = [:]
@@ -544,6 +548,10 @@ struct PermissionsSettingsView: View {
         browserAutomationRefreshTask?.cancel()
         let targets = targets ?? browserTargets
         let knownAuthorizedBrowserBundleIDs = loadKnownAuthorizedBrowserBundleIDs()
+        // Browser Automation checks can block on AppleScript / Apple Events, so
+        // refresh them off the main actor. When the user is actively pressing
+        // Request or Test, skip that row here so an older refresh result does
+        // not overwrite the newer user-triggered state.
         browserAutomationRefreshTask = Task.detached(priority: .userInitiated) {
             for target in targets {
                 guard !Task.isCancelled else { return }
@@ -585,6 +593,12 @@ struct PermissionsSettingsView: View {
                     failureMessage: nil
                 )
             } else {
+                // Request and Test have different goals:
+                // - Request should confirm / trigger Automation permission.
+                // - Test should verify that URL reading works right now.
+                // If the browser is already running and a script succeeds, we
+                // can treat that as permission already working without showing
+                // an extra macOS prompt.
                 let initialProbe = preflight.isRunning
                     ? Self.runAppleScriptCandidates(target.scripts)
                     : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
@@ -674,6 +688,10 @@ struct PermissionsSettingsView: View {
         knownAuthorizedBrowserBundleIDs: Set<String>
     ) -> PermissionState {
         if target.isCustom {
+            // Custom browsers are less consistent than Safari / Chrome: some do
+            // not answer the low-level permission API reliably, especially when
+            // the app is not running. For them we combine three signals:
+            // installation, running state, and remembered authorization.
             let isRememberedAuthorized = knownAuthorizedBrowserBundleIDs.contains(target.bundleID)
             guard isApplicationInstalled(bundleID: target.bundleID) else {
                 return .disabled
@@ -774,6 +792,10 @@ struct PermissionsSettingsView: View {
                 } else if scriptProbe.appNotRunning {
                     showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: browser is not running."))
                 } else if target.isCustom, scriptProbe.lastErrorCode == -1728 {
+                    // For several Chromium-like custom browsers, -1728 often
+                    // means "the current page has no readable URL yet" (for
+                    // example a New Tab / welcome page), not that the browser
+                    // is permanently unsupported.
                     showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: open a webpage in the browser and try again."))
                 } else if let lastErrorCode = scriptProbe.lastErrorCode {
                     showPermissionToast(AppLocalization.format("Browser URL read test failed (error: %@).", String(lastErrorCode)))

--- a/Voxt/Settings/PermissionsSettingsView.swift
+++ b/Voxt/Settings/PermissionsSettingsView.swift
@@ -60,6 +60,8 @@ struct PermissionsSettingsView: View {
         let isRunning: Bool
     }
 
+    private static let knownAuthorizedBrowserBundleIDsStorageKey = "voxt.permissions.knownAuthorizedBrowserBundleIDs"
+
     @State private var states: [SettingsPermissionKind: PermissionState] = [:]
     @State private var monitoringKinds: Set<SettingsPermissionKind> = []
     @State private var monitorTasks: [SettingsPermissionKind: Task<Void, Never>] = [:]
@@ -80,6 +82,7 @@ struct PermissionsSettingsView: View {
     @AppStorage(AppPreferenceKey.muteSystemAudioWhileRecording) private var muteSystemAudioWhileRecording = false
     @AppStorage(AppPreferenceKey.transcriptionEngine) private var transcriptionEngineRaw = TranscriptionEngine.mlxAudio.rawValue
     @AppStorage(AppPreferenceKey.featureSettings) private var featureSettingsRaw = ""
+    @AppStorage(Self.knownAuthorizedBrowserBundleIDsStorageKey) private var knownAuthorizedBrowserBundleIDsJSON = "[]"
 
     private var transcriptionEngine: TranscriptionEngine {
         TranscriptionEngine(rawValue: transcriptionEngineRaw) ?? .mlxAudio
@@ -165,8 +168,8 @@ struct PermissionsSettingsView: View {
         .onAppear {
             _ = AccessibilityPermissionManager.request(prompt: false)
             refreshStates()
-            loadBrowserTargets()
-            refreshBrowserAutomationStates()
+            let targets = loadBrowserTargets()
+            refreshBrowserAutomationStates(targets: targets)
         }
         .overlay(alignment: .top) {
             if !permissionToastMessage.isEmpty {
@@ -422,13 +425,14 @@ struct PermissionsSettingsView: View {
     }
 
     private func scriptsForCustomBrowser(bundleID: String, displayName: String) -> [String] {
-        BrowserAutomationScriptBuilder.customBrowserScripts(
+        BrowserAutomationScriptBuilder.customBrowserPermissionProbeScripts(
             bundleID: bundleID,
             displayName: displayName
         )
     }
 
-    private func loadBrowserTargets() {
+    @discardableResult
+    private func loadBrowserTargets() -> [BrowserAutomationTarget] {
         let builtIns = builtInBrowserTargets()
         let customBrowsers = loadStoredCustomBrowsers().map {
             BrowserAutomationTarget(
@@ -448,6 +452,7 @@ struct PermissionsSettingsView: View {
         }
 
         browserTargets = merged
+        return merged
     }
 
     private func loadStoredCustomBrowsers() -> [StoredCustomBrowser] {
@@ -464,6 +469,28 @@ struct PermissionsSettingsView: View {
             return
         }
         appBranchCustomBrowsersJSON = json
+    }
+
+    private func loadKnownAuthorizedBrowserBundleIDs() -> Set<String> {
+        guard let data = knownAuthorizedBrowserBundleIDsJSON.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return Set(decoded)
+    }
+
+    private func setKnownAuthorizedBrowser(_ bundleID: String, isAuthorized: Bool) {
+        var knownAuthorizedBrowserBundleIDs = loadKnownAuthorizedBrowserBundleIDs()
+        if isAuthorized {
+            knownAuthorizedBrowserBundleIDs.insert(bundleID)
+        } else {
+            knownAuthorizedBrowserBundleIDs.remove(bundleID)
+        }
+        guard let data = try? JSONEncoder().encode(Array(knownAuthorizedBrowserBundleIDs).sorted()),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        knownAuthorizedBrowserBundleIDsJSON = json
     }
 
     private func chooseBrowserApplication() {
@@ -499,8 +526,8 @@ struct PermissionsSettingsView: View {
         custom.append(StoredCustomBrowser(bundleID: bundleID, displayName: displayName))
         saveStoredCustomBrowsers(custom)
         browserPickerErrorMessage = nil
-        loadBrowserTargets()
-        refreshBrowserAutomationStates()
+        let targets = loadBrowserTargets()
+        refreshBrowserAutomationStates(targets: targets)
     }
 
     private func removeCustomBrowser(_ target: BrowserAutomationTarget) {
@@ -509,57 +536,94 @@ struct PermissionsSettingsView: View {
         custom.removeAll { $0.bundleID == target.bundleID }
         saveStoredCustomBrowsers(custom)
         browserAutomationStates.removeValue(forKey: target.bundleID)
-        loadBrowserTargets()
-        refreshBrowserAutomationStates()
+        let targets = loadBrowserTargets()
+        refreshBrowserAutomationStates(targets: targets)
     }
 
-    private func refreshBrowserAutomationStates() {
+    private func refreshBrowserAutomationStates(targets: [BrowserAutomationTarget]? = nil) {
         browserAutomationRefreshTask?.cancel()
-        let targets = browserTargets
-        browserAutomationRefreshTask = Task {
-            let pairs = await Task.detached(priority: .userInitiated) {
-                targets.map { target in
-                    (target.bundleID, Self.nonPromptingBrowserAutomationState(target))
+        let targets = targets ?? browserTargets
+        let knownAuthorizedBrowserBundleIDs = loadKnownAuthorizedBrowserBundleIDs()
+        browserAutomationRefreshTask = Task.detached(priority: .userInitiated) {
+            for target in targets {
+                guard !Task.isCancelled else { return }
+                let state = Self.nonPromptingBrowserAutomationState(
+                    target,
+                    knownAuthorizedBrowserBundleIDs: knownAuthorizedBrowserBundleIDs
+                )
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    guard !Task.isCancelled else { return }
+                    guard !browserAutomationRequestsInFlight.contains(target.bundleID),
+                          !browserAutomationTestsInFlight.contains(target.bundleID) else {
+                        return
+                    }
+                    browserAutomationStates[target.bundleID] = state
                 }
-            }.value
-            guard !Task.isCancelled else { return }
-            await MainActor.run {
-                for (bundleID, state) in pairs {
-                    browserAutomationStates[bundleID] = state
-                }
-            }
+           }
         }
     }
 
     private func requestBrowserAutomationPermission(_ target: BrowserAutomationTarget) {
         guard !isBrowserAutomationOperationInFlight else { return }
+        browserAutomationRefreshTask?.cancel()
+        browserAutomationRefreshTask = nil
 
         browserAutomationRequestsInFlight.insert(target.bundleID)
 
         let preflight = browserTargetPreflight(target)
-        let task = Task {
-            let result = await Task.detached(priority: .userInitiated) {
-                if let integrityError = preflight.appNotFoundError
-                    ?? Self.browserTargetSignatureIntegrityError(appPath: preflight.appPath) {
-                    return BrowserAutomationRequestResult(
-                        integrityError: integrityError,
-                        enabled: false,
-                        scriptProbe: nil
-                    )
-                }
-
-                let status = Self.automationPermissionStatus(for: target.bundleID, askUserIfNeeded: true)
-                let scriptProbe = preflight.isRunning
+        let task = Task.detached(priority: .userInitiated) {
+            guard !Task.isCancelled else { return }
+            let result: BrowserAutomationRequestResult
+            if let integrityError = preflight.appNotFoundError
+                ?? Self.browserTargetSignatureIntegrityError(appPath: preflight.appPath) {
+                result = BrowserAutomationRequestResult(
+                    integrityError: integrityError,
+                    enabled: false,
+                    permissionGranted: false,
+                    scriptProbe: nil,
+                    failureMessage: nil
+                )
+            } else {
+                let initialProbe = preflight.isRunning
                     ? Self.runAppleScriptCandidates(target.scripts)
                     : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
-                let enabled = scriptProbe.success || (status == noErr && !scriptProbe.permissionDenied)
-                return BrowserAutomationRequestResult(
-                    integrityError: nil,
-                    enabled: enabled,
-                    scriptProbe: scriptProbe
-                )
-            }.value
+                if initialProbe.success {
+                    result = BrowserAutomationRequestResult(
+                        integrityError: nil,
+                        enabled: true,
+                        permissionGranted: true,
+                        scriptProbe: initialProbe,
+                        failureMessage: nil
+                    )
+                } else if initialProbe.appNotRunning {
+                    result = BrowserAutomationRequestResult(
+                        integrityError: nil,
+                        enabled: false,
+                        permissionGranted: false,
+                        scriptProbe: initialProbe,
+                        failureMessage: nil
+                    )
+                } else {
+                    let permissionProbe = Self.runAutomationPermissionProbe(bundleID: target.bundleID)
+                    guard !Task.isCancelled else { return }
+                    let scriptProbe = Self.runAppleScriptCandidates(target.scripts)
+                    let permissionGranted = permissionProbe.success
+                    result = BrowserAutomationRequestResult(
+                        integrityError: nil,
+                        enabled: permissionGranted || scriptProbe.success,
+                        permissionGranted: permissionGranted,
+                        scriptProbe: scriptProbe,
+                        failureMessage: permissionGranted
+                            ? nil
+                            : permissionProbe.permissionDenied
+                                ? nil
+                            : AppLocalization.localizedString("This app does not support browser URL reading.")
+                    )
+                }
+            }
 
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard !Task.isCancelled else { return }
                 browserAutomationRequestTasks.removeValue(forKey: target.bundleID)
@@ -573,14 +637,25 @@ struct PermissionsSettingsView: View {
                 guard let scriptProbe = result.scriptProbe else { return }
                 browserAutomationStates[target.bundleID] = result.enabled ? .enabled : .disabled
                 if result.enabled {
-                    showPermissionToast(AppLocalization.localizedString("Authorization granted."))
+                    setKnownAuthorizedBrowser(target.bundleID, isAuthorized: true)
+                    if result.permissionGranted && scriptProbe.appNotRunning {
+                        showPermissionToast(AppLocalization.localizedString("Authorization granted. Open the browser and click Test if you want to verify URL reading."))
+                    } else if result.permissionGranted && !scriptProbe.success {
+                        showPermissionToast(AppLocalization.localizedString("Authorization granted. This app may not support browser URL reading. Click Test if you want to verify."))
+                    } else {
+                        showPermissionToast(AppLocalization.localizedString("Authorization granted."))
+                    }
                 } else if scriptProbe.appNotRunning {
                     showPermissionToast(AppLocalization.localizedString("Open the browser and try again to complete the authorization check."))
                 } else if scriptProbe.permissionDenied {
+                    setKnownAuthorizedBrowser(target.bundleID, isAuthorized: false)
                     showPermissionToast(AppLocalization.localizedString("Authorization denied by macOS. Open Automation settings or reset Apple Events permission and try again."), duration: 4.0)
+                } else if let failureMessage = result.failureMessage {
+                    showPermissionToast(failureMessage, duration: 4.0)
                 } else {
                     showPermissionToast(AppLocalization.localizedString("Authorization not granted."))
                 }
+                refreshBrowserAutomationStates()
             }
         }
         browserAutomationRequestTasks[target.bundleID] = task
@@ -589,15 +664,54 @@ struct PermissionsSettingsView: View {
     private struct BrowserAutomationRequestResult: Sendable {
         let integrityError: String?
         let enabled: Bool
+        let permissionGranted: Bool
         let scriptProbe: ScriptProbeResult?
+        let failureMessage: String?
     }
 
-    private static func nonPromptingBrowserAutomationState(_ target: BrowserAutomationTarget) -> PermissionState {
+    nonisolated private static func nonPromptingBrowserAutomationState(
+        _ target: BrowserAutomationTarget,
+        knownAuthorizedBrowserBundleIDs: Set<String>
+    ) -> PermissionState {
+        if target.isCustom {
+            let isRememberedAuthorized = knownAuthorizedBrowserBundleIDs.contains(target.bundleID)
+            guard isApplicationInstalled(bundleID: target.bundleID) else {
+                return .disabled
+            }
+            guard isApplicationRunning(bundleID: target.bundleID) else {
+                return isRememberedAuthorized ? .enabled : .disabled
+            }
+
+            let permissionProbe = runAutomationPermissionProbe(bundleID: target.bundleID)
+            if permissionProbe.success {
+                return .enabled
+            }
+            if permissionProbe.permissionDenied {
+                return .disabled
+            }
+            return isRememberedAuthorized ? .enabled : .disabled
+        }
+
         let status = automationPermissionStatus(for: target.bundleID, askUserIfNeeded: false)
-        return status == noErr ? .enabled : .disabled
+        if status == noErr {
+            return .enabled
+        }
+        if status == errAEEventNotPermitted || status == errAEPrivilegeError {
+            return .disabled
+        }
+        if knownAuthorizedBrowserBundleIDs.contains(target.bundleID) {
+            return .enabled
+        }
+        return .disabled
     }
 
-    private static func automationPermissionStatus(for bundleID: String, askUserIfNeeded: Bool) -> OSStatus {
+    nonisolated private static func runAutomationPermissionProbe(bundleID: String) -> ScriptProbeResult {
+        runAppleScriptCandidates([
+            "tell application id \"\(bundleID)\" to get name"
+        ])
+    }
+
+    nonisolated private static func automationPermissionStatus(for bundleID: String, askUserIfNeeded: Bool) -> OSStatus {
         let descriptor = NSAppleEventDescriptor(bundleIdentifier: bundleID)
         guard let aeDesc = descriptor.aeDesc else {
             return OSStatus(errAEEventNotPermitted)
@@ -613,24 +727,28 @@ struct PermissionsSettingsView: View {
 
     private func testBrowserURLRead(_ target: BrowserAutomationTarget) {
         guard !isBrowserAutomationOperationInFlight else { return }
+        browserAutomationRefreshTask?.cancel()
+        browserAutomationRefreshTask = nil
 
         browserAutomationTestsInFlight.insert(target.bundleID)
 
         let preflight = browserTargetPreflight(target)
-        let task = Task {
-            let result = await Task.detached(priority: .userInitiated) {
-                if let integrityError = preflight.appNotFoundError
-                    ?? Self.browserTargetSignatureIntegrityError(appPath: preflight.appPath) {
-                    return BrowserAutomationTestResult(integrityError: integrityError, scriptProbe: nil)
-                }
-                return BrowserAutomationTestResult(
+        let task = Task.detached(priority: .userInitiated) {
+            guard !Task.isCancelled else { return }
+            let result: BrowserAutomationTestResult
+            if let integrityError = preflight.appNotFoundError
+                ?? Self.browserTargetSignatureIntegrityError(appPath: preflight.appPath) {
+                result = BrowserAutomationTestResult(integrityError: integrityError, scriptProbe: nil)
+            } else {
+                result = BrowserAutomationTestResult(
                     integrityError: nil,
                     scriptProbe: preflight.isRunning
                         ? Self.runAppleScriptCandidates(target.scripts)
                         : ScriptProbeResult(success: false, permissionDenied: false, appNotRunning: true, lastErrorCode: nil)
                 )
-            }.value
+            }
 
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard !Task.isCancelled else { return }
                 browserAutomationTestTasks.removeValue(forKey: target.bundleID)
@@ -644,20 +762,25 @@ struct PermissionsSettingsView: View {
                 guard let scriptProbe = result.scriptProbe else { return }
                 if scriptProbe.success {
                     browserAutomationStates[target.bundleID] = .enabled
+                    setKnownAuthorizedBrowser(target.bundleID, isAuthorized: true)
                     showPermissionToast(AppLocalization.localizedString("Browser URL read test succeeded."))
                     return
                 }
 
                 if scriptProbe.permissionDenied {
                     browserAutomationStates[target.bundleID] = .disabled
+                    setKnownAuthorizedBrowser(target.bundleID, isAuthorized: false)
                     showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: permission denied."))
                 } else if scriptProbe.appNotRunning {
                     showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: browser is not running."))
+                } else if target.isCustom, scriptProbe.lastErrorCode == -1728 {
+                    showPermissionToast(AppLocalization.localizedString("Browser URL read test failed: open a webpage in the browser and try again."))
                 } else if let lastErrorCode = scriptProbe.lastErrorCode {
                     showPermissionToast(AppLocalization.format("Browser URL read test failed (error: %@).", String(lastErrorCode)))
                 } else {
                     showPermissionToast(AppLocalization.localizedString("Browser URL read test failed."))
                 }
+                refreshBrowserAutomationStates()
             }
         }
         browserAutomationTestTasks[target.bundleID] = task
@@ -668,12 +791,20 @@ struct PermissionsSettingsView: View {
         let scriptProbe: ScriptProbeResult?
     }
 
-    private static func runAppleScriptCandidates(_ scripts: [String]) -> ScriptProbeResult {
+    nonisolated private static func runAppleScriptCandidates(_ scripts: [String]) -> ScriptProbeResult {
         var sawPermissionDenied = false
         var sawAppNotRunning = false
         var lastErrorCode: Int?
 
         for source in scripts {
+            if Task.isCancelled {
+                return ScriptProbeResult(
+                    success: false,
+                    permissionDenied: sawPermissionDenied,
+                    appNotRunning: sawAppNotRunning,
+                    lastErrorCode: lastErrorCode
+                )
+            }
             var error: NSDictionary?
             let wrapped = """
             with timeout of 1 seconds
@@ -711,16 +842,20 @@ struct PermissionsSettingsView: View {
             appNotFoundError: appPath == nil
                 ? AppLocalization.localizedString("Browser app could not be found. Reinstall or add the browser again.")
                 : nil,
-            isRunning: isApplicationRunning(bundleID: target.bundleID)
+            isRunning: Self.isApplicationRunning(bundleID: target.bundleID)
         )
     }
 
-    private func isApplicationRunning(bundleID: String) -> Bool {
+    nonisolated private static func isApplicationRunning(bundleID: String) -> Bool {
         NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
             .contains(where: { !$0.isTerminated })
     }
 
-    private static func browserTargetSignatureIntegrityError(appPath: String?) -> String? {
+    nonisolated private static func isApplicationInstalled(bundleID: String) -> Bool {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) != nil
+    }
+
+    nonisolated private static func browserTargetSignatureIntegrityError(appPath: String?) -> String? {
         guard let appPath else { return nil }
 
         var staticCode: SecStaticCode?

--- a/Voxt/Support/BrowserAutomationScriptBuilder.swift
+++ b/Voxt/Support/BrowserAutomationScriptBuilder.swift
@@ -2,6 +2,10 @@ import Foundation
 
 enum BrowserAutomationScriptBuilder {
     static func customBrowserPermissionProbeScripts(bundleID: String, displayName: String) -> [String] {
+        // Permission probes run inside Settings, where avoiding UI freezes is
+        // more important than preserving runtime ordering. Try the tab-based
+        // variants first because some Chromium-like browsers return faster on
+        // those forms during permission checks.
         [
             "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
             "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
@@ -13,6 +17,9 @@ enum BrowserAutomationScriptBuilder {
     }
 
     static func customBrowserRuntimeScripts(bundleID: String, displayName: String) -> [String] {
+        // Runtime URL reads happen on the app's normal path, so keep the more
+        // conservative ordering that favors the historically successful
+        // front-document / current-tab forms before falling back to others.
         [
             "tell application id \"\(bundleID)\" to get URL of front document",
             "tell application id \"\(bundleID)\" to get URL of current tab of front window",

--- a/Voxt/Support/BrowserAutomationScriptBuilder.swift
+++ b/Voxt/Support/BrowserAutomationScriptBuilder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum BrowserAutomationScriptBuilder {
-    static func customBrowserScripts(bundleID: String, displayName: String) -> [String] {
+    static func customBrowserPermissionProbeScripts(bundleID: String, displayName: String) -> [String] {
         [
             "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
             "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
@@ -9,6 +9,17 @@ enum BrowserAutomationScriptBuilder {
             "tell application id \"\(bundleID)\" to get URL of front document",
             "tell application id \"\(bundleID)\" to get URL of current tab of front window",
             "tell application \"\(displayName)\" to get URL of front document"
+        ]
+    }
+
+    static func customBrowserRuntimeScripts(bundleID: String, displayName: String) -> [String] {
+        [
+            "tell application id \"\(bundleID)\" to get URL of front document",
+            "tell application id \"\(bundleID)\" to get URL of current tab of front window",
+            "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
+            "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
+            "tell application \"\(displayName)\" to get URL of front document",
+            "tell application \"\(displayName)\" to get the URL of active tab of front window"
         ]
     }
 }

--- a/Voxt/Support/BrowserAutomationScriptBuilder.swift
+++ b/Voxt/Support/BrowserAutomationScriptBuilder.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum BrowserAutomationScriptBuilder {
+    static func customBrowserScripts(bundleID: String, displayName: String) -> [String] {
+        [
+            "tell application id \"\(bundleID)\" to get the URL of active tab of front window",
+            "tell application id \"\(bundleID)\" to get the URL of active tab of window 1",
+            "tell application \"\(displayName)\" to get the URL of active tab of front window",
+            "tell application id \"\(bundleID)\" to get URL of front document",
+            "tell application id \"\(bundleID)\" to get URL of current tab of front window",
+            "tell application \"\(displayName)\" to get URL of front document"
+        ]
+    }
+}


### PR DESCRIPTION
## Symptom

After manually adding Dia as a custom browser, opening the Permissions settings could become noticeably stuck or unresponsive.

This happened because Voxt probes custom browser URL-reading support through AppleScript. Some browsers may not respond quickly to one of the candidate scripts, so the probe can wait until the AppleScript timeout.

## Root Cause

The browser automation checks were running on the main actor. When a custom browser URL-read probe timed out, the timeout blocked the SwiftUI settings UI.

The custom browser probe order also tried Safari-style document URL scripts before Chromium-style active-tab scripts. For browsers like Dia, the Safari-style `front document` probe can timeout, while the active-tab probe works quickly.

## Changes

- Move browser automation state refresh, permission requests, app signature checks, and URL-read tests off the main actor.
- Update UI state and toast messages on the main actor only after background probes finish.
- Reorder custom browser AppleScript candidates to try active-tab URL reads first.
- Keep Safari-style document URL reads as fallback candidates.