### PR TITLE
Add prompt lookup decoding experiment for enhancement

### DIFF
--- a/Voxt/App/AppDelegate+LLMSmoke.swift
+++ b/Voxt/App/AppDelegate+LLMSmoke.swift
@@ -57,6 +57,7 @@ extension AppDelegate {
                 .lowercased()
         )
         let prefillStepOverride = Int(environment["VOXT_LLM_SMOKE_PREFILL_STEP"] ?? "")
+        let promptLookupOverride = parseSmokeBool(environment["VOXT_LLM_SMOKE_PROMPT_LOOKUP"])
         let translationTargetLanguage = resolvedSmokeTranslationTargetLanguage(
             environment["VOXT_LLM_SMOKE_TARGET_LANGUAGE"]
         ) ?? .english
@@ -166,7 +167,8 @@ extension AppDelegate {
                 let originalTuning = self.customLLMManager.generationTuning
                 self.customLLMManager.generationTuning = CustomLLMGenerationTuning(
                     prefillStepSizeOverride: prefillStepOverride,
-                    maxTokensOverride: nil
+                    maxTokensOverride: nil,
+                    promptLookupEnabledOverride: promptLookupOverride
                 )
                 defer {
                     self.customLLMManager.generationTuning = originalTuning
@@ -201,6 +203,7 @@ extension AppDelegate {
                 print("[VOXT_SMOKE] iterations=\(iterations)")
                 print("[VOXT_SMOKE] prewarm=\(shouldPrewarm)")
                 print("[VOXT_SMOKE] prefillStepOverride=\(prefillStepOverride.map(String.init) ?? "auto")")
+                print("[VOXT_SMOKE] promptLookupOverride=\(promptLookupOverride.map(String.init) ?? "auto")")
                 print("[VOXT_SMOKE] delivery=\(String(describing: plan.delivery))")
                 print("[VOXT_SMOKE] promptChars=\(plan.promptCharacterCount)")
                 print("[VOXT_SMOKE] inputChars=\(plan.primaryInputCharacterCount)")
@@ -255,6 +258,11 @@ extension AppDelegate {
         print("\(prefix) generationMs=\(diagnostics.generationMs.map(String.init) ?? "n/a")")
         print("\(prefix) modelOverheadMs=\(diagnostics.modelOverheadMs.map(String.init) ?? "n/a")")
         print("\(prefix) totalOverheadMs=\(diagnostics.totalOverheadMs.map(String.init) ?? "n/a")")
+        print("\(prefix) promptLookupDraftTokens=\(diagnostics.promptLookupDraftTokens.map(String.init) ?? "n/a")")
+        print("\(prefix) promptLookupProposedTokens=\(diagnostics.promptLookupProposedTokens.map(String.init) ?? "n/a")")
+        print("\(prefix) promptLookupAcceptedTokens=\(diagnostics.promptLookupAcceptedTokens.map(String.init) ?? "n/a")")
+        print("\(prefix) promptLookupAcceptanceRatio=\(diagnostics.promptLookupAcceptanceRatio.map { String($0) } ?? "n/a")")
+        print("\(prefix) promptLookupFallback=\(diagnostics.promptLookupFallbackReason ?? "n/a")")
     }
 
     private func printAggregateMetrics(_ results: [LLMSmokeIterationResult]) {
@@ -279,6 +287,8 @@ extension AppDelegate {
         printOptionalAverageSummary(results, label: "totalOverheadMs") { $0.totalOverheadMs }
         printOptionalAverageSummary(results, label: "promptTokens") { $0.promptTokens }
         printOptionalAverageSummary(results, label: "completionTokens") { $0.completionTokens }
+        printOptionalAverageSummary(results, label: "promptLookupDraftTokens") { $0.promptLookupDraftTokens }
+        printOptionalAverageSummary(results, label: "promptLookupProposedTokens") { $0.promptLookupProposedTokens }
     }
 
     private func printAverageSummary(
@@ -309,6 +319,20 @@ extension AppDelegate {
         guard !values.isEmpty else { return 0 }
         let total = values.reduce(0, +)
         return Int((Double(total) / Double(values.count)).rounded())
+    }
+
+    private func parseSmokeBool(_ rawValue: String?) -> Bool? {
+        let normalized = rawValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard let normalized, !normalized.isEmpty else { return nil }
+        if ["1", "true", "yes", "on", "enabled"].contains(normalized) {
+            return true
+        }
+        if ["0", "false", "no", "off", "disabled"].contains(normalized) {
+            return false
+        }
+        return nil
     }
 
     private func resolvedSmokeTranslationTargetLanguage(_ rawValue: String?) -> TranslationTargetLanguage? {

--- a/Voxt/App/AppDelegate+LLMSmoke.swift
+++ b/Voxt/App/AppDelegate+LLMSmoke.swift
@@ -289,6 +289,8 @@ extension AppDelegate {
         printOptionalAverageSummary(results, label: "completionTokens") { $0.completionTokens }
         printOptionalAverageSummary(results, label: "promptLookupDraftTokens") { $0.promptLookupDraftTokens }
         printOptionalAverageSummary(results, label: "promptLookupProposedTokens") { $0.promptLookupProposedTokens }
+        printOptionalAverageSummary(results, label: "promptLookupAcceptedTokens") { $0.promptLookupAcceptedTokens }
+        printOptionalDoubleAverageSummary(results, label: "promptLookupAcceptanceRatio") { $0.promptLookupAcceptanceRatio }
     }
 
     private func printAverageSummary(
@@ -319,6 +321,26 @@ extension AppDelegate {
         guard !values.isEmpty else { return 0 }
         let total = values.reduce(0, +)
         return Int((Double(total) / Double(values.count)).rounded())
+    }
+
+    private func printOptionalDoubleAverageSummary(
+        _ results: [LLMSmokeIterationResult],
+        label: String,
+        value: (CustomLLMRunDiagnostics) -> Double?
+    ) {
+        let values = results.compactMap(\.diagnostics).compactMap(value)
+        guard !values.isEmpty else { return }
+        print("[VOXT_SMOKE][summary] avg\(label.prefix(1).uppercased())\(label.dropFirst())=\(average(values))")
+        let hotValues = Array(values.dropFirst())
+        if !hotValues.isEmpty {
+            print("[VOXT_SMOKE][summary] hotAvg\(label.prefix(1).uppercased())\(label.dropFirst())=\(average(hotValues))")
+        }
+    }
+
+    private func average(_ values: [Double]) -> String {
+        guard !values.isEmpty else { return "0" }
+        let total = values.reduce(0, +)
+        return String(format: "%.4f", total / Double(values.count))
     }
 
     private func parseSmokeBool(_ rawValue: String?) -> Bool? {

--- a/Voxt/App/AppDelegate+LLMWarmup.swift
+++ b/Voxt/App/AppDelegate+LLMWarmup.swift
@@ -208,11 +208,20 @@ extension AppDelegate {
                     verbose: true
                 )
             } catch {
-                VoxtLog.warning(
-                    "Remote LLM warmup failed. provider=\(context.provider.rawValue), model=\(context.configuration.model), reason=\(reason), error=\(error.localizedDescription)"
-                )
+                let message = "Remote LLM warmup failed. provider=\(context.provider.rawValue), model=\(context.configuration.model), reason=\(reason), error=\(error.localizedDescription)"
+                if Self.shouldLogRemoteWarmupFailureAsVerboseInfo(error, reason: reason) {
+                    VoxtLog.info(message, verbose: true)
+                } else {
+                    VoxtLog.warning(message)
+                }
             }
         }
+    }
+
+    private nonisolated static func shouldLogRemoteWarmupFailureAsVerboseInfo(_ error: Error, reason: String) -> Bool {
+        guard reason == "idle" else { return false }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
     }
 
     private func cancelRemoteLLMWarmupTasks(except keysToKeep: [String]) {

--- a/Voxt/Settings/AppPreferenceKey.swift
+++ b/Voxt/Settings/AppPreferenceKey.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum AppPreferenceKey {
+nonisolated enum AppPreferenceKey {
     static let transcriptionEngine = "transcriptionEngine"
     static let enhancementMode = "enhancementMode"
     static let enhancementSystemPrompt = "enhancementSystemPrompt"

--- a/Voxt/Settings/SettingsTypes.swift
+++ b/Voxt/Settings/SettingsTypes.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-extension Notification.Name {
+nonisolated extension Notification.Name {
     static let voxtSettingsSelectTab = Notification.Name("voxt.settings.selectTab")
     static let voxtSettingsNavigate = Notification.Name("voxt.settings.navigate")
     static let voxtInterfaceLanguageDidChange = Notification.Name("voxt.interfaceLanguage.didChange")
@@ -12,7 +12,7 @@ extension Notification.Name {
     static let voxtFeatureSettingsDidChange = Notification.Name("voxt.feature-settings.did-change")
 }
 
-enum AppInterfaceLanguage: String, CaseIterable, Identifiable {
+nonisolated enum AppInterfaceLanguage: String, CaseIterable, Identifiable {
     case system
     case english = "en"
     case chineseSimplified = "zh-Hans"

--- a/Voxt/Support/AppLocalization.swift
+++ b/Voxt/Support/AppLocalization.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-enum AppLocalization {
-    private struct LanguageSnapshot {
+nonisolated enum AppLocalization {
+    private nonisolated struct LanguageSnapshot {
         let language: AppInterfaceLanguage
         let localeIdentifier: String
         let locale: Locale

--- a/Voxt/Support/AppPromptDefaults.swift
+++ b/Voxt/Support/AppPromptDefaults.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum AppPromptKind: CaseIterable {
+nonisolated enum AppPromptKind: CaseIterable {
     case enhancement
     case translation
     case rewrite
@@ -13,7 +13,7 @@ enum AppPromptKind: CaseIterable {
     case whisperASRHint
 }
 
-enum AppPromptDefaults {
+nonisolated enum AppPromptDefaults {
     private static let transcriptPromptCurrentToken = TranscriptSummarySupport.transcriptRecordTemplateVariable
     private static let transcriptPromptLegacyToken = "{{MEETING_RECORD}}"
 

--- a/Voxt/Support/CustomLLMModelManager.swift
+++ b/Voxt/Support/CustomLLMModelManager.swift
@@ -4,7 +4,6 @@ import Combine
 import MLX
 import MLXLLM
 import MLXLMCommon
-import MLXNN
 import Tokenizers
 
 private struct LocalTokenizerBridge: MLXLMCommon.Tokenizer {
@@ -62,21 +61,20 @@ nonisolated private enum CustomLLMPromptLookupConfiguration {
     static let minimumDraftCharacters = 120
     static let minimumDraftTokens = 24
     static let maxSuffixTokens = 16
-    static let numDraftTokens = 4
-    static let maximumLogitsCacheEntries = 64
-}
-
-private struct CustomLLMPromptLookupGenerationResult: Sendable {
-    let text: String
-    let info: GenerateCompletionInfo
-    let metrics: CustomLLMPromptLookupMetrics
+    static let numDraftTokens = 1
 }
 
 private struct CustomLLMPromptLookupMetrics: Sendable {
     let draftTokenCount: Int
     let proposedTokenCount: Int
+    let acceptedTokenCount: Int
     let longestMatchedSuffix: Int
     let fallbackReason: String?
+
+    var acceptanceRatio: Double? {
+        guard proposedTokenCount > 0 else { return nil }
+        return Double(acceptedTokenCount) / Double(proposedTokenCount)
+    }
 }
 
 private struct CustomLLMPromptLookupEventStream: Sendable {
@@ -84,7 +82,7 @@ private struct CustomLLMPromptLookupEventStream: Sendable {
     let metrics: CustomLLMPromptLookupMetricsBox
 }
 
-private final class CustomLLMPromptLookupMetricsBox: @unchecked Sendable {
+nonisolated private final class CustomLLMPromptLookupMetricsBox: @unchecked Sendable {
     private let lock = NSLock()
     private var pending: CustomLLMPromptLookupMetrics?
 
@@ -103,134 +101,244 @@ private final class CustomLLMPromptLookupMetricsBox: @unchecked Sendable {
     }
 }
 
-nonisolated private final class CustomLLMPromptLookupDraftModel: Module, LanguageModel, @unchecked Sendable {
+nonisolated private struct CustomLLMPromptLookupIterator {
+    let model: any LanguageModel
     private let draftTokens: [Int]
-    private let maxSuffixTokens: Int
-    private let fallbackToken: Int
-    private let lock = NSLock()
+    private var state: LMOutput.State?
+    private var y: LMInput.Text
+    private var cache: [KVCache]
+    private var processor: LogitProcessor?
+    private let sampler: LogitSampler
+    private let kvBits: Int?
+    private let kvGroupSize: Int
+    private let quantizedKVStart: Int
 
-    private var vocabularySize: Int
-    private var observedTokens: [Int] = []
-    private var didConsumePrompt = false
+    private var generatedTokens: [Int] = []
+    private var pendingTokens: [Int] = []
+    private var pendingIndex = 0
+
+    var tokenCount = 0
+    let maxTokens: Int?
+    var promptPrefillTime: TimeInterval = 0.0
+
     private var proposedTokenCount = 0
+    private var acceptedTokenCount = 0
     private var longestMatchedSuffix = 0
-    private var logitsCache: [Int: MLXArray] = [:]
 
-    nonisolated init(draftTokens: [Int], maxSuffixTokens: Int) {
+    init(
+        input: LMInput,
+        model: any LanguageModel,
+        cache: [KVCache]? = nil,
+        parameters: GenerateParameters,
+        draftTokens: [Int]
+    ) throws {
+        self.model = model
         self.draftTokens = draftTokens
-        self.maxSuffixTokens = max(1, maxSuffixTokens)
-        self.vocabularySize = max(1, (draftTokens.max() ?? 0) + 1)
-        self.fallbackToken = draftTokens.first ?? 0
-        super.init()
-    }
-
-    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
-        let promptTokens = input.text.tokens.asArray(Int.self)
-        lock.lock()
-        vocabularySize = max(vocabularySize, (promptTokens.max() ?? 0) + 1)
-        observedTokens = []
-        didConsumePrompt = false
-        proposedTokenCount = 0
-        longestMatchedSuffix = 0
-        logitsCache.removeAll(keepingCapacity: true)
-        lock.unlock()
-        return .tokens(input.text)
-    }
-
-    func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?) -> LMOutput {
-        let inputTokens = input.tokens.asArray(Int.self)
-        lock.lock()
-        expandVocabularyIfNeeded(for: inputTokens)
-        if didConsumePrompt {
-            observedTokens.append(contentsOf: inputTokens)
-        } else {
-            didConsumePrompt = true
+        self.y = input.text
+        self.cache = cache ?? model.newCache(parameters: parameters)
+        self.processor = parameters.processor()
+        self.sampler = parameters.sampler()
+        self.kvBits = parameters.kvBits
+        self.kvGroupSize = parameters.kvGroupSize
+        self.quantizedKVStart = parameters.quantizedKVStart
+        self.maxTokens = parameters.maxTokens
+        self.promptPrefillTime = try customLLMMeasure {
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
         }
-        let nextToken = nextDraftToken(after: observedTokens)
-        let logitsVocabularySize = vocabularySize
-        proposedTokenCount += 1
-        let logits = cachedLogits(for: nextToken, vocabularySize: logitsVocabularySize)
-        lock.unlock()
-        return LMOutput(logits: logits)
     }
 
-    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
-        callAsFunction(LMInput.Text(tokens: inputs), cache: cache, state: nil).logits
-    }
-
-    func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        []
-    }
-
-    func metricsSnapshot() -> CustomLLMPromptLookupMetrics {
-        lock.lock()
-        let metrics = CustomLLMPromptLookupMetrics(
+    mutating func metricsSnapshot(fallbackReason: String? = nil) -> CustomLLMPromptLookupMetrics {
+        CustomLLMPromptLookupMetrics(
             draftTokenCount: draftTokens.count,
             proposedTokenCount: proposedTokenCount,
+            acceptedTokenCount: acceptedTokenCount,
             longestMatchedSuffix: longestMatchedSuffix,
-            fallbackReason: nil
+            fallbackReason: fallbackReason
         )
-        lock.unlock()
-        return metrics
     }
 
-    private func nextDraftToken(after generatedTokens: [Int]) -> Int {
-        guard !draftTokens.isEmpty else { return fallbackToken }
-        guard !generatedTokens.isEmpty else { return draftTokens[0] }
+    mutating func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
 
-        let suffixLimit = min(maxSuffixTokens, generatedTokens.count, draftTokens.count)
-        if suffixLimit > 0 {
-            for suffixLength in stride(from: suffixLimit, through: 1, by: -1) {
-                let suffix = Array(generatedTokens.suffix(suffixLength))
-                guard let matchStart = lastIndex(of: suffix, in: draftTokens) else { continue }
-                let nextIndex = matchStart + suffixLength
-                guard nextIndex < draftTokens.count else { continue }
-                longestMatchedSuffix = max(longestMatchedSuffix, suffixLength)
-                return draftTokens[nextIndex]
+        if pendingIndex < pendingTokens.count {
+            let token = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            tokenCount += 1
+            generatedTokens.append(token)
+            return token
+        }
+
+        pendingTokens.removeAll(keepingCapacity: true)
+        pendingIndex = 0
+        fillPendingTokens()
+        guard !pendingTokens.isEmpty else {
+            return nil
+        }
+
+        let token = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        generatedTokens.append(token)
+        return token
+    }
+
+    private mutating func prepare(input: LMInput, windowSize: Int?) throws {
+        processor?.prompt(input.text.tokens)
+
+        switch try model.prepare(input, cache: cache, windowSize: windowSize) {
+        case .tokens(let tokens):
+            y = tokens
+            let token = step(previous: y)
+            y = .init(tokens: token)
+            asyncEval(y.tokens)
+            pendingTokens.append(token.item(Int.self))
+        case .logits(let result):
+            y = .init(tokens: convertToToken(logits: result.logits))
+            asyncEval(y.tokens)
+            pendingTokens.append(y.tokens.item(Int.self))
+        }
+    }
+
+    private mutating func fillPendingTokens() {
+        let smokeDraftTokenOverride = ProcessInfo.processInfo.environment["VOXT_LLM_SMOKE_PROMPT_LOOKUP_NUM_DRAFT_TOKENS"]
+            .flatMap(Int.init)
+            .map { max(0, $0) }
+        let configuredDraftTokens = smokeDraftTokenOverride
+            ?? CustomLLMPromptLookupConfiguration.numDraftTokens
+        let remaining = maxTokens.map { $0 - tokenCount }
+            ?? configuredDraftTokens
+        let numDraft = Swift.min(remaining, configuredDraftTokens)
+        guard numDraft > 0 else {
+            return
+        }
+
+        if ProcessInfo.processInfo.environment["VOXT_LLM_SMOKE_PROMPT_LOOKUP_DISABLE_PROPOSALS"] == "1" {
+            let token = step(previous: y)
+            y = .init(tokens: token)
+            asyncEval(token)
+            pendingTokens.append(token.item(Int.self))
+            return
+        }
+
+        guard let proposal = CustomLLMPromptLookupProposalBuilder.proposal(
+            generatedTokens: generatedTokens,
+            draftTokens: draftTokens,
+            maxSuffixTokens: CustomLLMPromptLookupConfiguration.maxSuffixTokens,
+            maxDraftTokens: numDraft
+        ) else {
+            let token = step(previous: y)
+            y = .init(tokens: token)
+            asyncEval(token)
+            pendingTokens.append(token.item(Int.self))
+            return
+        }
+
+        longestMatchedSuffix = max(longestMatchedSuffix, proposal.matchedSuffixLength)
+        proposedTokenCount += proposal.tokens.count
+
+        let proposalTokenArrays = proposal.tokens.map { MLXArray($0).reshaped([1]) }
+        let verifyInput = LMInput.Text(tokens: concatenated([y.tokens] + proposalTokenArrays))
+        let verifyStart = verifyInput.tokens.dim(0) - (proposal.tokens.count + 1)
+        let result = model(verifyInput[text: .newAxis], cache: cache, state: state)
+        state = result.state
+
+        let mainTokens = sampleVerifiedTokens(
+            from: result.logits,
+            verifyStart: verifyStart,
+            count: proposal.tokens.count + 1
+        )
+        eval(mainTokens, concatenated(proposalTokenArrays))
+        let mainTokenList = mainTokens.asArray(Int.self)
+
+        var accepted = 0
+        for index in 0 ..< proposal.tokens.count {
+            guard mainTokenList[index] == proposal.tokens[index] else { break }
+            processor?.didSample(token: proposalTokenArrays[index])
+            pendingTokens.append(mainTokenList[index])
+            accepted += 1
+        }
+
+        acceptedTokenCount += accepted
+
+        let correctionToken = mainTokens[accepted ... accepted]
+        processor?.didSample(token: correctionToken)
+        pendingTokens.append(mainTokenList[accepted])
+
+        trimPromptCache(cache, numTokens: proposal.tokens.count - accepted)
+        maybeQuantizeKVCache(
+            cache: &cache,
+            kvBits: kvBits,
+            kvGroupSize: kvGroupSize,
+            quantizedKVStart: quantizedKVStart
+        )
+        y = .init(tokens: correctionToken)
+    }
+
+    private mutating func sampleVerifiedTokens(
+        from logits: MLXArray,
+        verifyStart: Int,
+        count: Int
+    ) -> MLXArray {
+        if var verifyProcessor = processor {
+            var sampled: [MLXArray] = []
+            sampled.reserveCapacity(count)
+            for offset in 0 ..< count {
+                var positionLogits = logits[0..., verifyStart + offset, 0...]
+                positionLogits = verifyProcessor.process(logits: positionLogits)
+                let token = sampler.sample(logits: positionLogits)
+                verifyProcessor.didSample(token: token)
+                sampled.append(token)
             }
+            return concatenated(sampled)
+        } else {
+            let verifyLogits = logits[0..., verifyStart..., 0...].squeezed(axis: 0)
+            return sampler.sample(logits: verifyLogits)
         }
-
-        let sequentialIndex = min(generatedTokens.count, draftTokens.count - 1)
-        return draftTokens[sequentialIndex]
     }
 
-    private func lastIndex(of needle: [Int], in haystack: [Int]) -> Int? {
-        guard !needle.isEmpty, needle.count <= haystack.count else { return nil }
-        var index = haystack.count - needle.count
-        while index >= 0 {
-            if Array(haystack[index ..< index + needle.count]) == needle {
-                return index
-            }
-            index -= 1
+    private mutating func convertToToken(logits: MLXArray) -> MLXArray {
+        var logits = logits[0..., -1, 0...]
+        logits = processor?.process(logits: logits) ?? logits
+        let token = sampler.sample(logits: logits)
+        processor?.didSample(token: token)
+        return token
+    }
+
+    private mutating func step(previous: LMInput.Text) -> MLXArray {
+        let result = model(previous[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: state)
+        state = result.state
+        maybeQuantizeKVCache(
+            cache: &cache,
+            kvBits: kvBits,
+            kvGroupSize: kvGroupSize,
+            quantizedKVStart: quantizedKVStart
+        )
+        return convertToToken(logits: result.logits)
+    }
+}
+
+nonisolated private func customLLMStopTokenIDs(
+    modelConfiguration: ModelConfiguration,
+    tokenizer: any MLXLMCommon.Tokenizer
+) -> Set<Int> {
+    var stopTokenIDs = modelConfiguration.eosTokenIds
+    if let tokenizerEOS = tokenizer.eosTokenId {
+        stopTokenIDs.insert(tokenizerEOS)
+    }
+    for token in modelConfiguration.extraEOSTokens {
+        if let id = tokenizer.convertTokenToId(token) {
+            stopTokenIDs.insert(id)
         }
-        return nil
     }
+    return stopTokenIDs
+}
 
-    private func expandVocabularyIfNeeded(for tokens: [Int]) {
-        let requiredSize = (tokens.max() ?? 0) + 1
-        guard requiredSize > vocabularySize else { return }
-        vocabularySize = requiredSize
-        logitsCache.removeAll(keepingCapacity: true)
-    }
-
-    private func cachedLogits(for token: Int, vocabularySize: Int) -> MLXArray {
-        let safeToken = max(0, min(token, vocabularySize - 1))
-        if let cached = logitsCache[safeToken] {
-            return cached
-        }
-        if logitsCache.count >= CustomLLMPromptLookupConfiguration.maximumLogitsCacheEntries {
-            logitsCache.removeAll(keepingCapacity: true)
-        }
-        let logits = logits(for: safeToken, vocabularySize: vocabularySize)
-        logitsCache[safeToken] = logits
-        return logits
-    }
-
-    private func logits(for token: Int, vocabularySize: Int) -> MLXArray {
-        var values = Array(repeating: Float32(-1_000_000), count: vocabularySize)
-        values[token] = 1_000_000
-        return MLXArray(values, [1, 1, vocabularySize])
-    }
+nonisolated private func customLLMMeasure(_ closure: () throws -> Void) rethrows -> TimeInterval {
+    let start = Date.timeIntervalSinceReferenceDate
+    try closure()
+    return Date.timeIntervalSinceReferenceDate - start
 }
 
 @MainActor
@@ -616,15 +724,18 @@ class CustomLLMModelManager: ObservableObject {
             var firstChunkLatencyMs: Int?
             var completionInfo: GenerateCompletionInfo?
             var promptLookupMetrics: CustomLLMPromptLookupMetrics?
+            var promptLookupSkippedReason: String?
             var repetitionStop: LLMOutputRepetition?
             let repetitionGuard = LLMOutputRepetitionGuard()
-            let promptLookupEventStream = try await promptLookupEventStreamIfEligible(
+            let promptLookupPreparation = try await promptLookupEventStreamIfEligible(
                 request: request,
                 container: container,
                 params: params,
                 behavior: behavior,
                 settings: settings
             )
+            let promptLookupEventStream = promptLookupPreparation.stream
+            promptLookupSkippedReason = promptLookupPreparation.skipReason
             let eventStream = promptLookupEventStream?.stream ?? session.streamDetails(
                 to: request.prompt,
                 images: [],
@@ -730,12 +841,17 @@ class CustomLLMModelManager: ObservableObject {
             if let promptLookupMetrics {
                 diagnostics.promptLookupDraftTokens = promptLookupMetrics.draftTokenCount
                 diagnostics.promptLookupProposedTokens = promptLookupMetrics.proposedTokenCount
-                diagnostics.promptLookupAcceptedTokens = nil
-                diagnostics.promptLookupAcceptanceRatio = nil
+                diagnostics.promptLookupAcceptedTokens = promptLookupMetrics.acceptedTokenCount
+                diagnostics.promptLookupAcceptanceRatio = promptLookupMetrics.acceptanceRatio
                 diagnostics.promptLookupFallbackReason = promptLookupMetrics.fallbackReason
                 let fallback = promptLookupMetrics.fallbackReason ?? "none"
                 VoxtLog.llm(
-                    "Custom LLM \(request.kind.logLabel) prompt lookup metrics. repo=\(request.repo), draftTokens=\(promptLookupMetrics.draftTokenCount), proposedTokens=\(promptLookupMetrics.proposedTokenCount), longestSuffix=\(promptLookupMetrics.longestMatchedSuffix), fallback=\(fallback)"
+                    "Custom LLM \(request.kind.logLabel) prompt lookup metrics. repo=\(request.repo), draftTokens=\(promptLookupMetrics.draftTokenCount), proposedTokens=\(promptLookupMetrics.proposedTokenCount), acceptedTokens=\(promptLookupMetrics.acceptedTokenCount), acceptanceRatio=\(promptLookupMetrics.acceptanceRatio.map { String(format: "%.3f", $0) } ?? "n/a"), longestSuffix=\(promptLookupMetrics.longestMatchedSuffix), fallback=\(fallback)"
+                )
+            } else if let promptLookupSkippedReason {
+                diagnostics.promptLookupFallbackReason = promptLookupSkippedReason
+                VoxtLog.llm(
+                    "Custom LLM \(request.kind.logLabel) prompt lookup skipped. repo=\(request.repo), reason=\(promptLookupSkippedReason)"
                 )
             }
             lastRunDiagnostics = diagnostics
@@ -756,13 +872,20 @@ class CustomLLMModelManager: ObservableObject {
         params: GenerateParameters,
         behavior: CustomLLMModelBehavior,
         settings: LLMGenerationSettings
-    ) async throws -> CustomLLMPromptLookupEventStream? {
-        guard generationTuning.promptLookupEnabledOverride != false else { return nil }
-        guard request.kind == .enhancement else { return nil }
+    ) async throws -> (stream: CustomLLMPromptLookupEventStream?, skipReason: String?) {
+        guard generationTuning.promptLookupEnabledOverride == true else {
+            return (nil, nil)
+        }
+        guard request.kind == .enhancement else {
+            return (nil, "nonEnhancementTask")
+        }
+        if let skipReason = request.promptLookupSkipReason {
+            return (nil, skipReason)
+        }
         guard let draftText = request.promptLookupDraftText?.trimmingCharacters(in: .whitespacesAndNewlines),
               draftText.count >= CustomLLMPromptLookupConfiguration.minimumDraftCharacters
         else {
-            return nil
+            return (nil, "draftTextTooShort")
         }
 
         let additionalContext = localThinkingAdditionalContext(
@@ -774,20 +897,16 @@ class CustomLLMModelManager: ObservableObject {
         let stream: AsyncThrowingStream<Generation, Error> = AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    let result = try await runPromptLookupGeneration(
+                    try await runPromptLookupGenerationStream(
                         container: container,
                         instructions: request.instructions,
                         prompt: request.prompt,
                         params: params,
                         draftText: draftText,
-                        additionalContext: additionalContext
+                        additionalContext: additionalContext,
+                        metricsBox: metricsBox,
+                        continuation: continuation
                     )
-                    metricsBox.put(result.metrics)
-                    if !result.text.isEmpty {
-                        continuation.yield(.chunk(result.text))
-                    }
-                    continuation.yield(.info(result.info))
-                    continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
@@ -797,17 +916,22 @@ class CustomLLMModelManager: ObservableObject {
                 task.cancel()
             }
         }
-        return CustomLLMPromptLookupEventStream(stream: stream, metrics: metricsBox)
+        return (
+            CustomLLMPromptLookupEventStream(stream: stream, metrics: metricsBox),
+            nil
+        )
     }
 
-    private func runPromptLookupGeneration(
+    private func runPromptLookupGenerationStream(
         container: ModelContainer,
         instructions: String,
         prompt: String,
         params: GenerateParameters,
         draftText: String,
-        additionalContext: [String: any Sendable]?
-    ) async throws -> CustomLLMPromptLookupGenerationResult {
+        additionalContext: [String: any Sendable]?,
+        metricsBox: CustomLLMPromptLookupMetricsBox,
+        continuation: AsyncThrowingStream<Generation, Error>.Continuation
+    ) async throws {
         try await container.perform { context in
             var messages: [Chat.Message] = []
             let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -824,109 +948,120 @@ class CustomLLMModelManager: ObservableObject {
             )
             let draftTokens = context.tokenizer.encode(text: draftText)
             guard draftTokens.count >= CustomLLMPromptLookupConfiguration.minimumDraftTokens else {
-                let metrics = CustomLLMPromptLookupMetrics(
+                metricsBox.put(CustomLLMPromptLookupMetrics(
                     draftTokenCount: draftTokens.count,
                     proposedTokenCount: 0,
+                    acceptedTokenCount: 0,
                     longestMatchedSuffix: 0,
                     fallbackReason: "draftTooShort"
-                )
-                return try await runStandardGenerationInContext(
-                    input: input,
-                    params: params,
-                    context: context,
-                    metrics: metrics
-                )
-            }
-
-            let draftModel = CustomLLMPromptLookupDraftModel(
-                draftTokens: draftTokens,
-                maxSuffixTokens: CustomLLMPromptLookupConfiguration.maxSuffixTokens
-            )
-            let stream: AsyncStream<Generation>
-            do {
-                stream = try MLXLMCommon.generate(
+                ))
+                let fallbackStream = try MLXLMCommon.generate(
                     input: input,
                     parameters: params,
-                    context: context,
-                    draftModel: draftModel,
-                    numDraftTokens: CustomLLMPromptLookupConfiguration.numDraftTokens
+                    context: context
                 )
-            } catch {
-                let snapshot = draftModel.metricsSnapshot()
-                let metrics = CustomLLMPromptLookupMetrics(
-                    draftTokenCount: snapshot.draftTokenCount,
-                    proposedTokenCount: snapshot.proposedTokenCount,
-                    longestMatchedSuffix: snapshot.longestMatchedSuffix,
-                    fallbackReason: "speculativeUnavailable"
-                )
-                return try await runStandardGenerationInContext(
-                    input: input,
-                    params: params,
-                    context: context,
-                    metrics: metrics
-                )
+                for await event in fallbackStream {
+                    if case .terminated = continuation.yield(event) {
+                        break
+                    }
+                }
+                Stream().synchronize()
+                continuation.finish()
+                return
             }
-            var text = ""
-            var info: GenerateCompletionInfo?
-            for await event in stream {
-                switch event {
-                case .chunk(let chunk):
-                    text += chunk
-                case .info(let completion):
-                    info = completion
-                case .toolCall:
-                    continue
+
+            let cache = context.model.newCache(parameters: params)
+            guard canTrimPromptCache(cache) else {
+                metricsBox.put(CustomLLMPromptLookupMetrics(
+                    draftTokenCount: draftTokens.count,
+                    proposedTokenCount: 0,
+                    acceptedTokenCount: 0,
+                    longestMatchedSuffix: 0,
+                    fallbackReason: "cacheNotTrimmable"
+                ))
+                let fallbackStream = try MLXLMCommon.generate(
+                    input: input,
+                    cache: cache,
+                    parameters: params,
+                    context: context
+                )
+                for await event in fallbackStream {
+                    if case .terminated = continuation.yield(event) {
+                        break
+                    }
+                }
+                Stream().synchronize()
+                continuation.finish()
+                return
+            }
+
+            var iterator = try CustomLLMPromptLookupIterator(
+                input: input,
+                model: context.model,
+                cache: cache,
+                parameters: params,
+                draftTokens: draftTokens,
+            )
+
+            var detokenizer = NaiveStreamingDetokenizer(tokenizer: context.tokenizer)
+            let stopTokenIDs = customLLMStopTokenIDs(
+                modelConfiguration: context.configuration,
+                tokenizer: context.tokenizer
+            )
+
+            var start = Date.timeIntervalSinceReferenceDate
+            var promptTime: TimeInterval = 0
+            var generationTokenCount = 0
+            var stopReason: GenerateStopReason?
+
+            generationLoop: while let token = iterator.next() {
+                if Task.isCancelled {
+                    stopReason = .cancelled
+                    break
+                }
+
+                if promptTime == 0 {
+                    let now = Date.timeIntervalSinceReferenceDate
+                    promptTime = now - start
+                    start = now
+                }
+
+                if token == context.tokenizer.unknownTokenId || stopTokenIDs.contains(token) {
+                    stopReason = .stop
+                    break
+                }
+
+                generationTokenCount += 1
+                detokenizer.append(token: token)
+                if let chunk = detokenizer.next(), !chunk.isEmpty,
+                   case .terminated = continuation.yield(.chunk(chunk)) {
+                    stopReason = .cancelled
+                    break generationLoop
                 }
             }
 
-            return CustomLLMPromptLookupGenerationResult(
-                text: text,
-                info: info ?? GenerateCompletionInfo(
-                    promptTokenCount: input.text.tokens.size,
-                    generationTokenCount: 0,
-                    promptTime: 0,
-                    generationTime: 0,
-                    stopReason: .cancelled
-                ),
-                metrics: draftModel.metricsSnapshot()
-            )
-        }
-    }
-
-    private func runStandardGenerationInContext(
-        input: LMInput,
-        params: GenerateParameters,
-        context: ModelContext,
-        metrics: CustomLLMPromptLookupMetrics
-    ) async throws -> CustomLLMPromptLookupGenerationResult {
-        let stream = try MLXLMCommon.generate(
-            input: input,
-            parameters: params,
-            context: context
-        )
-        var text = ""
-        var info: GenerateCompletionInfo?
-        for await event in stream {
-            switch event {
-            case .chunk(let chunk):
-                text += chunk
-            case .info(let completion):
-                info = completion
-            case .toolCall:
-                continue
+            if stopReason == nil {
+                if Task.isCancelled {
+                    stopReason = .cancelled
+                } else if let maxTokens = iterator.maxTokens, iterator.tokenCount >= maxTokens {
+                    stopReason = .length
+                } else {
+                    stopReason = .cancelled
+                }
             }
-        }
-        return CustomLLMPromptLookupGenerationResult(
-            text: text,
-            info: info ?? GenerateCompletionInfo(
+
+            let info = GenerateCompletionInfo(
                 promptTokenCount: input.text.tokens.size,
-                generationTokenCount: 0,
-                promptTime: 0,
-                generationTime: 0,
-                stopReason: .cancelled
-            ),
-            metrics: metrics
-        )
+                generationTokenCount: generationTokenCount,
+                promptTime: promptTime + iterator.promptPrefillTime,
+                generationTime: Date.timeIntervalSinceReferenceDate - start,
+                stopReason: stopReason ?? .cancelled
+            )
+            metricsBox.put(iterator.metricsSnapshot())
+            _ = continuation.yield(.info(info))
+            Stream().synchronize()
+            continuation.finish()
+        }
     }
 
     private func startLogMessage(

--- a/Voxt/Support/CustomLLMModelManager.swift
+++ b/Voxt/Support/CustomLLMModelManager.swift
@@ -4,6 +4,7 @@ import Combine
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXNN
 import Tokenizers
 
 private struct LocalTokenizerBridge: MLXLMCommon.Tokenizer {
@@ -54,6 +55,181 @@ private struct LocalTokenizerLoader: MLXLMCommon.TokenizerLoader {
     func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
         let tokenizer = try await Tokenizers.AutoTokenizer.from(modelFolder: directory)
         return LocalTokenizerBridge(tokenizer)
+    }
+}
+
+nonisolated private enum CustomLLMPromptLookupConfiguration {
+    static let minimumDraftCharacters = 120
+    static let minimumDraftTokens = 24
+    static let maxSuffixTokens = 16
+    static let numDraftTokens = 4
+    static let maximumLogitsCacheEntries = 64
+}
+
+private struct CustomLLMPromptLookupGenerationResult: Sendable {
+    let text: String
+    let info: GenerateCompletionInfo
+    let metrics: CustomLLMPromptLookupMetrics
+}
+
+private struct CustomLLMPromptLookupMetrics: Sendable {
+    let draftTokenCount: Int
+    let proposedTokenCount: Int
+    let longestMatchedSuffix: Int
+    let fallbackReason: String?
+}
+
+private struct CustomLLMPromptLookupEventStream: Sendable {
+    let stream: AsyncThrowingStream<Generation, Error>
+    let metrics: CustomLLMPromptLookupMetricsBox
+}
+
+private final class CustomLLMPromptLookupMetricsBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pending: CustomLLMPromptLookupMetrics?
+
+    func put(_ metrics: CustomLLMPromptLookupMetrics) {
+        lock.lock()
+        pending = metrics
+        lock.unlock()
+    }
+
+    func take() -> CustomLLMPromptLookupMetrics? {
+        lock.lock()
+        let metrics = pending
+        pending = nil
+        lock.unlock()
+        return metrics
+    }
+}
+
+nonisolated private final class CustomLLMPromptLookupDraftModel: Module, LanguageModel, @unchecked Sendable {
+    private let draftTokens: [Int]
+    private let maxSuffixTokens: Int
+    private let fallbackToken: Int
+    private let lock = NSLock()
+
+    private var vocabularySize: Int
+    private var observedTokens: [Int] = []
+    private var didConsumePrompt = false
+    private var proposedTokenCount = 0
+    private var longestMatchedSuffix = 0
+    private var logitsCache: [Int: MLXArray] = [:]
+
+    nonisolated init(draftTokens: [Int], maxSuffixTokens: Int) {
+        self.draftTokens = draftTokens
+        self.maxSuffixTokens = max(1, maxSuffixTokens)
+        self.vocabularySize = max(1, (draftTokens.max() ?? 0) + 1)
+        self.fallbackToken = draftTokens.first ?? 0
+        super.init()
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        let promptTokens = input.text.tokens.asArray(Int.self)
+        lock.lock()
+        vocabularySize = max(vocabularySize, (promptTokens.max() ?? 0) + 1)
+        observedTokens = []
+        didConsumePrompt = false
+        proposedTokenCount = 0
+        longestMatchedSuffix = 0
+        logitsCache.removeAll(keepingCapacity: true)
+        lock.unlock()
+        return .tokens(input.text)
+    }
+
+    func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?) -> LMOutput {
+        let inputTokens = input.tokens.asArray(Int.self)
+        lock.lock()
+        expandVocabularyIfNeeded(for: inputTokens)
+        if didConsumePrompt {
+            observedTokens.append(contentsOf: inputTokens)
+        } else {
+            didConsumePrompt = true
+        }
+        let nextToken = nextDraftToken(after: observedTokens)
+        let logitsVocabularySize = vocabularySize
+        proposedTokenCount += 1
+        let logits = cachedLogits(for: nextToken, vocabularySize: logitsVocabularySize)
+        lock.unlock()
+        return LMOutput(logits: logits)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        callAsFunction(LMInput.Text(tokens: inputs), cache: cache, state: nil).logits
+    }
+
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        []
+    }
+
+    func metricsSnapshot() -> CustomLLMPromptLookupMetrics {
+        lock.lock()
+        let metrics = CustomLLMPromptLookupMetrics(
+            draftTokenCount: draftTokens.count,
+            proposedTokenCount: proposedTokenCount,
+            longestMatchedSuffix: longestMatchedSuffix,
+            fallbackReason: nil
+        )
+        lock.unlock()
+        return metrics
+    }
+
+    private func nextDraftToken(after generatedTokens: [Int]) -> Int {
+        guard !draftTokens.isEmpty else { return fallbackToken }
+        guard !generatedTokens.isEmpty else { return draftTokens[0] }
+
+        let suffixLimit = min(maxSuffixTokens, generatedTokens.count, draftTokens.count)
+        if suffixLimit > 0 {
+            for suffixLength in stride(from: suffixLimit, through: 1, by: -1) {
+                let suffix = Array(generatedTokens.suffix(suffixLength))
+                guard let matchStart = lastIndex(of: suffix, in: draftTokens) else { continue }
+                let nextIndex = matchStart + suffixLength
+                guard nextIndex < draftTokens.count else { continue }
+                longestMatchedSuffix = max(longestMatchedSuffix, suffixLength)
+                return draftTokens[nextIndex]
+            }
+        }
+
+        let sequentialIndex = min(generatedTokens.count, draftTokens.count - 1)
+        return draftTokens[sequentialIndex]
+    }
+
+    private func lastIndex(of needle: [Int], in haystack: [Int]) -> Int? {
+        guard !needle.isEmpty, needle.count <= haystack.count else { return nil }
+        var index = haystack.count - needle.count
+        while index >= 0 {
+            if Array(haystack[index ..< index + needle.count]) == needle {
+                return index
+            }
+            index -= 1
+        }
+        return nil
+    }
+
+    private func expandVocabularyIfNeeded(for tokens: [Int]) {
+        let requiredSize = (tokens.max() ?? 0) + 1
+        guard requiredSize > vocabularySize else { return }
+        vocabularySize = requiredSize
+        logitsCache.removeAll(keepingCapacity: true)
+    }
+
+    private func cachedLogits(for token: Int, vocabularySize: Int) -> MLXArray {
+        let safeToken = max(0, min(token, vocabularySize - 1))
+        if let cached = logitsCache[safeToken] {
+            return cached
+        }
+        if logitsCache.count >= CustomLLMPromptLookupConfiguration.maximumLogitsCacheEntries {
+            logitsCache.removeAll(keepingCapacity: true)
+        }
+        let logits = logits(for: safeToken, vocabularySize: vocabularySize)
+        logitsCache[safeToken] = logits
+        return logits
+    }
+
+    private func logits(for token: Int, vocabularySize: Int) -> MLXArray {
+        var values = Array(repeating: Float32(-1_000_000), count: vocabularySize)
+        values[token] = 1_000_000
+        return MLXArray(values, [1, 1, vocabularySize])
     }
 }
 
@@ -439,13 +615,23 @@ class CustomLLMModelManager: ObservableObject {
             var aggregated = ""
             var firstChunkLatencyMs: Int?
             var completionInfo: GenerateCompletionInfo?
+            var promptLookupMetrics: CustomLLMPromptLookupMetrics?
             var repetitionStop: LLMOutputRepetition?
             let repetitionGuard = LLMOutputRepetitionGuard()
-            for try await event in session.streamDetails(
+            let promptLookupEventStream = try await promptLookupEventStreamIfEligible(
+                request: request,
+                container: container,
+                params: params,
+                behavior: behavior,
+                settings: settings
+            )
+            let eventStream = promptLookupEventStream?.stream ?? session.streamDetails(
                 to: request.prompt,
                 images: [],
                 videos: []
-            ) {
+            )
+
+            for try await event in eventStream {
                 switch event {
                 case .chunk(let chunk):
                     if firstChunkLatencyMs == nil, !chunk.isEmpty {
@@ -468,6 +654,9 @@ class CustomLLMModelManager: ObservableObject {
                     }
                 case .info(let info):
                     completionInfo = info
+                    if let metrics = promptLookupEventStream?.metrics.take() {
+                        promptLookupMetrics = metrics
+                    }
                 case .toolCall:
                     continue
                 }
@@ -538,6 +727,17 @@ class CustomLLMModelManager: ObservableObject {
                     "Custom LLM \(request.kind.logLabel) metrics. repo=\(request.repo), containerSource=\(containerSnapshot.source.rawValue), containerLoadMs=\(containerSnapshot.elapsedMs), setupMs=\(max(0, setupMs)), firstChunkMs=\(firstChunkText), overallFirstChunkMs=\(diagnostics.overallFirstChunkMs.map(String.init) ?? "n/a"), promptTokens=\(completionInfo.promptTokenCount), generationTokens=\(completionInfo.generationTokenCount), prefillMs=\(prefillMs), generationMs=\(generationMs), modelOverheadMs=\(modelOverheadMs), totalOverheadMs=\(totalOverheadMs), promptTPS=\(promptTPS), generationTPS=\(generationTPS), stopReason=\(completionInfo.stopReason)"
                 )
             }
+            if let promptLookupMetrics {
+                diagnostics.promptLookupDraftTokens = promptLookupMetrics.draftTokenCount
+                diagnostics.promptLookupProposedTokens = promptLookupMetrics.proposedTokenCount
+                diagnostics.promptLookupAcceptedTokens = nil
+                diagnostics.promptLookupAcceptanceRatio = nil
+                diagnostics.promptLookupFallbackReason = promptLookupMetrics.fallbackReason
+                let fallback = promptLookupMetrics.fallbackReason ?? "none"
+                VoxtLog.llm(
+                    "Custom LLM \(request.kind.logLabel) prompt lookup metrics. repo=\(request.repo), draftTokens=\(promptLookupMetrics.draftTokenCount), proposedTokens=\(promptLookupMetrics.proposedTokenCount), longestSuffix=\(promptLookupMetrics.longestMatchedSuffix), fallback=\(fallback)"
+                )
+            }
             lastRunDiagnostics = diagnostics
             VoxtLog.llm(
                 """
@@ -548,6 +748,185 @@ class CustomLLMModelManager: ObservableObject {
             )
             return cleaned.isEmpty ? request.resultFallback : cleaned
         }
+    }
+
+    private func promptLookupEventStreamIfEligible(
+        request: CustomLLMRequestPlan,
+        container: ModelContainer,
+        params: GenerateParameters,
+        behavior: CustomLLMModelBehavior,
+        settings: LLMGenerationSettings
+    ) async throws -> CustomLLMPromptLookupEventStream? {
+        guard generationTuning.promptLookupEnabledOverride != false else { return nil }
+        guard request.kind == .enhancement else { return nil }
+        guard let draftText = request.promptLookupDraftText?.trimmingCharacters(in: .whitespacesAndNewlines),
+              draftText.count >= CustomLLMPromptLookupConfiguration.minimumDraftCharacters
+        else {
+            return nil
+        }
+
+        let additionalContext = localThinkingAdditionalContext(
+            behavior: behavior,
+            settings: settings
+        )
+
+        let metricsBox = CustomLLMPromptLookupMetricsBox()
+        let stream: AsyncThrowingStream<Generation, Error> = AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let result = try await runPromptLookupGeneration(
+                        container: container,
+                        instructions: request.instructions,
+                        prompt: request.prompt,
+                        params: params,
+                        draftText: draftText,
+                        additionalContext: additionalContext
+                    )
+                    metricsBox.put(result.metrics)
+                    if !result.text.isEmpty {
+                        continuation.yield(.chunk(result.text))
+                    }
+                    continuation.yield(.info(result.info))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+        return CustomLLMPromptLookupEventStream(stream: stream, metrics: metricsBox)
+    }
+
+    private func runPromptLookupGeneration(
+        container: ModelContainer,
+        instructions: String,
+        prompt: String,
+        params: GenerateParameters,
+        draftText: String,
+        additionalContext: [String: any Sendable]?
+    ) async throws -> CustomLLMPromptLookupGenerationResult {
+        try await container.perform { context in
+            var messages: [Chat.Message] = []
+            let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedInstructions.isEmpty {
+                messages.append(.system(trimmedInstructions))
+            }
+            messages.append(.user(prompt))
+
+            let input = try await context.processor.prepare(
+                input: UserInput(
+                    chat: messages,
+                    additionalContext: additionalContext
+                )
+            )
+            let draftTokens = context.tokenizer.encode(text: draftText)
+            guard draftTokens.count >= CustomLLMPromptLookupConfiguration.minimumDraftTokens else {
+                let metrics = CustomLLMPromptLookupMetrics(
+                    draftTokenCount: draftTokens.count,
+                    proposedTokenCount: 0,
+                    longestMatchedSuffix: 0,
+                    fallbackReason: "draftTooShort"
+                )
+                return try await runStandardGenerationInContext(
+                    input: input,
+                    params: params,
+                    context: context,
+                    metrics: metrics
+                )
+            }
+
+            let draftModel = CustomLLMPromptLookupDraftModel(
+                draftTokens: draftTokens,
+                maxSuffixTokens: CustomLLMPromptLookupConfiguration.maxSuffixTokens
+            )
+            let stream: AsyncStream<Generation>
+            do {
+                stream = try MLXLMCommon.generate(
+                    input: input,
+                    parameters: params,
+                    context: context,
+                    draftModel: draftModel,
+                    numDraftTokens: CustomLLMPromptLookupConfiguration.numDraftTokens
+                )
+            } catch {
+                let snapshot = draftModel.metricsSnapshot()
+                let metrics = CustomLLMPromptLookupMetrics(
+                    draftTokenCount: snapshot.draftTokenCount,
+                    proposedTokenCount: snapshot.proposedTokenCount,
+                    longestMatchedSuffix: snapshot.longestMatchedSuffix,
+                    fallbackReason: "speculativeUnavailable"
+                )
+                return try await runStandardGenerationInContext(
+                    input: input,
+                    params: params,
+                    context: context,
+                    metrics: metrics
+                )
+            }
+            var text = ""
+            var info: GenerateCompletionInfo?
+            for await event in stream {
+                switch event {
+                case .chunk(let chunk):
+                    text += chunk
+                case .info(let completion):
+                    info = completion
+                case .toolCall:
+                    continue
+                }
+            }
+
+            return CustomLLMPromptLookupGenerationResult(
+                text: text,
+                info: info ?? GenerateCompletionInfo(
+                    promptTokenCount: input.text.tokens.size,
+                    generationTokenCount: 0,
+                    promptTime: 0,
+                    generationTime: 0,
+                    stopReason: .cancelled
+                ),
+                metrics: draftModel.metricsSnapshot()
+            )
+        }
+    }
+
+    private func runStandardGenerationInContext(
+        input: LMInput,
+        params: GenerateParameters,
+        context: ModelContext,
+        metrics: CustomLLMPromptLookupMetrics
+    ) async throws -> CustomLLMPromptLookupGenerationResult {
+        let stream = try MLXLMCommon.generate(
+            input: input,
+            parameters: params,
+            context: context
+        )
+        var text = ""
+        var info: GenerateCompletionInfo?
+        for await event in stream {
+            switch event {
+            case .chunk(let chunk):
+                text += chunk
+            case .info(let completion):
+                info = completion
+            case .toolCall:
+                continue
+            }
+        }
+        return CustomLLMPromptLookupGenerationResult(
+            text: text,
+            info: info ?? GenerateCompletionInfo(
+                promptTokenCount: input.text.tokens.size,
+                generationTokenCount: 0,
+                promptTime: 0,
+                generationTime: 0,
+                stopReason: .cancelled
+            ),
+            metrics: metrics
+        )
     }
 
     private func startLogMessage(

--- a/Voxt/Support/CustomLLMModelSupport.swift
+++ b/Voxt/Support/CustomLLMModelSupport.swift
@@ -240,6 +240,7 @@ struct CustomLLMRequestPlan: Equatable {
     let resultFallback: String
     let responseExtractionMode: CustomLLMResponseExtractionMode
     var promptLookupDraftText: String? = nil
+    var promptLookupSkipReason: String? = nil
 }
 
 enum CustomLLMResponseExtractionMode: Equatable {
@@ -248,6 +249,21 @@ enum CustomLLMResponseExtractionMode: Equatable {
 }
 
 enum CustomLLMRequestPlanBuilder {
+    private static func promptLookupDraftPlan(for input: String) -> (draftText: String?, skipReason: String?) {
+        switch TaskLLMStrategyResolver.promptLookupEligibility(
+            taskKind: .transcriptionEnhancement,
+            rawText: input
+        ) {
+        case .eligible:
+            return (
+                CustomLLMPromptLookupDraftBuilder.structuredResultTextDraft(from: input),
+                nil
+            )
+        case .ineligible(let reason):
+            return (nil, reason)
+        }
+    }
+
     static func compiled(
         request: LLMCompiledRequest,
         repo: String
@@ -278,6 +294,9 @@ enum CustomLLMRequestPlanBuilder {
                 content: request.prompt
             )
         )
+        let promptLookupPlan = kind == .enhancement
+            ? promptLookupDraftPlan(for: request.debugInput)
+            : (nil, "nonEnhancementTask")
 
         return CustomLLMRequestPlan(
             kind: kind,
@@ -290,9 +309,8 @@ enum CustomLLMRequestPlanBuilder {
             contentLogSections: sections,
             resultFallback: request.fallbackText,
             responseExtractionMode: .textResultPayloadOrNormalizedText,
-            promptLookupDraftText: kind == .enhancement
-                ? CustomLLMPromptLookupDraftBuilder.plainTextDraft(from: request.debugInput)
-                : nil
+            promptLookupDraftText: promptLookupPlan.draftText,
+            promptLookupSkipReason: kind == .enhancement ? promptLookupPlan.skipReason : nil
         )
     }
 
@@ -303,6 +321,7 @@ enum CustomLLMRequestPlanBuilder {
         resultFallback: String,
         structuredOutputPrompt: (String, String) -> String
     ) -> CustomLLMRequestPlan {
+        let promptLookupPlan = promptLookupDraftPlan(for: input)
         let prompt = structuredOutputPrompt(
             "Clean up this transcription while preserving meaning and style.",
             input
@@ -322,7 +341,8 @@ enum CustomLLMRequestPlanBuilder {
             ],
             resultFallback: resultFallback,
             responseExtractionMode: .textResultPayloadOrNormalizedText,
-            promptLookupDraftText: CustomLLMPromptLookupDraftBuilder.structuredResultTextDraft(from: input)
+            promptLookupDraftText: promptLookupPlan.draftText,
+            promptLookupSkipReason: promptLookupPlan.skipReason
         )
     }
 
@@ -496,6 +516,65 @@ enum CustomLLMPromptLookupDraftBuilder {
             return trimmed
         }
         return encoded
+    }
+}
+
+struct CustomLLMPromptLookupProposal: Equatable {
+    let startIndex: Int
+    let matchedSuffixLength: Int
+    let tokens: [Int]
+}
+
+nonisolated enum CustomLLMPromptLookupProposalBuilder {
+    static func proposal(
+        generatedTokens: [Int],
+        draftTokens: [Int],
+        maxSuffixTokens: Int,
+        maxDraftTokens: Int
+    ) -> CustomLLMPromptLookupProposal? {
+        guard !draftTokens.isEmpty, maxDraftTokens > 0 else { return nil }
+
+        if generatedTokens.isEmpty {
+            let tokens = Array(draftTokens.prefix(maxDraftTokens))
+            guard !tokens.isEmpty else { return nil }
+            return CustomLLMPromptLookupProposal(
+                startIndex: 0,
+                matchedSuffixLength: 0,
+                tokens: tokens
+            )
+        }
+
+        let suffixLimit = min(max(1, maxSuffixTokens), generatedTokens.count, draftTokens.count)
+        guard suffixLimit > 0 else { return nil }
+
+        for suffixLength in stride(from: suffixLimit, through: 1, by: -1) {
+            let suffix = Array(generatedTokens.suffix(suffixLength))
+            guard let matchStart = lastIndex(of: suffix, in: draftTokens) else { continue }
+            let proposalStart = matchStart + suffixLength
+            guard proposalStart < draftTokens.count else { continue }
+            let proposalEnd = min(draftTokens.count, proposalStart + maxDraftTokens)
+            let tokens = Array(draftTokens[proposalStart ..< proposalEnd])
+            guard !tokens.isEmpty else { continue }
+            return CustomLLMPromptLookupProposal(
+                startIndex: proposalStart,
+                matchedSuffixLength: suffixLength,
+                tokens: tokens
+            )
+        }
+
+        return nil
+    }
+
+    private static func lastIndex(of needle: [Int], in haystack: [Int]) -> Int? {
+        guard !needle.isEmpty, needle.count <= haystack.count else { return nil }
+        var index = haystack.count - needle.count
+        while index >= 0 {
+            if Array(haystack[index ..< index + needle.count]) == needle {
+                return index
+            }
+            index -= 1
+        }
+        return nil
     }
 }
 

--- a/Voxt/Support/CustomLLMModelSupport.swift
+++ b/Voxt/Support/CustomLLMModelSupport.swift
@@ -145,13 +145,29 @@ struct CustomLLMRunDiagnostics: Equatable {
     let generationMs: Int?
     let modelOverheadMs: Int?
     let totalOverheadMs: Int?
+    var promptLookupDraftTokens: Int? = nil
+    var promptLookupProposedTokens: Int? = nil
+    var promptLookupAcceptedTokens: Int? = nil
+    var promptLookupAcceptanceRatio: Double? = nil
+    var promptLookupFallbackReason: String? = nil
 }
 
 struct CustomLLMGenerationTuning: Equatable {
     let prefillStepSizeOverride: Int?
     let maxTokensOverride: Int?
+    let promptLookupEnabledOverride: Bool?
 
-    static let `default` = CustomLLMGenerationTuning(prefillStepSizeOverride: nil, maxTokensOverride: nil)
+    init(
+        prefillStepSizeOverride: Int? = nil,
+        maxTokensOverride: Int? = nil,
+        promptLookupEnabledOverride: Bool? = nil
+    ) {
+        self.prefillStepSizeOverride = prefillStepSizeOverride
+        self.maxTokensOverride = maxTokensOverride
+        self.promptLookupEnabledOverride = promptLookupEnabledOverride
+    }
+
+    static let `default` = CustomLLMGenerationTuning()
 }
 
 struct LLMOutputRepetition: Equatable {
@@ -223,6 +239,7 @@ struct CustomLLMRequestPlan: Equatable {
     let contentLogSections: [CustomLLMLogSection]
     let resultFallback: String
     let responseExtractionMode: CustomLLMResponseExtractionMode
+    var promptLookupDraftText: String? = nil
 }
 
 enum CustomLLMResponseExtractionMode: Equatable {
@@ -272,7 +289,10 @@ enum CustomLLMRequestPlanBuilder {
             logMode: usesUserMessageMode ? "userMessage" : nil,
             contentLogSections: sections,
             resultFallback: request.fallbackText,
-            responseExtractionMode: .textResultPayloadOrNormalizedText
+            responseExtractionMode: .textResultPayloadOrNormalizedText,
+            promptLookupDraftText: kind == .enhancement
+                ? CustomLLMPromptLookupDraftBuilder.plainTextDraft(from: request.debugInput)
+                : nil
         )
     }
 
@@ -301,7 +321,8 @@ enum CustomLLMRequestPlanBuilder {
                 CustomLLMLogSection(label: "request_content", content: prompt)
             ],
             resultFallback: resultFallback,
-            responseExtractionMode: .textResultPayloadOrNormalizedText
+            responseExtractionMode: .textResultPayloadOrNormalizedText,
+            promptLookupDraftText: CustomLLMPromptLookupDraftBuilder.structuredResultTextDraft(from: input)
         )
     }
 
@@ -457,6 +478,29 @@ enum CustomLLMRequestPlanBuilder {
             responseExtractionMode: .normalizedRawText
         )
     }
+}
+
+enum CustomLLMPromptLookupDraftBuilder {
+    static func plainTextDraft(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func structuredResultTextDraft(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let payload = CustomLLMStructuredResultTextDraft(resultText: trimmed)
+        guard let data = try? JSONEncoder().encode(payload),
+              let encoded = String(data: data, encoding: .utf8)
+        else {
+            return trimmed
+        }
+        return encoded
+    }
+}
+
+private struct CustomLLMStructuredResultTextDraft: Encodable {
+    let resultText: String
 }
 
 enum CustomLLMModelFamily: Equatable {

--- a/Voxt/Support/EnhancementStrategyResolver.swift
+++ b/Voxt/Support/EnhancementStrategyResolver.swift
@@ -27,6 +27,38 @@ enum TaskLLMContextBudgetPolicy: String, Equatable {
     case reducedForLongInput
 }
 
+enum TaskPromptLookupEligibility: Equatable {
+    case eligible
+    case ineligible(reason: String)
+
+    var isEligible: Bool {
+        switch self {
+        case .eligible:
+            return true
+        case .ineligible:
+            return false
+        }
+    }
+
+    var reason: String? {
+        switch self {
+        case .eligible:
+            return nil
+        case .ineligible(let reason):
+            return reason
+        }
+    }
+
+    var logLabel: String {
+        switch self {
+        case .eligible:
+            return "eligible"
+        case .ineligible(let reason):
+            return "ineligible:\(reason)"
+        }
+    }
+}
+
 struct LLMProviderModelCapabilities: Equatable {
     let maxContextTokens: Int?
     let maxOutputTokens: Int?
@@ -61,6 +93,7 @@ struct TaskLLMExecutionStrategy: Equatable {
     let outputTokenBudgetHint: Int?
     let segmentationCharacterLimit: Int?
     let truncationGuard: TaskLLMTruncationGuardPolicy
+    let promptLookupEligibility: TaskPromptLookupEligibility
 
     var logLabel: String {
         [
@@ -71,7 +104,8 @@ struct TaskLLMExecutionStrategy: Equatable {
             "contextBudget=\(contextBudgetPolicy.rawValue)",
             "outputBudgetHint=\(outputTokenBudgetHint.map(String.init) ?? "n/a")",
             "segmentLimit=\(segmentationCharacterLimit.map(String.init) ?? "n/a")",
-            "truncationGuard=\(truncationGuard.isEnabled)"
+            "truncationGuard=\(truncationGuard.isEnabled)",
+            "promptLookup=\(promptLookupEligibility.logLabel)"
         ].joined(separator: ",")
     }
 }
@@ -122,8 +156,43 @@ enum TaskLLMStrategyResolver {
             segmentationCharacterLimit: mode == .segmented ? max(longTextThreshold, 280) : nil,
             truncationGuard: isLongText
                 ? truncationGuardPolicy(for: taskKind)
-                : .disabled
+                : .disabled,
+            promptLookupEligibility: promptLookupEligibility(
+                taskKind: taskKind,
+                rawText: rawText
+            )
         )
+    }
+
+    static func promptLookupEligibility(
+        taskKind: TaskLLMKind,
+        rawText: String
+    ) -> TaskPromptLookupEligibility {
+        guard taskKind == .transcriptionEnhancement else {
+            return .ineligible(reason: "nonEnhancementTask")
+        }
+
+        let normalized = normalizedComparableText(rawText).lowercased()
+        guard !normalized.isEmpty else {
+            return .ineligible(reason: "emptyInput")
+        }
+
+        let orderedListSignalCount = orderedListSignalCount(in: normalized)
+        let sectionOutlineSignalCount = sectionOutlineSignalCount(in: normalized)
+        if orderedListSignalCount + sectionOutlineSignalCount >= 2 {
+            return .ineligible(reason: "structureSensitiveInput")
+        }
+
+        if denseEnumerationDelimiterCount(in: rawText) >= 4 {
+            return .ineligible(reason: "structureSensitiveInput")
+        }
+
+        if orderedListSignalCount >= 1,
+           normalized.contains("待办") || normalized.contains("todo") || normalized.contains("清单") {
+            return .ineligible(reason: "structureSensitiveInput")
+        }
+
+        return .eligible
     }
 
     static func applyTruncationGuard(
@@ -262,5 +331,43 @@ enum TaskLLMStrategyResolver {
         text
             .replacingOccurrences(of: "\\s+", with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func orderedListSignalCount(in text: String) -> Int {
+        let patterns = [
+            #"第[一二三四五六七八九十0-9]+[个项点部分]"#,
+            #"(?:^|[。；;!！?？\s])(第一|第二|第三|第四|第五|第六|第七|第八|第九|第十)(?:[，。；;:：\s]|$)"#,
+            #"(?:^|[\s,.，。;；:：])(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|finally|next)(?:[\s,.，。;；:：]|$)"#
+        ]
+        return patterns.reduce(into: 0) { total, pattern in
+            total += regexMatchCount(pattern, in: text)
+        }
+    }
+
+    private static func sectionOutlineSignalCount(in text: String) -> Int {
+        let patterns = [
+            #"分成[一二三四五六七八九十0-9]+(部分|块|项|点)"#,
+            #"有[一二三四五六七八九十0-9]+(个)?(待办|任务|问题|部分|步骤|项)"#,
+            #"(?:^|[。；;!！?？\s])(首先|其次|最后|一是|二是|三是|四是)(?:[，。；;:：\s]|$)"#
+        ]
+        return patterns.reduce(into: 0) { total, pattern in
+            total += regexMatchCount(pattern, in: text)
+        }
+    }
+
+    private static func regexMatchCount(_ pattern: String, in text: String) -> Int {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return 0
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.numberOfMatches(in: text, options: [], range: range)
+    }
+
+    private static func denseEnumerationDelimiterCount(in text: String) -> Int {
+        text.reduce(into: 0) { total, character in
+            if [",", "，", "、", ";", "；"].contains(character) {
+                total += 1
+            }
+        }
     }
 }

--- a/Voxt/Support/ProjectDictionaryScanner.swift
+++ b/Voxt/Support/ProjectDictionaryScanner.swift
@@ -5,7 +5,7 @@ struct ProjectDictionaryDiscovery: Equatable {
     let terms: [String]
 }
 
-enum ProjectDictionaryScanner {
+nonisolated enum ProjectDictionaryScanner {
     private static let contentCharacterLimit = 32_768
     private static let maxScannedFiles = 240
     private static let maxReturnedTerms = 64
@@ -230,12 +230,12 @@ enum ProjectDictionaryScanner {
     }
 }
 
-private extension String {
+nonisolated private extension String {
     var hasProjectDictionaryDecoration: Bool {
         contains(where: { $0.isUppercase || ProjectDictionaryScannerDecorations.characters.contains($0) })
     }
 }
 
-private enum ProjectDictionaryScannerDecorations {
+nonisolated private enum ProjectDictionaryScannerDecorations {
     static let characters = "._+-/"
 }

--- a/Voxt/Support/RemoteLLMRuntimeClient.swift
+++ b/Voxt/Support/RemoteLLMRuntimeClient.swift
@@ -1556,7 +1556,7 @@ struct RemoteLLMRuntimeClient {
         switch settings.thinking.mode {
         case .budget:
             guard let budget = settings.thinking.budgetTokens else { break }
-            var thinking: [String: Any] = [
+            let thinking: [String: Any] = [
                 "type": "enabled",
                 "budget_tokens": budget,
                 "display": "omitted"

--- a/Voxt/Support/RemoteProviderConnectivityTester.swift
+++ b/Voxt/Support/RemoteProviderConnectivityTester.swift
@@ -360,7 +360,7 @@ struct RemoteProviderConnectivityTester {
         token: String,
         model: String
     ) async throws -> String {
-        guard let url = URL(string: endpoint) else {
+        guard URL(string: endpoint) != nil else {
             throw NSError(
                 domain: "Voxt.Settings",
                 code: -22,

--- a/Voxt/Support/TranscriptSummarySupport.swift
+++ b/Voxt/Support/TranscriptSummarySupport.swift
@@ -59,7 +59,7 @@ struct TranscriptSummaryModelOption: Identifiable, Hashable, Sendable {
     let subtitle: String
 }
 
-enum TranscriptSummarySupport {
+nonisolated enum TranscriptSummarySupport {
     static let transcriptRecordTemplateVariable = "{{TRANSCRIPT_RECORD}}"
     static let promptTemplateVariables = [
         AppPreferenceKey.asrUserMainLanguageTemplateVariable,

--- a/Voxt/Support/VoxtLog.swift
+++ b/Voxt/Support/VoxtLog.swift
@@ -64,7 +64,7 @@ enum VoxtLog {
         }
     }
 
-    nonisolated static func latestLogExportPayload(limit: Int = 1000) -> ExportPayload {
+    static func latestLogExportPayload(limit: Int = 1000) -> ExportPayload {
         lock.lock()
         defer { lock.unlock() }
         loadCacheIfNeeded()
@@ -77,14 +77,14 @@ enum VoxtLog {
         return ExportPayload(filename: filename, content: content)
     }
 
-    nonisolated static func latestLogDisplayText(limit: Int = 1000) -> String {
+    static func latestLogDisplayText(limit: Int = 1000) -> String {
         lock.lock()
         defer { lock.unlock() }
         loadCacheIfNeeded()
         return composedLogContent(limit: limit)
     }
 
-    nonisolated static func exportLatestLogs(limit: Int = 1000) throws -> URL {
+    static func exportLatestLogs(limit: Int = 1000) throws -> URL {
         let payload = latestLogExportPayload(limit: limit)
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(payload.filename)
         try payload.content.write(to: url, atomically: true, encoding: .utf8)
@@ -167,7 +167,7 @@ enum VoxtLog {
         }
     }
 
-    private nonisolated static func composedLogContent(limit: Int) -> String {
+    private static func composedLogContent(limit: Int) -> String {
         let resolvedLimit = max(1, limit)
         let selectedLines = Array(logLines.suffix(resolvedLimit))
         let logText = selectedLines.isEmpty
@@ -180,7 +180,7 @@ enum VoxtLog {
         ].joined(separator: "\n\n")
     }
 
-    private nonisolated static func diagnosticsMetadataText(defaults: UserDefaults = .standard) -> String {
+    private static func diagnosticsMetadataText(defaults: UserDefaults = .standard) -> String {
         let featureSettings = FeatureSettingsStore.load(defaults: defaults)
         let proxySettings = VoxtNetworkSession.currentProxySettings
         let systemProxyStatus = VoxtNetworkSession.currentSystemProxyStatus
@@ -321,7 +321,7 @@ enum VoxtLog {
         return lines.joined(separator: "\n")
     }
 
-    private nonisolated static func bundleVersionText() -> String {
+    private static func bundleVersionText() -> String {
         let bundle = Bundle.main
         let shortVersion = (bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -339,7 +339,7 @@ enum VoxtLog {
         }
     }
 
-    private nonisolated static func machineSummary() -> String {
+    private static func machineSummary() -> String {
         let model = sysctlString(named: "hw.model")
         let machine = sysctlString(named: "hw.machine")
         if model == machine {
@@ -348,7 +348,7 @@ enum VoxtLog {
         return "\(model) / \(machine)"
     }
 
-    private nonisolated static func sysctlString(named name: String) -> String {
+    private static func sysctlString(named name: String) -> String {
         var size = 0
         guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else {
             return "unknown"
@@ -361,7 +361,7 @@ enum VoxtLog {
         return value.isEmpty ? "unknown" : value
     }
 
-    private nonisolated static func proxyRouteSummary(
+    private static func proxyRouteSummary(
         settings: VoxtNetworkSession.ProxySettings,
         systemStatus: VoxtNetworkSession.SystemProxyStatus
     ) -> String {
@@ -378,7 +378,7 @@ enum VoxtLog {
         }
     }
 
-    private nonisolated static func remoteASRConfigurationSummary(
+    private static func remoteASRConfigurationSummary(
         provider: RemoteASRProvider,
         configuration: RemoteProviderConfiguration
     ) -> String {
@@ -399,7 +399,7 @@ enum VoxtLog {
         return extras.joined(separator: ", ")
     }
 
-    private nonisolated static func remoteLLMConfigurationSummary(
+    private static func remoteLLMConfigurationSummary(
         provider: RemoteLLMProvider,
         configuration: RemoteProviderConfiguration
     ) -> String {
@@ -418,7 +418,7 @@ enum VoxtLog {
         return extras.joined(separator: ", ")
     }
 
-    private nonisolated static func aliyunASRRouteSummary(for model: String) -> String {
+    private static func aliyunASRRouteSummary(for model: String) -> String {
         if let kind = RemoteASREndpointSupport.aliyunQwenRealtimeSessionKind(for: model) {
             switch kind {
             case .qwenASR:
@@ -436,16 +436,16 @@ enum VoxtLog {
         return "unknown"
     }
 
-    private nonisolated static func resolvedProviderSummary(_ provider: RemoteLLMProvider?) -> String {
+    private static func resolvedProviderSummary(_ provider: RemoteLLMProvider?) -> String {
         guard let provider else { return "<unset>" }
         return "\(provider.rawValue) [\(provider.title)]"
     }
 
-    private nonisolated static func shortcutSummary(_ shortcut: FeatureShortcutSettings) -> String {
+    private static func shortcutSummary(_ shortcut: FeatureShortcutSettings) -> String {
         "keyCode=\(shortcut.keyCode), modifiers=\(shortcut.modifiers.rawValue), sidedModifiers=\(shortcut.sidedModifiers.rawValue)"
     }
 
-    private nonisolated static func nonEmptyOrPlaceholder(_ value: String?, placeholder: String = "<empty>") -> String {
+    private static func nonEmptyOrPlaceholder(_ value: String?, placeholder: String = "<empty>") -> String {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? placeholder : trimmed
     }

--- a/Voxt/Support/VoxtNetworkSession.swift
+++ b/Voxt/Support/VoxtNetworkSession.swift
@@ -3,7 +3,7 @@ import CFNetwork
 import Network
 import Darwin
 
-enum VoxtNetworkSession {
+nonisolated enum VoxtNetworkSession {
     private enum SecureField: String {
         case customProxyUsername
         case customProxyPassword

--- a/VoxtTests/EnhancementStrategyResolverTests.swift
+++ b/VoxtTests/EnhancementStrategyResolverTests.swift
@@ -16,6 +16,7 @@ final class EnhancementStrategyResolverTests: XCTestCase {
         XCTAssertEqual(strategy.contextBudgetPolicy, .standard)
         XCTAssertNil(strategy.outputTokenBudgetHint)
         XCTAssertFalse(strategy.truncationGuard.isEnabled)
+        XCTAssertTrue(strategy.promptLookupEligibility.isEligible)
     }
 
     func testLongTranslationWithTightModelLimitUsesSegmentedMode() {
@@ -46,6 +47,52 @@ final class EnhancementStrategyResolverTests: XCTestCase {
 
         XCTAssertEqual(strategy.mode, .singlePass)
         XCTAssertFalse(strategy.truncationGuard.isEnabled)
+        XCTAssertTrue(strategy.promptLookupEligibility.isEligible)
+    }
+
+    func testPromptLookupDisabledForSpokenOrderedListTranscription() {
+        let rawText = """
+        本周的项目进展分成四部分。第一，录音链路已经完成基本稳定性测试。第二，实时转写在短句场景下表现比较稳定，但是长句仍然需要继续观察。第三，增强模型的延迟主要集中在 prefill 和 generation 两个阶段。第四，我们需要用真实样本判断 prompt lookup decoding 是否值得默认开启。
+        """
+        let strategy = TaskLLMStrategyResolver.resolve(
+            taskKind: .transcriptionEnhancement,
+            rawText: rawText,
+            promptCharacterCount: 120,
+            baseGlossarySelectionPolicy: DictionaryGlossaryPurpose.enhancement.selectionPolicy,
+            capabilities: .unknown
+        )
+
+        XCTAssertEqual(strategy.promptLookupEligibility, .ineligible(reason: "structureSensitiveInput"))
+    }
+
+    func testPromptLookupRemainsEligibleForMixedLanguageCleanup() {
+        let rawText = """
+        我们今天要检查 Redis cache 的命中率，还有 Kubernetes pod 的重启次数。API endpoint 是 https://api.example.com/v1/transcriptions，记得不要改 JWT secret 和 DATABASE_URL。
+        """
+        let strategy = TaskLLMStrategyResolver.resolve(
+            taskKind: .transcriptionEnhancement,
+            rawText: rawText,
+            promptCharacterCount: 120,
+            baseGlossarySelectionPolicy: DictionaryGlossaryPurpose.enhancement.selectionPolicy,
+            capabilities: .unknown
+        )
+
+        XCTAssertTrue(strategy.promptLookupEligibility.isEligible)
+    }
+
+    func testPromptLookupDisabledForDenseEnumerationCleanup() {
+        let rawText = """
+        The main action item is to compare baseline generation with prompt lookup decoding on the same ASR transcripts. 我们需要记录 total elapsed milliseconds, prefill milliseconds, generation milliseconds, prompt tokens, completion tokens, draft tokens, proposed tokens, and fallback reason. 最后输出一个平均速度提升比例。
+        """
+        let strategy = TaskLLMStrategyResolver.resolve(
+            taskKind: .transcriptionEnhancement,
+            rawText: rawText,
+            promptCharacterCount: 120,
+            baseGlossarySelectionPolicy: DictionaryGlossaryPurpose.enhancement.selectionPolicy,
+            capabilities: .unknown
+        )
+
+        XCTAssertEqual(strategy.promptLookupEligibility, .ineligible(reason: "structureSensitiveInput"))
     }
 
     func testTruncationGuardFallsBackForPrefixLikeOutput() {

--- a/VoxtTests/MLXModelManagerTests.swift
+++ b/VoxtTests/MLXModelManagerTests.swift
@@ -458,6 +458,7 @@ final class MLXModelManagerTests: XCTestCase {
         XCTAssertNil(plan.logMode)
         XCTAssertEqual(plan.contentLogSections.map(\.label), ["system_prompt", "input", "request_content"])
         XCTAssertEqual(plan.contentLogSections.last?.content, "Clean up this transcription while preserving meaning and style.\nINPUT:hello world")
+        XCTAssertEqual(plan.promptLookupDraftText, #"{"resultText":"hello world"}"#)
     }
 
     func testCustomLLMRequestPlanBuilderBuildsUserPromptEnhancementRequest() {
@@ -472,6 +473,7 @@ final class MLXModelManagerTests: XCTestCase {
         XCTAssertEqual(plan.logMode, "userMessage")
         XCTAssertEqual(plan.contentLogSections.map(\.label), ["system_prompt", "input"])
         XCTAssertEqual(plan.contentLogSections.first?.content, "<empty>")
+        XCTAssertNil(plan.promptLookupDraftText)
     }
 
     func testCustomLLMRequestPlanBuilderBuildsTranslationRequest() {
@@ -488,6 +490,7 @@ final class MLXModelManagerTests: XCTestCase {
         XCTAssertEqual(plan.inputCharacterCount, 7)
         XCTAssertEqual(plan.contentLogSections.map(\.label), ["system_prompt", "input", "request_content"])
         XCTAssertEqual(plan.contentLogSections.last?.content, "Process the input according to the instructions. => bonjour")
+        XCTAssertNil(plan.promptLookupDraftText)
     }
 
     func testCustomLLMRequestPlanBuilderBuildsRewriteRequest() {
@@ -505,6 +508,7 @@ final class MLXModelManagerTests: XCTestCase {
         XCTAssertTrue(plan.prompt.contains("Produce the final text to insert according to the instructions."))
         XCTAssertTrue(plan.contentLogSections[1].content.contains("Spoken instruction:"))
         XCTAssertTrue(plan.contentLogSections[1].content.contains("Selected source text:"))
+        XCTAssertNil(plan.promptLookupDraftText)
     }
 
     func testCustomLLMCompiledPlanPreservesOutputTokenBudgetHint() {
@@ -527,6 +531,17 @@ final class MLXModelManagerTests: XCTestCase {
         )
 
         XCTAssertEqual(plan.maxTokensOverride, 321)
+        XCTAssertEqual(plan.promptLookupDraftText, "input")
+    }
+
+    func testCustomLLMPromptLookupDraftBuilderTrimsBlankInput() {
+        XCTAssertNil(CustomLLMPromptLookupDraftBuilder.plainTextDraft(from: " \n "))
+        XCTAssertEqual(CustomLLMPromptLookupDraftBuilder.plainTextDraft(from: " hello "), "hello")
+        XCTAssertNil(CustomLLMPromptLookupDraftBuilder.structuredResultTextDraft(from: "\t"))
+        XCTAssertEqual(
+            CustomLLMPromptLookupDraftBuilder.structuredResultTextDraft(from: " hello "),
+            #"{"resultText":"hello"}"#
+        )
     }
 
     func testCustomLLMNormalizeResultTextStripsThinkBlocksAndMarkers() {

--- a/VoxtTests/MLXModelManagerTests.swift
+++ b/VoxtTests/MLXModelManagerTests.swift
@@ -544,6 +544,53 @@ final class MLXModelManagerTests: XCTestCase {
         )
     }
 
+    func testCustomLLMPromptLookupProposalBuilderStartsFromDraftPrefix() {
+        let proposal = CustomLLMPromptLookupProposalBuilder.proposal(
+            generatedTokens: [],
+            draftTokens: [10, 11, 12, 13],
+            maxSuffixTokens: 16,
+            maxDraftTokens: 3
+        )
+
+        XCTAssertEqual(
+            proposal,
+            CustomLLMPromptLookupProposal(
+                startIndex: 0,
+                matchedSuffixLength: 0,
+                tokens: [10, 11, 12]
+            )
+        )
+    }
+
+    func testCustomLLMPromptLookupProposalBuilderUsesLongestRecentSuffix() {
+        let proposal = CustomLLMPromptLookupProposalBuilder.proposal(
+            generatedTokens: [90, 91, 92],
+            draftTokens: [10, 11, 90, 91, 92, 93, 94],
+            maxSuffixTokens: 16,
+            maxDraftTokens: 2
+        )
+
+        XCTAssertEqual(
+            proposal,
+            CustomLLMPromptLookupProposal(
+                startIndex: 5,
+                matchedSuffixLength: 3,
+                tokens: [93, 94]
+            )
+        )
+    }
+
+    func testCustomLLMPromptLookupProposalBuilderReturnsNilWhenNoMatchExists() {
+        let proposal = CustomLLMPromptLookupProposalBuilder.proposal(
+            generatedTokens: [50, 51],
+            draftTokens: [10, 11, 12, 13],
+            maxSuffixTokens: 16,
+            maxDraftTokens: 4
+        )
+
+        XCTAssertNil(proposal)
+    }
+
     func testCustomLLMNormalizeResultTextStripsThinkBlocksAndMarkers() {
         let output = """
         <think>

--- a/docs/PromptLookupDecodingPlan.md
+++ b/docs/PromptLookupDecodingPlan.md
@@ -1,0 +1,260 @@
+# Prompt Lookup Decoding Plan
+
+This document outlines a proposed local LLM acceleration strategy for Voxt's transcription refinement path.
+
+The feature is based on Prompt Lookup Decoding: use the original ASR transcript as a draft-token source while the main local LLM verifies and generates the final refined text.
+
+## Summary
+
+Voxt often uses a local Custom LLM after ASR to clean up transcription output. In conservative cleanup, the final text is usually very close to the raw ASR transcript. Prompt Lookup Decoding can exploit that overlap by proposing likely output tokens from the raw transcript and letting the main model verify them in batches.
+
+This should be treated as an internal local generation optimization, not as a separate user-facing feature. The intended behavior is unchanged output with lower local LLM latency.
+
+## Pipeline Timing
+
+The optimization happens after ASR and before final text delivery:
+
+```text
+recording stops
+-> ASR produces raw transcript
+-> enhancement prompt is resolved
+-> local Custom LLM request is built
+-> local LLM decodes final refined text
+   -> prompt lookup proposes draft tokens from the raw transcript
+   -> main model verifies accepted tokens
+-> final text is sanitized, delivered, and saved
+```
+
+It does not accelerate audio capture, ASR, remote network requests, Apple Intelligence, model loading, or prompt prefill. It only targets the local LLM token generation phase.
+
+## Current Voxt Entry Points
+
+The current local enhancement path is:
+
+1. `AppDelegate+TranscriptionFlow.swift`
+   - Resolves enhancement strategy and prompt.
+   - Builds the enhancement execution plan.
+2. `AppDelegate+LLMExecutionPlanning.swift`
+   - Dispatches `.customLLM(repo:)` plans to `CustomLLMModelManager.executeCompiledRequest(...)`.
+3. `CustomLLMModelManager.swift`
+   - `executeCompiledRequest(...)` converts `LLMCompiledRequest` into `CustomLLMRequestPlan`.
+   - `runLocalPromptRequest(...)` creates a `ChatSession`.
+   - `session.streamDetails(...)` performs normal MLX token generation.
+4. `CustomLLMModelSupport.swift`
+   - `CustomLLMRequestPlan` carries local request metadata.
+   - `CustomLLMRequestPlanBuilder.enhancement(...)` builds the transcription cleanup request.
+
+The proposed optimization belongs at step 3: the local token generation path.
+
+## Supported Scope
+
+Initial scope should be narrow.
+
+| Flow | Support | Reason |
+| --- | --- | --- |
+| Plain ASR transcription without LLM enhancement | No | There is no LLM decoding stage to accelerate. |
+| Local Custom LLM transcription enhancement | Yes | Output usually reuses most of the ASR transcript. |
+| Local Custom LLM selected-text rewrite | Later / conditional | Useful only for conservative polish, not open-ended rewriting. |
+| Local Custom LLM direct-answer rewrite | No | Output is not a transformation of source text. |
+| Translation | No by default | Output language differs, so draft-token acceptance is expected to be low. |
+| Remote LLM | No | Remote APIs do not expose token-level verification. |
+| Apple Intelligence | No | Voxt cannot control the decoding loop. |
+
+## Request Plan Changes
+
+Add an explicit optional draft source to local LLM requests:
+
+```swift
+struct CustomLLMRequestPlan {
+    ...
+    let promptLookupDraftText: String?
+}
+```
+
+Populate it only for local transcription enhancement in the first iteration:
+
+```swift
+CustomLLMRequestPlanBuilder.enhancement(
+    input: rawASRTranscript,
+    ...
+    promptLookupDraftText: rawASRTranscript
+)
+```
+
+Keep this field separate from `contentLogSections`, `debugInput`, and prompt content. The draft source is generation metadata, not instructions to the model.
+
+## Generation Strategy
+
+The clean long-term implementation is to add a Prompt Lookup Decoding path to the MLX generation layer.
+
+The iterator should:
+
+1. Tokenize the raw transcript into `draftTokens`.
+2. Maintain generated/accepted output tokens.
+3. Match the recent generated suffix inside `draftTokens`.
+4. Propose the next `N` draft tokens after the matched position.
+5. Run the main model once over the proposed tokens.
+6. Accept the matching prefix.
+7. Emit the first main-model token at the mismatch point.
+8. Rewind any rejected cache entries.
+9. Repeat until normal stop conditions are met.
+
+This mirrors speculative decoding, but the draft source is code plus prompt text rather than a smaller draft model.
+
+## Integration Options
+
+### Option A: Extend MLXLMCommon
+
+Add an upstream-style API to `mlx-swift-lm`:
+
+```swift
+generate(
+    input: LMInput,
+    parameters: GenerateParameters,
+    context: ModelContext,
+    promptLookupDraftTokens: [Int],
+    promptLookupConfig: PromptLookupDecodingConfig
+)
+```
+
+Then extend `ChatSession` or add a parallel stream API that accepts prompt lookup options.
+
+Benefits:
+- Keeps decoding logic in the model runtime layer.
+- Avoids duplicating tokenizer, cache, streaming, and metrics behavior in Voxt.
+- Easier to test independently against MLX token iterators.
+
+Costs:
+- Requires changes in the package dependency or a fork/tag.
+- Needs careful API design to avoid carrying Voxt-specific behavior upstream.
+
+### Option B: Add a Voxt-local Generation Path
+
+Bypass `ChatSession.streamDetails(...)` only when `promptLookupDraftText` is present:
+
+1. Prepare chat input using the same model processor.
+2. Create the model cache.
+3. Run a Voxt-owned prompt lookup iterator.
+4. Decode chunks with the tokenizer.
+5. Preserve existing streaming, repetition guard, diagnostics, and output sanitizer behavior.
+
+Benefits:
+- More contained to Voxt.
+- Can be prototyped without waiting on upstream API shape.
+
+Costs:
+- Duplicates parts of `ChatSession`.
+- Higher maintenance risk when `mlx-swift-lm` changes.
+- Easy to diverge from existing tool-call or chat-template behavior.
+
+Recommendation: prefer Option A for the final implementation. Use Option B only for a short-lived prototype if we need real latency data before committing to a package-level change.
+
+## Configuration
+
+Do not expose this as a primary user-facing feature at first.
+
+Recommended initial behavior:
+
+- Enabled only for local Custom LLM transcription enhancement.
+- Disabled for translation, direct-answer rewrite, and remote providers.
+- Hidden behind an internal preference or debug flag until metrics are stable.
+- Automatically bypassed for very short inputs where matching overhead may exceed benefit.
+
+Potential internal gate:
+
+```text
+provider == customLLM
+task == enhancement
+rawTranscriptCharacterCount >= 80
+promptLookupAccelerationEnabled == true
+```
+
+## Metrics
+
+Add diagnostics before enabling broadly:
+
+| Metric | Purpose |
+| --- | --- |
+| `promptLookupDraftTokens` | Size of draft-token source. |
+| `promptLookupProposedTokens` | Total candidate tokens proposed. |
+| `promptLookupAcceptedTokens` | Tokens accepted without normal single-token generation. |
+| `promptLookupAcceptanceRatio` | Main success signal. |
+| `firstChunkMs` | Ensure first visible output does not regress badly. |
+| `generationMs` | Main expected improvement target. |
+| `totalElapsedMs` | End-to-end local LLM impact. |
+| `fallbackToNormalDecoding` | Detect unsupported or low-value paths. |
+
+Expected useful thresholds:
+
+- `acceptanceRatio >= 0.60`: likely worth enabling for that path.
+- `acceptanceRatio < 0.30`: likely not worth using.
+- Short inputs may show low or no total latency gain even with good acceptance.
+
+## Expected Impact
+
+The optimization only affects local LLM generation time. It should not be expected to improve cold model load, ASR, remote LLM latency, or prompt prefill.
+
+Estimated impact for local Custom LLM enhancement:
+
+| Scenario | Expected Result |
+| --- | --- |
+| Short input under 80 characters | 0-10% total improvement, possibly no benefit. |
+| 100-500 character conservative cleanup | 10-30% local LLM total improvement. |
+| Long conservative cleanup with high overlap | 25-50% generation-phase improvement, 15-40% local LLM total improvement. |
+| Rewrite/translation/open generation | Low or negative benefit. |
+
+These estimates need validation with real app logs and local smoke runs.
+
+## Risks
+
+- Low acceptance ratio can add overhead.
+- Cache rewind behavior must be correct, or generated text can drift.
+- Tokenizer-specific behavior matters; character-level similarity does not guarantee token-level acceptance.
+- Structured JSON extraction paths must continue to work.
+- Streaming previews should not flicker or regress.
+- Repetition guard and output sanitization must stay in place.
+- Any package-level changes need a clear dependency policy, preferably upstream-friendly.
+
+## Test Plan
+
+Unit-level tests:
+
+- Request plan builder populates draft source only for enhancement.
+- Prompt lookup matching finds suffixes and proposes expected token windows.
+- Low-match and empty-input cases fall back to normal decoding.
+- Metrics calculate proposed, accepted, and ratio correctly.
+
+Runtime/local tests:
+
+- Existing core prompt/runtime suites from `docs/LocalRegressionMatrix.md`.
+- Local LLM smoke for transcription enhancement with and without prompt lookup.
+- Manual app runs comparing:
+  - raw ASR text
+  - final enhanced text
+  - generation latency
+  - acceptance ratio
+  - first chunk latency
+
+Regression acceptance:
+
+- Output should remain semantically equivalent to normal decoding.
+- If outputs differ, differences should be no worse than normal sampling variance at the configured temperature.
+- For deterministic local settings, compare sanitized final output against baseline fixtures where feasible.
+
+## Rollout Plan
+
+1. Add metrics-only scaffolding and draft-source plumbing.
+2. Prototype prompt lookup decoding in a local branch.
+3. Run local smoke tests on representative English and Chinese transcripts.
+4. Compare normal decoding vs prompt lookup decoding.
+5. Enable internally for local Custom LLM transcription enhancement when acceptance ratio is strong.
+6. Decide whether to upstream or fork/tag the MLX runtime change.
+7. Consider selected-text rewrite only after enhancement proves reliable.
+
+## Open Questions
+
+- Should this live upstream in `mlx-swift-lm`, or as a Voxt-maintained fork patch?
+- What minimum input length should enable prompt lookup?
+- What draft window size gives the best latency tradeoff on Apple Silicon?
+- Should the optimization auto-disable per repo if recent acceptance ratio is low?
+- How should metrics be surfaced in existing session timing summaries?

--- a/docs/PromptLookupDecodingPlan.zh-CN.md
+++ b/docs/PromptLookupDecodingPlan.zh-CN.md
@@ -1,0 +1,340 @@
+# Prompt Lookup Decoding 实现方案
+
+本文档描述 Voxt 针对本地 LLM 转写润色链路的一个性能优化方案。
+
+核心思路是：在 ASR 得到原始转写文本后，如果后续需要用本地 Custom LLM 做保守润色，可以把原始 ASR 文本作为草稿 token 来源，让主模型在生成最终润色文本时批量验证这些候选 token，从而减少逐 token 生成的开销。
+
+这个能力应当作为本地 LLM 的内部加速策略，而不是一个独立的用户功能。目标是不改变最终输出语义，只降低本地 LLM 生成延迟。
+
+## 一句话结论
+
+第一版建议只做：
+
+```text
+Local Custom LLM + transcription enhancement
+```
+
+也就是只优化“本地 LLM 转写增强 / 润色”这一条路径。
+
+暂不建议用于：
+
+- 纯 ASR 转录
+- 远程 LLM
+- Apple Intelligence
+- 翻译
+- 无选中文本的开放式 rewrite / direct answer
+- 大幅改写类 rewrite
+
+## 生效时间点
+
+这个优化发生在 ASR 之后、最终文本交付之前，具体是在本地 LLM 解码生成 token 的阶段。
+
+```text
+录音结束
+-> ASR 生成原始转写文本
+-> 解析 enhancement prompt / app enhancement / 词典上下文
+-> 构建本地 Custom LLM 请求
+-> 本地 LLM 生成最终润色文本
+   -> 从原始 ASR 文本中查找候选 draft tokens
+   -> 主模型批量验证候选 tokens
+   -> 匹配的 token 直接接受
+   -> 不匹配时回退到主模型正常生成
+-> 清理模型输出
+-> 粘贴 / 展示 / 写入历史
+```
+
+它不会优化：
+
+- 录音采集耗时
+- ASR 推理耗时
+- 远程 API 请求耗时
+- Apple Intelligence 调用耗时
+- 本地模型冷启动 / 加载耗时
+- prompt prefill 耗时
+
+它只优化本地 LLM 的 generation 阶段。
+
+## 当前代码链路
+
+当前本地转写增强的大致链路是：
+
+1. `AppDelegate+TranscriptionFlow.swift`
+   - ASR 完成后进入 enhancement 流程。
+   - 解析 enhancement 策略和 prompt。
+   - 构建 `LLMExecutionPlan`。
+2. `AppDelegate+LLMExecutionPlanning.swift`
+   - 根据 provider 分发执行。
+   - `.customLLM(repo:)` 会进入 `CustomLLMModelManager.executeCompiledRequest(...)`。
+3. `CustomLLMModelManager.swift`
+   - `executeCompiledRequest(...)` 把 `LLMCompiledRequest` 转成 `CustomLLMRequestPlan`。
+   - `runLocalPromptRequest(...)` 创建 `ChatSession`。
+   - `session.streamDetails(...)` 执行当前普通 MLX 流式生成。
+4. `CustomLLMModelSupport.swift`
+   - `CustomLLMRequestPlan` 承载本地 LLM 请求信息。
+   - `CustomLLMRequestPlanBuilder.enhancement(...)` 构建转写清理请求。
+
+因此，Prompt Lookup Decoding 的实现落点不在 UI，也不在 prompt builder，而是在本地 LLM 最终 token generation 这一层。
+
+## 支持范围
+
+| 功能 | 第一版是否支持 | 原因 |
+| --- | --- | --- |
+| 纯 ASR 转录 | 不支持 | 没有 LLM 生成阶段，无法应用该优化。 |
+| 本地 Custom LLM 转写增强 | 支持 | 最终文本通常大量复用原始 ASR 文本，命中率最高。 |
+| 本地 Custom LLM 选中文本 rewrite | 后续评估 | 只适合“润色 / 修正 / 改语气”这种保守改写。 |
+| 本地 Custom LLM direct answer | 不支持 | 输出不是输入文本的轻微变体。 |
+| 翻译 | 默认不支持 | 输出语言变化，draft token 命中率预计较低。 |
+| 远程 LLM | 不支持 | 远程 API 不开放 token 级解码控制。 |
+| Apple Intelligence | 不支持 | Voxt 无法控制底层生成循环。 |
+
+## 请求结构调整
+
+建议给本地 LLM 请求计划增加一个显式的可选草稿来源：
+
+```swift
+struct CustomLLMRequestPlan {
+    ...
+    let promptLookupDraftText: String?
+}
+```
+
+第一版只在 enhancement builder 中设置：
+
+```swift
+CustomLLMRequestPlanBuilder.enhancement(
+    input: rawASRTranscript,
+    ...
+    promptLookupDraftText: rawASRTranscript
+)
+```
+
+注意：`promptLookupDraftText` 不应该混进 prompt 文本，也不应该复用日志字段。它是生成阶段的元数据，不是给模型看的指令。
+
+这样可以保持几个概念清晰分离：
+
+- `prompt`: 模型实际看到的用户请求
+- `instructions`: system prompt / app enhancement / 规则
+- `contentLogSections`: 调试日志
+- `promptLookupDraftText`: 解码阶段用的草稿来源
+
+## 解码算法
+
+Prompt Lookup Decoding 可以理解成“不使用 draft model 的 speculative decoding”。
+
+普通 speculative decoding 是：
+
+```text
+小模型先猜 N 个 token
+-> 大模型批量验证
+-> 猜对就接受
+-> 猜错就回退到大模型 token
+```
+
+Prompt Lookup Decoding 是：
+
+```text
+代码从原始 ASR 文本中查找 N 个候选 token
+-> 主模型批量验证
+-> 匹配就接受
+-> 不匹配就回退到主模型 token
+```
+
+建议的 iterator 逻辑：
+
+1. 把原始 ASR 文本 tokenize 成 `draftTokens`。
+2. 维护已经生成并接受的输出 tokens。
+3. 取最近一段输出 token 后缀。
+4. 在 `draftTokens` 中查找这个后缀。
+5. 如果找到，取后面的 `N` 个 token 作为候选。
+6. 主模型一次性验证这批候选 tokens。
+7. 从头接受连续匹配的 tokens。
+8. 第一个不匹配的位置使用主模型自己的 token。
+9. 回滚 rejected tokens 对应的 KV cache。
+10. 重复直到达到 stop / max token 条件。
+
+关键点是：输出仍然由主模型验证，draft tokens 只是候选，不是直接强行复制。
+
+## 实现路径
+
+### 方案 A：扩展 MLXLMCommon
+
+在 `mlx-swift-lm` 中增加 Prompt Lookup Decoding 能力，例如：
+
+```swift
+generate(
+    input: LMInput,
+    parameters: GenerateParameters,
+    context: ModelContext,
+    promptLookupDraftTokens: [Int],
+    promptLookupConfig: PromptLookupDecodingConfig
+)
+```
+
+同时扩展 `ChatSession` 或提供一个并行的 stream API，让 Voxt 可以在保持现有 chat-template、tokenizer、KV cache、streaming 逻辑的基础上启用 prompt lookup。
+
+优点：
+
+- 解码逻辑放在模型运行时层，边界最清楚。
+- 不需要在 Voxt 里复制 `ChatSession` 的内部逻辑。
+- 更容易在 MLX 层做独立测试。
+- 后续也可能对其他使用 `mlx-swift-lm` 的项目有价值。
+
+缺点：
+
+- 需要改 package 依赖，可能要 fork/tag 或推动 upstream。
+- API 需要设计得通用，不能太 Voxt 特化。
+
+### 方案 B：Voxt 本地实现一条专用生成路径
+
+当 `promptLookupDraftText` 存在时，不走 `session.streamDetails(...)`，而是在 Voxt 里直接调用更底层的 MLX processor / tokenizer / model / cache，运行自定义 prompt lookup iterator。
+
+大致步骤：
+
+1. 用当前 model processor 准备 chat input。
+2. 创建 KV cache。
+3. 用 Voxt 自己的 prompt lookup iterator 生成 token。
+4. 用 tokenizer 解码成 streaming chunks。
+5. 保留现有 repetition guard、output sanitizer、diagnostics、partial preview。
+
+优点：
+
+- 不需要马上改上游包。
+- 可以较快做出原型验证真实收益。
+
+缺点：
+
+- 容易复制 `ChatSession` 内部逻辑。
+- 后续 `mlx-swift-lm` 更新时维护成本更高。
+- 可能遗漏 tool call、chat-template、additionalContext、streaming 细节。
+
+推荐：最终实现优先选方案 A。方案 B 只适合作为短期原型，用来先采集真实延迟和命中率数据。
+
+## 配置策略
+
+第一版不建议放到普通设置页。
+
+建议初始策略：
+
+- 只对本地 Custom LLM 的 transcription enhancement 生效。
+- 对 translation、direct-answer rewrite、remote provider、Apple Intelligence 默认关闭。
+- 可以先放在内部 debug flag 或隐藏偏好里。
+- 输入过短时自动跳过，因为查找和验证开销可能大于收益。
+
+建议 gate：
+
+```text
+provider == customLLM
+task == enhancement
+rawTranscriptCharacterCount >= 80
+promptLookupAccelerationEnabled == true
+```
+
+后续可以根据真实命中率做自适应：
+
+```text
+recentAcceptanceRatio < 0.30 -> 自动关闭
+recentAcceptanceRatio >= 0.60 -> 保持启用
+```
+
+## 指标设计
+
+启用前必须先加指标，否则无法判断是否真的变快。
+
+| 指标 | 用途 |
+| --- | --- |
+| `promptLookupDraftTokens` | 原始 ASR 草稿 token 数。 |
+| `promptLookupProposedTokens` | 总共提议了多少候选 tokens。 |
+| `promptLookupAcceptedTokens` | 被主模型接受的候选 tokens。 |
+| `promptLookupAcceptanceRatio` | 核心收益指标。 |
+| `firstChunkMs` | 检查首个可见输出是否变慢。 |
+| `generationMs` | 主要预期优化目标。 |
+| `totalElapsedMs` | 本地 LLM 总耗时。 |
+| `fallbackToNormalDecoding` | 记录何时回退普通解码。 |
+
+判断阈值建议：
+
+- `acceptanceRatio >= 0.60`：通常值得启用。
+- `acceptanceRatio < 0.30`：大概率收益有限，应该关闭或回退。
+- 短文本即使命中率高，总耗时也可能无明显改善。
+
+## 预期收益
+
+这个优化只影响本地 LLM generation 阶段，所以端到端收益取决于 generation 在整条链路中的占比。
+
+| 场景 | 预期收益 |
+| --- | --- |
+| 80 字以内短文本 | 0-10%，可能无感。 |
+| 100-500 字保守转写润色 | 本地 LLM 总耗时降低 10-30%。 |
+| 500+ 字长文本，且输出高度复用原文 | generation 阶段降低 25-50%，本地 LLM 总耗时降低 15-40%。 |
+| 翻译 / 开放式 rewrite | 低收益或负收益。 |
+
+更现实的目标：
+
+- `generationMs` 降低 25-40%
+- `totalElapsedMs` 降低 10-25%
+- `firstChunkMs` 不一定改善，甚至可能略微变差
+
+是否值得做，最终要看真实 app 日志里的 `promptLookupAcceptanceRatio`。
+
+## 风险
+
+- 命中率低时会增加额外开销。
+- KV cache 回滚必须正确，否则输出可能漂移。
+- 字符串相似不代表 token 相似，tokenizer 会影响命中率。
+- JSON 结构化输出提取不能被破坏。
+- partial preview 不能出现明显闪烁或倒退。
+- repetition guard 和 output sanitizer 必须保留。
+- 如果改 `mlx-swift-lm`，需要明确依赖策略，避免长期维护重 fork。
+
+## 测试计划
+
+单元测试：
+
+- enhancement request plan 只在合适场景填充 draft source。
+- translation / direct answer / remote path 不填充 draft source。
+- prompt lookup suffix matching 能找到预期 token 窗口。
+- 空输入、短输入、低命中率时能回退普通解码。
+- proposed / accepted / ratio 指标计算正确。
+
+本地运行测试：
+
+- `docs/LocalRegressionMatrix.md` 中的 core prompt/runtime suites。
+- Local LLM smoke，对比开启和关闭 prompt lookup。
+- 英文、中文转写样本各跑一组。
+- 长文本和短文本分开统计。
+
+手动验证：
+
+- 原始 ASR 文本
+- 普通 LLM 润色结果
+- Prompt Lookup LLM 润色结果
+- `generationMs`
+- `firstChunkMs`
+- `totalElapsedMs`
+- `acceptanceRatio`
+
+验收标准：
+
+- 输出语义不应比普通生成更差。
+- 在确定性设置下，尽量和 baseline 输出保持一致。
+- 在非确定性采样下，差异不应超过正常采样波动。
+- 只有在真实日志显示稳定收益后才默认启用。
+
+## 分阶段计划
+
+1. 先加 request plan 字段和指标 scaffolding，但不改变生成行为。
+2. 做 prompt lookup iterator 原型。
+3. 用真实本地 LLM enhancement 样本跑 A/B 对比。
+4. 根据 acceptance ratio 和 latency 判断是否继续。
+5. 若收益稳定，决定把实现放进 `mlx-swift-lm` upstream/fork，还是保留 Voxt 本地路径。
+6. 第一版只启用本地 Custom LLM transcription enhancement。
+7. 后续再评估 selected-text rewrite 的保守润色场景。
+
+## 仍需确认的问题
+
+- 实现应该进入 upstream `mlx-swift-lm`，还是 Voxt fork/tag？
+- 最小输入长度应该是多少？
+- 每轮 draft window size 设为多少最合适？
+- 是否按模型 repo 记录近期命中率并自动开关？
+- 指标是否并入现有 session timing summary？
+- 对中文、英文、混合语言文本的 token 命中率是否有明显差异？

--- a/tools/benchmark_prompt_lookup.py
+++ b/tools/benchmark_prompt_lookup.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CASES = ROOT / "tools" / "prompt_lookup_benchmark_cases.json"
+
+
+def run(command, *, env=None, cwd=ROOT, check=True):
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if check and result.returncode != 0:
+        tail = "\n".join(result.stdout.splitlines()[-80:])
+        raise RuntimeError(f"Command failed: {' '.join(command)}\n{tail}")
+    return result
+
+
+def build_app(configuration):
+    run([
+        "xcodebuild",
+        "build",
+        "-project",
+        "Voxt.xcodeproj",
+        "-scheme",
+        "Voxt",
+        "-configuration",
+        configuration,
+        "-destination",
+        "platform=macOS",
+        "CODE_SIGNING_ALLOWED=NO",
+    ])
+
+
+def resolve_app_binary(configuration):
+    result = run([
+        "xcodebuild",
+        "-showBuildSettings",
+        "-json",
+        "-project",
+        "Voxt.xcodeproj",
+        "-scheme",
+        "Voxt",
+        "-configuration",
+        configuration,
+        "-destination",
+        "platform=macOS",
+        "CODE_SIGNING_ALLOWED=NO",
+    ])
+    json_start = result.stdout.find("[")
+    if json_start < 0:
+        raise RuntimeError("xcodebuild did not return JSON build settings.")
+    settings_sets = json.loads(result.stdout[json_start:])
+    settings = None
+    for candidate in settings_sets:
+        if candidate.get("target") == "Voxt":
+            settings = candidate.get("buildSettings", {})
+            break
+    if settings is None:
+        settings = settings_sets[0].get("buildSettings", {})
+    executable_path = settings.get("EXECUTABLE_PATH")
+    target_build_dir = settings.get("TARGET_BUILD_DIR")
+    if not executable_path or not target_build_dir:
+        raise RuntimeError("Unable to resolve built app executable path from xcodebuild settings.")
+    return Path(target_build_dir) / executable_path
+
+
+def parse_metric(output, name):
+    matches = re.findall(rf"{re.escape(name)}=([^\s]+)", output)
+    if not matches:
+        return None
+    value = matches[-1]
+    if value == "n/a":
+        return None
+    if value.isdigit():
+        return int(value)
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def parse_smoke_output(output):
+    metric = {
+        "avgElapsedMs": parse_metric(output, "avgElapsedMs"),
+        "hotAvgElapsedMs": parse_metric(output, "hotAvgElapsedMs"),
+        "avgPrefillMs": parse_metric(output, "avgPrefillMs"),
+        "hotAvgPrefillMs": parse_metric(output, "hotAvgPrefillMs"),
+        "avgGenerationMs": parse_metric(output, "avgGenerationMs"),
+        "hotAvgGenerationMs": parse_metric(output, "hotAvgGenerationMs"),
+        "avgPromptTokens": parse_metric(output, "avgPromptTokens"),
+        "avgCompletionTokens": parse_metric(output, "avgCompletionTokens"),
+        "avgPromptLookupDraftTokens": parse_metric(output, "avgPromptLookupDraftTokens"),
+        "avgPromptLookupProposedTokens": parse_metric(output, "avgPromptLookupProposedTokens"),
+        "promptLookupFallback": parse_metric(output, "promptLookupFallback"),
+    }
+    elapsed = metric["hotAvgElapsedMs"] or metric["avgElapsedMs"]
+    metric["elapsedMs"] = elapsed
+    return metric
+
+
+def run_smoke(binary, case, *, repo, iterations, prompt_lookup, prefill_step):
+    env = os.environ.copy()
+    env.update({
+        "VOXT_LLM_SMOKE_TASK": "enhancement",
+        "VOXT_LLM_SMOKE_ENHANCEMENT_TEXT": case["text"],
+        "VOXT_LLM_SMOKE_LOCAL_REPO": repo,
+        "VOXT_LLM_SMOKE_ITERATIONS": str(iterations),
+        "VOXT_LLM_SMOKE_PREWARM": "1",
+        "VOXT_LLM_SMOKE_PROMPT_LOOKUP": "1" if prompt_lookup else "0",
+    })
+    if prefill_step is not None:
+        env["VOXT_LLM_SMOKE_PREFILL_STEP"] = str(prefill_step)
+    result = run([str(binary)], env=env, check=False)
+    if result.returncode != 0:
+        tail = "\n".join(result.stdout.splitlines()[-80:])
+        raise RuntimeError(f"Smoke run failed for {case['id']} prompt_lookup={prompt_lookup}\n{tail}")
+    return parse_smoke_output(result.stdout)
+
+
+def load_cases(path, limit):
+    with path.open("r", encoding="utf-8") as handle:
+        cases = json.load(handle)
+    if limit is not None:
+        cases = cases[:limit]
+    for case in cases:
+        if not case.get("id") or not case.get("text"):
+            raise RuntimeError(f"Invalid benchmark case: {case}")
+    return cases
+
+
+def percent_delta(baseline, candidate):
+    if not baseline or not candidate:
+        return None
+    return ((baseline - candidate) / baseline) * 100.0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark Voxt custom LLM prompt lookup decoding.")
+    parser.add_argument("--cases", type=Path, default=DEFAULT_CASES)
+    parser.add_argument("--repo", default="mlx-community/gemma-4-e2b-it-4bit")
+    parser.add_argument("--configuration", default="Debug")
+    parser.add_argument("--iterations", type=int, default=2)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--prefill-step", type=int)
+    parser.add_argument("--app-binary", type=Path)
+    parser.add_argument("--no-build", action="store_true")
+    parser.add_argument("--csv", type=Path)
+    args = parser.parse_args()
+
+    cases = load_cases(args.cases, args.limit)
+    if args.app_binary:
+        binary = args.app_binary
+    else:
+        if not args.no_build:
+            build_app(args.configuration)
+        binary = resolve_app_binary(args.configuration)
+    if not binary.exists():
+        raise RuntimeError(f"Built app binary does not exist: {binary}")
+
+    csv_path = args.csv or (ROOT / "tmp" / f"prompt_lookup_benchmark_{int(time.time())}.csv")
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    print(f"binary={binary}")
+    print(f"repo={args.repo} cases={len(cases)} iterations={args.iterations}")
+    print("case,chars,off_ms,on_ms,speedup_pct,on_draft_tokens,on_proposed_tokens,on_fallback")
+
+    for case in cases:
+        off = run_smoke(
+            binary,
+            case,
+            repo=args.repo,
+            iterations=args.iterations,
+            prompt_lookup=False,
+            prefill_step=args.prefill_step,
+        )
+        on = run_smoke(
+            binary,
+            case,
+            repo=args.repo,
+            iterations=args.iterations,
+            prompt_lookup=True,
+            prefill_step=args.prefill_step,
+        )
+        speedup = percent_delta(off["elapsedMs"], on["elapsedMs"])
+        row = {
+            "id": case["id"],
+            "origin": case.get("origin", ""),
+            "chars": len(case["text"]),
+            "off_elapsed_ms": off["elapsedMs"],
+            "on_elapsed_ms": on["elapsedMs"],
+            "speedup_pct": None if speedup is None else round(speedup, 2),
+            "off_prefill_ms": off["hotAvgPrefillMs"] or off["avgPrefillMs"],
+            "on_prefill_ms": on["hotAvgPrefillMs"] or on["avgPrefillMs"],
+            "off_generation_ms": off["hotAvgGenerationMs"] or off["avgGenerationMs"],
+            "on_generation_ms": on["hotAvgGenerationMs"] or on["avgGenerationMs"],
+            "on_draft_tokens": on["avgPromptLookupDraftTokens"],
+            "on_proposed_tokens": on["avgPromptLookupProposedTokens"],
+            "on_fallback": on["promptLookupFallback"] or "",
+        }
+        rows.append(row)
+        speedup_text = "n/a" if speedup is None else f"{speedup:.2f}"
+        print(
+            f"{row['id']},{row['chars']},{row['off_elapsed_ms']},"
+            f"{row['on_elapsed_ms']},{speedup_text},{row['on_draft_tokens']},"
+            f"{row['on_proposed_tokens']},{row['on_fallback']}"
+        )
+
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    valid = [row for row in rows if row["off_elapsed_ms"] and row["on_elapsed_ms"]]
+    if valid:
+        avg_off = sum(row["off_elapsed_ms"] for row in valid) / len(valid)
+        avg_on = sum(row["on_elapsed_ms"] for row in valid) / len(valid)
+        avg_speedup = percent_delta(avg_off, avg_on)
+        print(f"summary_avg_off_ms={avg_off:.1f}")
+        print(f"summary_avg_on_ms={avg_on:.1f}")
+        print(f"summary_speedup_pct={avg_speedup:.2f}")
+    print(f"csv={csv_path}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception as error:
+        print(f"error={error}", file=sys.stderr)
+        sys.exit(1)

--- a/tools/benchmark_prompt_lookup.py
+++ b/tools/benchmark_prompt_lookup.py
@@ -93,6 +93,14 @@ def parse_metric(output, name):
         return value
 
 
+def parse_output_block(output):
+    marker = "[VOXT_SMOKE][output]\n"
+    index = output.rfind(marker)
+    if index < 0:
+        return None
+    return output[index + len(marker):].rstrip("\n")
+
+
 def parse_smoke_output(output):
     metric = {
         "avgElapsedMs": parse_metric(output, "avgElapsedMs"),
@@ -105,7 +113,10 @@ def parse_smoke_output(output):
         "avgCompletionTokens": parse_metric(output, "avgCompletionTokens"),
         "avgPromptLookupDraftTokens": parse_metric(output, "avgPromptLookupDraftTokens"),
         "avgPromptLookupProposedTokens": parse_metric(output, "avgPromptLookupProposedTokens"),
+        "avgPromptLookupAcceptedTokens": parse_metric(output, "avgPromptLookupAcceptedTokens"),
+        "avgPromptLookupAcceptanceRatio": parse_metric(output, "avgPromptLookupAcceptanceRatio"),
         "promptLookupFallback": parse_metric(output, "promptLookupFallback"),
+        "finalOutput": parse_output_block(output),
     }
     elapsed = metric["hotAvgElapsedMs"] or metric["avgElapsedMs"]
     metric["elapsedMs"] = elapsed
@@ -142,6 +153,13 @@ def load_cases(path, limit):
     return cases
 
 
+def filter_cases_by_category(cases, categories):
+    if not categories:
+        return cases
+    requested = {category.strip() for category in categories if category.strip()}
+    return [case for case in cases if case.get("category") in requested]
+
+
 def percent_delta(baseline, candidate):
     if not baseline or not candidate:
         return None
@@ -155,13 +173,19 @@ def main():
     parser.add_argument("--configuration", default="Debug")
     parser.add_argument("--iterations", type=int, default=2)
     parser.add_argument("--limit", type=int)
+    parser.add_argument("--category", action="append")
     parser.add_argument("--prefill-step", type=int)
     parser.add_argument("--app-binary", type=Path)
     parser.add_argument("--no-build", action="store_true")
     parser.add_argument("--csv", type=Path)
     args = parser.parse_args()
 
-    cases = load_cases(args.cases, args.limit)
+    cases = filter_cases_by_category(
+        load_cases(args.cases, args.limit),
+        args.category,
+    )
+    if not cases:
+        raise RuntimeError("No benchmark cases matched the requested filters.")
     if args.app_binary:
         binary = args.app_binary
     else:
@@ -177,7 +201,7 @@ def main():
     rows = []
     print(f"binary={binary}")
     print(f"repo={args.repo} cases={len(cases)} iterations={args.iterations}")
-    print("case,chars,off_ms,on_ms,speedup_pct,on_draft_tokens,on_proposed_tokens,on_fallback")
+    print("case,category,chars,off_ms,on_ms,speedup_pct,output_match,on_draft_tokens,on_proposed_tokens,on_accepted_tokens,on_acceptance_ratio,on_fallback")
 
     for case in cases:
         off = run_smoke(
@@ -197,27 +221,33 @@ def main():
             prefill_step=args.prefill_step,
         )
         speedup = percent_delta(off["elapsedMs"], on["elapsedMs"])
+        output_match = off["finalOutput"] == on["finalOutput"]
         row = {
             "id": case["id"],
             "origin": case.get("origin", ""),
+            "category": case.get("category", ""),
             "chars": len(case["text"]),
             "off_elapsed_ms": off["elapsedMs"],
             "on_elapsed_ms": on["elapsedMs"],
             "speedup_pct": None if speedup is None else round(speedup, 2),
+            "output_match": output_match,
             "off_prefill_ms": off["hotAvgPrefillMs"] or off["avgPrefillMs"],
             "on_prefill_ms": on["hotAvgPrefillMs"] or on["avgPrefillMs"],
             "off_generation_ms": off["hotAvgGenerationMs"] or off["avgGenerationMs"],
             "on_generation_ms": on["hotAvgGenerationMs"] or on["avgGenerationMs"],
             "on_draft_tokens": on["avgPromptLookupDraftTokens"],
             "on_proposed_tokens": on["avgPromptLookupProposedTokens"],
+            "on_accepted_tokens": on["avgPromptLookupAcceptedTokens"],
+            "on_acceptance_ratio": on["avgPromptLookupAcceptanceRatio"],
             "on_fallback": on["promptLookupFallback"] or "",
         }
         rows.append(row)
         speedup_text = "n/a" if speedup is None else f"{speedup:.2f}"
         print(
-            f"{row['id']},{row['chars']},{row['off_elapsed_ms']},"
-            f"{row['on_elapsed_ms']},{speedup_text},{row['on_draft_tokens']},"
-            f"{row['on_proposed_tokens']},{row['on_fallback']}"
+            f"{row['id']},{row['category']},{row['chars']},{row['off_elapsed_ms']},"
+            f"{row['on_elapsed_ms']},{speedup_text},{str(output_match).lower()},{row['on_draft_tokens']},"
+            f"{row['on_proposed_tokens']},{row['on_accepted_tokens']},"
+            f"{row['on_acceptance_ratio']},{row['on_fallback']}"
         )
 
     with csv_path.open("w", newline="", encoding="utf-8") as handle:
@@ -233,6 +263,17 @@ def main():
         print(f"summary_avg_off_ms={avg_off:.1f}")
         print(f"summary_avg_on_ms={avg_on:.1f}")
         print(f"summary_speedup_pct={avg_speedup:.2f}")
+        categories = sorted({row["category"] for row in valid if row.get("category")})
+        for category in categories:
+            category_rows = [row for row in valid if row.get("category") == category]
+            category_avg_off = sum(row["off_elapsed_ms"] for row in category_rows) / len(category_rows)
+            category_avg_on = sum(row["on_elapsed_ms"] for row in category_rows) / len(category_rows)
+            category_speedup = percent_delta(category_avg_off, category_avg_on)
+            output_matches = sum(1 for row in category_rows if row["output_match"])
+            print(
+                f"summary_category={category} cases={len(category_rows)} output_match={output_matches}/{len(category_rows)} "
+                f"avg_off_ms={category_avg_off:.1f} avg_on_ms={category_avg_on:.1f} speedup_pct={category_speedup:.2f}"
+            )
     print(f"csv={csv_path}")
 
 

--- a/tools/prompt_lookup_benchmark_cases.json
+++ b/tools/prompt_lookup_benchmark_cases.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "qwen-short-en-exact",
+    "origin": "Qwen-Audio official sample reference text",
+    "text": "mister quilter is the apostle of the middle classes and we are glad to welcome his gospel"
+  },
+  {
+    "id": "qwen-short-zh-chongqing-exact",
+    "origin": "Qwen-Audio official sample reference text",
+    "text": "对了我还想提议我们可以租一些自行车骑行一下既锻炼身体又心情愉悦"
+  },
+  {
+    "id": "qwen-short-zh-relaxed-exact",
+    "origin": "Qwen-Audio official sample reference text",
+    "text": "你没事吧"
+  },
+  {
+    "id": "qwen-short-zh-negative-exact",
+    "origin": "Qwen-Audio official sample reference text",
+    "text": "你没事吧"
+  },
+  {
+    "id": "qwen-long-en-composite",
+    "origin": "Derived from repeated Qwen-Audio official English sample",
+    "text": "mister quilter is the apostle of the middle classes and we are glad to welcome his gospel. mister quilter is the apostle of the middle classes and we are glad to welcome his gospel. mister quilter is the apostle of the middle classes and we are glad to welcome his gospel. mister quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+  },
+  {
+    "id": "qwen-long-zh-composite",
+    "origin": "Derived from repeated Qwen-Audio official Chinese samples",
+    "text": "对了我还想提议我们可以租一些自行车骑行一下既锻炼身体又心情愉悦。你没事吧。你没事吧。对了我还想提议我们可以租一些自行车骑行一下既锻炼身体又心情愉悦。你没事吧。你没事吧。"
+  },
+  {
+    "id": "meeting-product-flow",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "今天我们主要讨论一下产品的语音输入流程，包括录音开始、实时转写、结束检测，以及后续的文本润色处理。原始转写一般已经比较接近用户想表达的内容，所以增强模型主要保留原文本结构。呃，我们只修正标点、错别字和少量语序的问题。"
+  },
+  {
+    "id": "self-correction-shopping",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "嗯你帮我买一些水果吧，比如苹果香蕉梨，还有一些甘蔗。啊不不不甘蔗不用了，帮我带一点枇杷，再买两瓶无糖酸奶，晚上六点之前送到公司前台。"
+  },
+  {
+    "id": "numbers-and-time",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "这个项目的完成率大概是百分之七十，我们需要在下午两点十五分之前完成第一轮验收，晚上七点半之前把数据报表发给产品和运营团队，手机号码是一三八零零一三八零零零。"
+  },
+  {
+    "id": "mixed-language-tech",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "我们今天要检查 Redis cache 的命中率，还有 Kubernetes pod 的重启次数。API endpoint 是 https://api.example.com/v1/transcriptions，记得不要改 JWT secret 和 DATABASE_URL。"
+  },
+  {
+    "id": "ordered-list",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "今天的待办有三个，第一整理昨天的用户反馈，第二把语音转写的错误样本分类，第三和设计确认设置页面里的模型选择说明。完成之后发到飞书群里。"
+  },
+  {
+    "id": "long-office-note",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "我刚才和客户沟通了一下，他们主要关心三个问题。第一个是本地模型启动速度，第二个是远程模型在弱网情况下的失败提示，第三个是转写结果进入历史记录之后能不能继续编辑。我们先把启动速度和失败提示排到这个版本，历史编辑放到下一个版本。"
+  },
+  {
+    "id": "punctuation-words",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "请帮我记录这句话冒号今天的发布计划已经确认逗号后端服务会在下午三点升级逗号桌面客户端会在下午五点发布句号如果发现登录失败逗号请先检查网络代理和账号权限句号"
+  },
+  {
+    "id": "email-and-path",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "麻烦把日志文件发给 support@example.com，路径是 slash users slash guanwei slash library slash application support slash voxt slash logs slash voxt dot log，同时附上当前使用的模型名字和系统版本。"
+  },
+  {
+    "id": "casual-correction",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "我明天不对是后天上午十点去上海，先和销售团队开会，然后下午两点去拜访客户。晚上如果还有时间，我会把会议纪要整理出来发给大家。"
+  },
+  {
+    "id": "dictionary-learning",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "自动词典学习这块我们要观察用户粘贴之后有没有手动修改，如果用户把敬业限制改成竞业限制，或者把十五分钟改成15分钟，我们应该记录这个候选纠错。"
+  },
+  {
+    "id": "asr-quality-review",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "这段录音的识别质量整体还可以，但是中间有两个地方需要注意。一个是结束检测被识别成检索检测，另一个是实时转写后面的停顿被错误地合并到了下一句话里。"
+  },
+  {
+    "id": "translation-intent-but-transcription",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "我现在不是要翻译这段话，只是想把中文原文整理得更清楚一点。请保留里面的英文产品名，比如 OpenAI、ChatGPT、WhisperKit 和 MLX，不要把它们翻译成中文。"
+  },
+  {
+    "id": "long-project-update",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "本周的项目进展分成四部分。第一，录音链路已经完成基本稳定性测试。第二，实时转写在短句场景下表现比较稳定，但是长句仍然需要继续观察。第三，增强模型的延迟主要集中在 prefill 和 generation 两个阶段。第四，我们需要用真实样本判断 prompt lookup decoding 是否值得默认开启。"
+  },
+  {
+    "id": "long-mixed-meeting",
+    "origin": "Representative post-ASR Voxt transcription case",
+    "text": "The main action item is to compare baseline generation with prompt lookup decoding on the same ASR transcripts. 我们需要记录 total elapsed milliseconds, prefill milliseconds, generation milliseconds, prompt tokens, completion tokens, draft tokens, proposed tokens, and fallback reason. 最后输出一个平均速度提升比例。"
+  }
+]

--- a/tools/prompt_lookup_benchmark_cases.json
+++ b/tools/prompt_lookup_benchmark_cases.json
@@ -2,101 +2,121 @@
   {
     "id": "qwen-short-en-exact",
     "origin": "Qwen-Audio official sample reference text",
+    "category": "cleanup_safe",
     "text": "mister quilter is the apostle of the middle classes and we are glad to welcome his gospel"
   },
   {
     "id": "qwen-short-zh-chongqing-exact",
     "origin": "Qwen-Audio official sample reference text",
+    "category": "cleanup_safe",
     "text": "对了我还想提议我们可以租一些自行车骑行一下既锻炼身体又心情愉悦"
   },
   {
     "id": "qwen-short-zh-relaxed-exact",
     "origin": "Qwen-Audio official sample reference text",
+    "category": "cleanup_safe",
     "text": "你没事吧"
   },
   {
     "id": "qwen-short-zh-negative-exact",
     "origin": "Qwen-Audio official sample reference text",
+    "category": "cleanup_safe",
     "text": "你没事吧"
   },
   {
     "id": "qwen-long-en-composite",
     "origin": "Derived from repeated Qwen-Audio official English sample",
+    "category": "cleanup_safe",
     "text": "mister quilter is the apostle of the middle classes and we are glad to welcome his gospel. mister quilter is the apostle of the middle classes and we are glad to welcome his gospel. mister quilter is the apostle of the middle classes and we are glad to welcome his gospel. mister quilter is the apostle of the middle classes and we are glad to welcome his gospel."
   },
   {
     "id": "qwen-long-zh-composite",
     "origin": "Derived from repeated Qwen-Audio official Chinese samples",
+    "category": "cleanup_safe",
     "text": "对了我还想提议我们可以租一些自行车骑行一下既锻炼身体又心情愉悦。你没事吧。你没事吧。对了我还想提议我们可以租一些自行车骑行一下既锻炼身体又心情愉悦。你没事吧。你没事吧。"
   },
   {
     "id": "meeting-product-flow",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "今天我们主要讨论一下产品的语音输入流程，包括录音开始、实时转写、结束检测，以及后续的文本润色处理。原始转写一般已经比较接近用户想表达的内容，所以增强模型主要保留原文本结构。呃，我们只修正标点、错别字和少量语序的问题。"
   },
   {
     "id": "self-correction-shopping",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "嗯你帮我买一些水果吧，比如苹果香蕉梨，还有一些甘蔗。啊不不不甘蔗不用了，帮我带一点枇杷，再买两瓶无糖酸奶，晚上六点之前送到公司前台。"
   },
   {
     "id": "numbers-and-time",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "normalization_heavy",
     "text": "这个项目的完成率大概是百分之七十，我们需要在下午两点十五分之前完成第一轮验收，晚上七点半之前把数据报表发给产品和运营团队，手机号码是一三八零零一三八零零零。"
   },
   {
     "id": "mixed-language-tech",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "我们今天要检查 Redis cache 的命中率，还有 Kubernetes pod 的重启次数。API endpoint 是 https://api.example.com/v1/transcriptions，记得不要改 JWT secret 和 DATABASE_URL。"
   },
   {
     "id": "ordered-list",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "structure_sensitive",
     "text": "今天的待办有三个，第一整理昨天的用户反馈，第二把语音转写的错误样本分类，第三和设计确认设置页面里的模型选择说明。完成之后发到飞书群里。"
   },
   {
     "id": "long-office-note",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "structure_sensitive",
     "text": "我刚才和客户沟通了一下，他们主要关心三个问题。第一个是本地模型启动速度，第二个是远程模型在弱网情况下的失败提示，第三个是转写结果进入历史记录之后能不能继续编辑。我们先把启动速度和失败提示排到这个版本，历史编辑放到下一个版本。"
   },
   {
     "id": "punctuation-words",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "normalization_heavy",
     "text": "请帮我记录这句话冒号今天的发布计划已经确认逗号后端服务会在下午三点升级逗号桌面客户端会在下午五点发布句号如果发现登录失败逗号请先检查网络代理和账号权限句号"
   },
   {
     "id": "email-and-path",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "麻烦把日志文件发给 support@example.com，路径是 slash users slash guanwei slash library slash application support slash voxt slash logs slash voxt dot log，同时附上当前使用的模型名字和系统版本。"
   },
   {
     "id": "casual-correction",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "我明天不对是后天上午十点去上海，先和销售团队开会，然后下午两点去拜访客户。晚上如果还有时间，我会把会议纪要整理出来发给大家。"
   },
   {
     "id": "dictionary-learning",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "normalization_heavy",
     "text": "自动词典学习这块我们要观察用户粘贴之后有没有手动修改，如果用户把敬业限制改成竞业限制，或者把十五分钟改成15分钟，我们应该记录这个候选纠错。"
   },
   {
     "id": "asr-quality-review",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "这段录音的识别质量整体还可以，但是中间有两个地方需要注意。一个是结束检测被识别成检索检测，另一个是实时转写后面的停顿被错误地合并到了下一句话里。"
   },
   {
     "id": "translation-intent-but-transcription",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "cleanup_safe",
     "text": "我现在不是要翻译这段话，只是想把中文原文整理得更清楚一点。请保留里面的英文产品名，比如 OpenAI、ChatGPT、WhisperKit 和 MLX，不要把它们翻译成中文。"
   },
   {
     "id": "long-project-update",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "structure_sensitive",
     "text": "本周的项目进展分成四部分。第一，录音链路已经完成基本稳定性测试。第二，实时转写在短句场景下表现比较稳定，但是长句仍然需要继续观察。第三，增强模型的延迟主要集中在 prefill 和 generation 两个阶段。第四，我们需要用真实样本判断 prompt lookup decoding 是否值得默认开启。"
   },
   {
     "id": "long-mixed-meeting",
     "origin": "Representative post-ASR Voxt transcription case",
+    "category": "structure_sensitive",
     "text": "The main action item is to compare baseline generation with prompt lookup decoding on the same ASR transcripts. 我们需要记录 total elapsed milliseconds, prefill milliseconds, generation milliseconds, prompt tokens, completion tokens, draft tokens, proposed tokens, and fallback reason. 最后输出一个平均速度提升比例。"
   }
 ]


### PR DESCRIPTION
## Summary
- Add a real local prompt lookup decoding experiment for Custom LLM enhancement instead of the earlier fake draft-model approach.
- Route enhancement requests by task shape so structure-sensitive inputs fall back to standard decoding, and add benchmark tooling plus bilingual design docs.
- Clean up a batch of Xcode concurrency and warning issues touched by this branch.

## 实现 / Implementation
### English
- Added a prompt-lookup verifier path in [CustomLLMModelManager.swift](/Users/guanwei/x/doit/Voxt/Voxt/Support/CustomLLMModelManager.swift) that uses ASR-derived draft tokens and lets the main model verify/accept tokens during local enhancement generation.
- Added request-plan metadata in [CustomLLMModelSupport.swift](/Users/guanwei/x/doit/Voxt/Voxt/Support/CustomLLMModelSupport.swift) so enhancement requests can carry `promptLookupDraftText` and an explicit skip reason.
- Added task-shape routing in [EnhancementStrategyResolver.swift](/Users/guanwei/x/doit/Voxt/Voxt/Support/EnhancementStrategyResolver.swift) to classify structure-sensitive inputs and bypass prompt lookup for ordered-list / outline / dense-enumeration cases.
- Added smoke metrics and benchmark harness updates in [AppDelegate+LLMSmoke.swift](/Users/guanwei/x/doit/Voxt/Voxt/App/AppDelegate+LLMSmoke.swift), [benchmark_prompt_lookup.py](/Users/guanwei/x/doit/Voxt/tools/benchmark_prompt_lookup.py), and [prompt_lookup_benchmark_cases.json](/Users/guanwei/x/doit/Voxt/tools/prompt_lookup_benchmark_cases.json).
- Added design docs in [PromptLookupDecodingPlan.md](/Users/guanwei/x/doit/Voxt/docs/PromptLookupDecodingPlan.md) and [PromptLookupDecodingPlan.zh-CN.md](/Users/guanwei/x/doit/Voxt/docs/PromptLookupDecodingPlan.zh-CN.md).

### 中文
- 在 [CustomLLMModelManager.swift](/Users/guanwei/x/doit/Voxt/Voxt/Support/CustomLLMModelManager.swift) 中实现了真正的 prompt lookup verifier 路径：使用 ASR draft tokens，由主模型在本地 enhancement 生成过程中逐步验证和接受 token，不再走之前的 fake draft model。
- 在 [CustomLLMModelSupport.swift](/Users/guanwei/x/doit/Voxt/Voxt/Support/CustomLLMModelSupport.swift) 中为 request plan 增加 `promptLookupDraftText` 和显式 skip reason。
- 在 [EnhancementStrategyResolver.swift](/Users/guanwei/x/doit/Voxt/Voxt/Support/EnhancementStrategyResolver.swift) 中加入任务形态路由，对列表/提纲/高密度枚举类输入判定为 `structureSensitiveInput`，直接回退到标准生成。
- 在 [AppDelegate+LLMSmoke.swift](/Users/guanwei/x/doit/Voxt/Voxt/App/AppDelegate+LLMSmoke.swift)、[benchmark_prompt_lookup.py](/Users/guanwei/x/doit/Voxt/tools/benchmark_prompt_lookup.py) 和 [prompt_lookup_benchmark_cases.json](/Users/guanwei/x/doit/Voxt/tools/prompt_lookup_benchmark_cases.json) 中补充了 smoke 指标和 benchmark 工具。
- 补充了中英文方案文档：[PromptLookupDecodingPlan.md](/Users/guanwei/x/doit/Voxt/docs/PromptLookupDecodingPlan.md) 和 [PromptLookupDecodingPlan.zh-CN.md](/Users/guanwei/x/doit/Voxt/docs/PromptLookupDecodingPlan.zh-CN.md)。

## 性能 / Performance
### English
- With the initial aggressive verifier window, long-case speedup was measurable but output equivalence regressed.
- After shrinking the proposal window to `1` token and routing structure-sensitive inputs away from prompt lookup, correctness recovered.
- Current categorized benchmark results:
  - `cleanup_safe`: 13/13 output match, average speedup `+3.34%`
  - `normalization_heavy`: 3/3 output match, average speedup `-1.24%`
  - `structure_sensitive`: 4/4 output match, average speedup `-1.38%`
- On the subset of `cleanup_safe` cases that actually entered prompt lookup, average speedup is about `+2.00%`.

### 中文
- 初始激进 verifier window 下，长文本 case 有可见提速，但输出等价性出现回归。
- 将 proposal window 收到 `1` token，并把结构敏感输入从 prompt lookup 路由出去之后，correctness 已经收回。
- 当前分类 benchmark 结果：
  - `cleanup_safe`: 13/13 输出一致，平均提速 `+3.34%`
  - `normalization_heavy`: 3/3 输出一致，平均提速 `-1.24%`
  - `structure_sensitive`: 4/4 输出一致，平均提速 `-1.38%`
- 只看真正进入 prompt lookup 的 `cleanup_safe` 子集，平均提速约 `+2.00%`。

## 效果 / Effect
### English
- This branch proves that prompt lookup can be integrated correctly into Voxt's local enhancement path and benchmarked with reliable diagnostics.
- It also shows that the optimization is narrow: it only helps conservative cleanup-like enhancement, and it is not a good default for mixed cleanup + restructuring prompts.
- The branch therefore leaves prompt lookup as an experiment/decision point rather than treating it as a ready default optimization.

### 中文
- 这个分支已经证明：prompt lookup 可以被正确接入 Voxt 的本地 enhancement 链路，并且可以通过可靠的诊断和 benchmark 进行评估。
- 同时也证明了它的适用面很窄：只对保守清理类 enhancement 有帮助，对“清理 + 结构整理”混合 prompt 不适合作为默认优化。
- 所以这个分支的价值更多是把边界测清楚，而不是直接把 prompt lookup 作为默认优化上线。

## 影响 / Impact
### English
- User-visible behavior should remain unchanged on the guarded path because structure-sensitive cases are routed back to standard generation.
- The branch adds internal complexity in the local generation path, but it also adds stronger observability and benchmark support.
- The practical product takeaway today is that prompt lookup should remain internal / experimental until we split enhancement into clearer cleanup vs rewrite modes or further simplify the cleanup prompt.

### 中文
- 在当前保护策略下，用户可见行为应当保持不变，因为结构敏感 case 会自动回退到标准生成。
- 这条分支确实增加了本地生成路径的内部复杂度，但也补齐了观测能力和 benchmark 支撑。
- 当前更现实的产品结论是：prompt lookup 应继续保持为内部实验能力，除非后续把 enhancement 进一步拆成更清晰的 cleanup / rewrite 模式，或者显著简化 cleanup prompt。

## Test Plan
- [x] `xcodebuild build -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -quiet`
- [x] `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/EnhancementStrategyResolverTests -quiet`
- [x] `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/MLXModelManagerTests -quiet`
- [x] `python3 tools/benchmark_prompt_lookup.py --cases tools/prompt_lookup_benchmark_cases.json --category cleanup_safe --iterations 1 --no-build`
- [x] `python3 tools/benchmark_prompt_lookup.py --cases tools/prompt_lookup_benchmark_cases.json --category normalization_heavy --iterations 1 --no-build`
- [x] `python3 tools/benchmark_prompt_lookup.py --cases tools/prompt_lookup_benchmark_cases.json --category structure_sensitive --iterations 1 --no-build`
- [x] `git diff --check`
