### PR TITLE
Fix StepFun SSE final transcript handling

### DIFF
--- a/Voxt/Transcription/RemoteASRSupport.swift
+++ b/Voxt/Transcription/RemoteASRSupport.swift
@@ -383,6 +383,14 @@ enum RemoteASRTextSupport {
     }
 }
 
+enum StepFunSSEDataPayload: Equatable {
+    case delta(String)
+    case completed(String)
+    case error(String)
+    case fragment(String)
+    case ignore
+}
+
 enum StepFunPayloadSupport {
     static func supportsSSEPrompt(model: String) -> Bool {
         model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "stepaudio-2-asr-pro"
@@ -459,6 +467,53 @@ enum StepFunPayloadSupport {
                 ]
             ]
         ]
+    }
+
+    static func parseSSEDataLine(_ line: String) -> StepFunSSEDataPayload {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .ignore }
+
+        guard let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) else {
+            return .fragment(trimmed)
+        }
+
+        guard let dict = object as? [String: Any] else {
+            if let text = RemoteASRTextSupport.extractText(in: object),
+               let normalized = RemoteASRTextSupport.normalizedTextFragment(text) {
+                return .fragment(normalized)
+            }
+            return .ignore
+        }
+
+        let type = (dict["type"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        switch type {
+        case "transcript.text.delta":
+            guard let value = dict["delta"],
+                  let text = RemoteASRTextSupport.extractText(in: value),
+                  let normalized = RemoteASRTextSupport.normalizedTextFragment(text) else {
+                return .ignore
+            }
+            return .delta(normalized)
+        case "transcript.text.done":
+            guard let value = dict["text"],
+                  let text = RemoteASRTextSupport.extractText(in: value),
+                  let normalized = RemoteASRTextSupport.normalizedTextFragment(text) else {
+                return .ignore
+            }
+            return .completed(normalized)
+        default:
+            if type == "error" || type.hasSuffix(".error") {
+                return .error(RemoteASRTextSupport.extractStreamErrorMessage(fromLine: trimmed) ?? trimmed)
+            }
+        }
+
+        if let text = RemoteASRTextSupport.extractTextFragment(fromLine: trimmed) {
+            return .fragment(text)
+        }
+        return .ignore
     }
 }
 

--- a/Voxt/Transcription/RemoteASRTranscriber.swift
+++ b/Voxt/Transcription/RemoteASRTranscriber.swift
@@ -810,7 +810,8 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
             )
         }
 
-        var aggregate = ""
+        var previewText = ""
+        var finalText: String?
         var sseEvent: String?
         for try await rawLine in bytes.lines {
             let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -849,18 +850,33 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
                 )
             }
 
-            if let fragment = RemoteASRTextSupport.extractTextFragment(fromLine: line),
-               !fragment.isEmpty {
-                aggregate = RemoteASRTextSupport.mergeStreamFragment(current: aggregate, incoming: fragment)
+            switch StepFunPayloadSupport.parseSSEDataLine(line) {
+            case .delta(let fragment), .fragment(let fragment):
+                previewText = RemoteASRTextSupport.mergeStreamFragment(current: previewText, incoming: fragment)
                 await MainActor.run {
-                    self.publishIntermediateTranscription(aggregate)
+                    self.publishIntermediateTranscription(previewText)
                 }
+            case .completed(let text):
+                finalText = text
+                previewText = text
+                await MainActor.run {
+                    self.publishIntermediateTranscription(text)
+                }
+            case .error(let message):
+                throw NSError(
+                    domain: "Voxt.RemoteASR",
+                    code: -11,
+                    userInfo: [NSLocalizedDescriptionKey: "StepFun ASR stream error: \(message)"]
+                )
+            case .ignore:
+                break
             }
             sseEvent = nil
         }
 
-        if aggregate.isEmpty { return transcribedText }
-        return aggregate
+        if let finalText, !finalText.isEmpty { return finalText }
+        if !previewText.isEmpty { return previewText }
+        return transcribedText
     }
 
     private func transcribeDoubao(

--- a/VoxtTests/RemoteASRSupportTests.swift
+++ b/VoxtTests/RemoteASRSupportTests.swift
@@ -116,6 +116,18 @@ final class RemoteASRSupportTests: XCTestCase {
         XCTAssertTrue(StepFunPayloadSupport.supportsSSEPrompt(model: "stepaudio-2-asr-pro"))
     }
 
+    func testStepFunSSEDoneTextIsParsedAsCompletedResult() {
+        let delta = StepFunPayloadSupport.parseSSEDataLine(
+            #"{"type":"transcript.text.delta","delta":"一二三四五。"}"#
+        )
+        let completed = StepFunPayloadSupport.parseSSEDataLine(
+            #"{"type":"transcript.text.done","text":"12345。"}"#
+        )
+
+        XCTAssertEqual(delta, .delta("一二三四五。"))
+        XCTAssertEqual(completed, .completed("12345。"))
+    }
+
     func testStepFunRealtimeSessionUpdateUsesWebSocketShape() throws {
         let payload = StepFunPayloadSupport.sessionUpdatePayload(
             model: "step-asr-1.1-stream",


### PR DESCRIPTION
## Summary

- Parse StepFun SSE event types instead of treating every text payload as an appendable stream fragment.
- Use `transcript.text.delta` only for live preview updates.
- Return `transcript.text.done.text` as the authoritative final transcript.

## Context

StepFun SSE final `done.text` can differ from the accumulated preview text. For example, speaking `12345` may stream a preview like `一二三四五。`, then finish with `12345.` as the final text.

Previously Voxt could merge both values and output `一二三四五。12345.`. This fixes the stream handling so the final result uses the `done.text` value instead.

## 中文说明

StepFun SSE 的最终 `done.text` 可能和预览阶段聚合出的文本不一样。比如语音输入 `12345` 时，预览流里可能先返回 `一二三四五。`，最终 `done.text` 返回的是 `12345.`。

之前的逻辑会把预览文本和最终文本继续合并，导致输出变成 `一二三四五。12345.`。这个 PR 将 `transcript.text.delta` 只用于实时预览，并把 `transcript.text.done.text` 作为最终权威转写结果返回。