### PR TITLE
应用增强支持自动按键和 URL 图标测试

### DIFF
--- a/Voxt/App/EnhancementPromptFlow.swift
+++ b/Voxt/App/EnhancementPromptFlow.swift
@@ -9,6 +9,13 @@ extension AppDelegate {
     static let rawTranscriptionTemplateVariable = EnhancementPromptResolver.rawTranscriptionTemplateVariable
     static let userMainLanguageTemplateVariable = EnhancementPromptResolver.userMainLanguageTemplateVariable
 
+    private struct AppBranchAutoKeyPressMatch {
+        let group: AppBranchGroup
+        let matchedAppGroupName: String?
+        let matchedURLGroupName: String?
+        let overlayIconMatch: OverlayEnhancementIconMatch?
+    }
+
     struct EnhancementPromptResolution {
         enum Delivery {
             case systemPrompt
@@ -167,6 +174,28 @@ extension AppDelegate {
         return (nil, nil)
     }
 
+    func autoKeyPressHotkeyForCurrentAppBranchSession() -> HotkeyPreference.Hotkey? {
+        guard appEnhancementEnabled else { return nil }
+        guard let match = currentAppBranchAutoKeyPressMatch() else { return nil }
+
+        if match.group.autoKeyPressEnabled {
+            lastEnhancementPromptContext = EnhancementPromptContext(
+                focusedAppName: currentEnhancementContext().appName,
+                focusedAppBundleID: currentEnhancementContext().bundleID,
+                matchedGroupID: match.group.id,
+                matchedGroupName: match.matchedURLGroupName ?? match.matchedAppGroupName,
+                matchedAppGroupName: match.matchedAppGroupName,
+                matchedURLGroupName: match.matchedURLGroupName,
+                overlayIconMatch: match.overlayIconMatch
+            )
+            VoxtLog.input(
+                "Auto Key enabled for app branch group. group=\(match.group.name), hotkey=\(HotkeyPreference.displayString(for: match.group.autoKeyPressHotkey, distinguishModifierSides: false))"
+            )
+        }
+
+        return match.group.autoKeyPressEnabled ? match.group.autoKeyPressHotkey : nil
+    }
+
     private func resolveEnhancementPromptVariables(in prompt: String, rawTranscription: String) -> String {
         prompt
             .replacingOccurrences(of: Self.rawTranscriptionTemplateVariable, with: rawTranscription)
@@ -200,6 +229,59 @@ extension AppDelegate {
             }
         }
         return captureEnhancementContextSnapshot()
+    }
+
+    private func currentAppBranchAutoKeyPressMatch() -> AppBranchAutoKeyPressMatch? {
+        let groups = loadAppBranchGroups()
+        guard !groups.isEmpty else { return nil }
+
+        let urlsByID = loadAppBranchURLsByID()
+        let context = currentEnhancementContext()
+        let frontmostBundleID = context.bundleID
+
+        if isBrowserBundleID(frontmostBundleID) {
+            let activeURL = activeBrowserTabURL(frontmostBundleID: frontmostBundleID)
+            guard let normalizedActiveURL = AppBranchURLPatternService.normalizedURLForMatching(activeURL),
+                  let urlMatch = AppBranchURLPatternService.firstGroupMatch(
+                    groups: groups,
+                    urlsByID: urlsByID,
+                    normalizedURL: normalizedActiveURL
+                  ),
+                  let group = groups.first(where: { $0.id == urlMatch.groupID })
+            else {
+                return nil
+            }
+
+            return AppBranchAutoKeyPressMatch(
+                group: group,
+                matchedAppGroupName: nil,
+                matchedURLGroupName: urlMatch.groupName,
+                overlayIconMatch: frontmostBundleID.map {
+                    OverlayEnhancementIconMatch(
+                        kind: .url,
+                        bundleID: $0,
+                        urlOrigin: EnhancementOverlayIconResolver.faviconOrigin(fromPageURL: activeURL)
+                    )
+                }
+            )
+        }
+
+        guard let frontmostBundleID,
+              let group = groups.first(where: { $0.appBundleIDs.contains(frontmostBundleID) })
+        else {
+            return nil
+        }
+
+        return AppBranchAutoKeyPressMatch(
+            group: group,
+            matchedAppGroupName: group.name,
+            matchedURLGroupName: nil,
+            overlayIconMatch: OverlayEnhancementIconMatch(
+                kind: .app,
+                bundleID: frontmostBundleID,
+                urlOrigin: nil
+            )
+        )
     }
 
     private func overlayIconMatch(

--- a/Voxt/App/SessionTextIO.swift
+++ b/Voxt/App/SessionTextIO.swift
@@ -485,10 +485,16 @@ extension AppDelegate {
 
         switch delivery {
         case .typeText:
+            let autoKeyPressHotkey = sessionOutputMode == .transcription
+                ? autoKeyPressHotkeyForCurrentAppBranchSession()
+                : nil
             beginOverlayOutputDelivery()
             typeText(context.outputText) { [weak self] didInject in
                 self?.sessionFinalOutputDeliveredAt = Date()
                 self?.endOverlayOutputDelivery()
+                if didInject, let autoKeyPressHotkey {
+                    self?.pressAutoKeyAfterTextInjection(autoKeyPressHotkey)
+                }
                 completion?(didInject)
             }
         case .answerOverlay:

--- a/Voxt/App/TextInputIO.swift
+++ b/Voxt/App/TextInputIO.swift
@@ -4,6 +4,7 @@
 import Foundation
 import AppKit
 import ApplicationServices
+import Carbon
 
 extension AppDelegate {
     private static let axMessagingTimeout: Float = 0.05
@@ -963,6 +964,66 @@ extension AppDelegate {
                 }
             )
         }
+    }
+
+    func pressAutoKeyAfterTextInjection(
+        _ hotkey: HotkeyPreference.Hotkey,
+        delay: TimeInterval = 0.12
+    ) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard AccessibilityPermissionManager.isTrusted() else {
+                VoxtLog.inputWarning("Auto Key skipped: accessibility permission missing.")
+                return
+            }
+            guard let source = CGEventSource(stateID: .hidSystemState) else {
+                VoxtLog.error("Auto Key failed: unable to create CGEventSource")
+                return
+            }
+            guard case .keyboard(let keyCode) = hotkey.input,
+                  keyCode != HotkeyPreference.modifierOnlyKeyCode
+            else {
+                VoxtLog.inputWarning("Auto Key skipped: unsupported shortcut input.")
+                return
+            }
+
+            let cgKeyCode = CGKeyCode(keyCode)
+            let flags = Self.cgEventFlags(for: hotkey.modifiers)
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: cgKeyCode, keyDown: true)
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: cgKeyCode, keyDown: false)
+
+            guard let keyDown, let keyUp else {
+                VoxtLog.error("Auto Key failed: unable to create key events")
+                return
+            }
+
+            keyDown.flags = flags
+            keyUp.flags = flags
+            keyDown.post(tap: .cgAnnotatedSessionEventTap)
+            keyUp.post(tap: .cgAnnotatedSessionEventTap)
+            VoxtLog.input(
+                "Auto Key event posted after text injection. hotkey=\(HotkeyPreference.displayString(for: hotkey, distinguishModifierSides: false))"
+            )
+        }
+    }
+
+    private static func cgEventFlags(for modifiers: NSEvent.ModifierFlags) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        if modifiers.contains(.control) {
+            flags.insert(.maskControl)
+        }
+        if modifiers.contains(.option) {
+            flags.insert(.maskAlternate)
+        }
+        if modifiers.contains(.shift) {
+            flags.insert(.maskShift)
+        }
+        if modifiers.contains(.command) {
+            flags.insert(.maskCommand)
+        }
+        if modifiers.contains(.function) {
+            flags.insert(.maskSecondaryFn)
+        }
+        return flags
     }
 
     func beginOverlayOutputDelivery() {

--- a/Voxt/App/TranscriptionFlow.swift
+++ b/Voxt/App/TranscriptionFlow.swift
@@ -152,6 +152,13 @@ extension AppDelegate {
             verbose: true
         )
         if promptResolution.delivery == EnhancementPromptResolution.Delivery.skipEnhancement {
+            if let sessionID,
+               autoKeyPressHotkeyForCurrentAppBranchSession() != nil {
+                applyEnhancementOverlayIconIfNeeded(
+                    match: lastEnhancementPromptContext?.overlayIconMatch,
+                    sessionID: sessionID
+                )
+            }
             return text
         }
         if let sessionID {

--- a/Voxt/Hotkey/HotkeySupport.swift
+++ b/Voxt/Hotkey/HotkeySupport.swift
@@ -308,7 +308,7 @@ nonisolated struct HotkeyPreference {
         }
     }
 
-    struct Hotkey: Equatable {
+    struct Hotkey: Equatable, Codable {
         enum Input: Equatable {
             case keyboard(UInt16)
             case mouseButton(Int)
@@ -331,6 +331,14 @@ nonisolated struct HotkeyPreference {
         let input: Input
         let modifiers: NSEvent.ModifierFlags
         let sidedModifiers: SidedModifierFlags
+
+        private enum CodingKeys: String, CodingKey {
+            case inputType
+            case keyCode
+            case mouseButtonNumber
+            case modifiers
+            case sidedModifiers
+        }
 
         init(
             input: Input,
@@ -378,6 +386,37 @@ nonisolated struct HotkeyPreference {
 
         var isMouseButton: Bool {
             mouseButtonNumber != nil
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let inputType = try container.decodeIfPresent(String.self, forKey: .inputType)
+            let keyCode = try container.decodeIfPresent(UInt16.self, forKey: .keyCode) ?? HotkeyPreference.modifierOnlyKeyCode
+            let mouseButtonNumber = try container.decodeIfPresent(Int.self, forKey: .mouseButtonNumber)
+            if Input.Kind(rawValue: inputType ?? "") == .mouseButton,
+               let mouseButtonNumber,
+               mouseButtonNumber >= HotkeyPreference.middleMouseButtonNumber {
+                input = .mouseButton(mouseButtonNumber)
+            } else {
+                input = .keyboard(keyCode)
+            }
+            let modifiersRaw = try container.decodeIfPresent(UInt.self, forKey: .modifiers) ?? 0
+            modifiers = NSEvent.ModifierFlags(rawValue: modifiersRaw).intersection(.hotkeyRelevant)
+            let sidedRaw = try container.decodeIfPresent(Int.self, forKey: .sidedModifiers) ?? 0
+            sidedModifiers = SidedModifierFlags(rawValue: sidedRaw).filtered(by: modifiers)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(input.kind.rawValue, forKey: .inputType)
+            switch input {
+            case .keyboard(let keyCode):
+                try container.encode(keyCode, forKey: .keyCode)
+            case .mouseButton(let buttonNumber):
+                try container.encode(buttonNumber, forKey: .mouseButtonNumber)
+            }
+            try container.encode(modifiers.rawValue, forKey: .modifiers)
+            try container.encode(sidedModifiers.filtered(by: modifiers).rawValue, forKey: .sidedModifiers)
         }
     }
 

--- a/Voxt/Settings/AppEnhancement/AppEnhancementCards.swift
+++ b/Voxt/Settings/AppEnhancement/AppEnhancementCards.swift
@@ -125,6 +125,8 @@ extension AppEnhancementSettingsView {
                     Button(AppLocalization.localizedString("Create Group")) {
                         groupNameDraft = ""
                         groupPromptDraft = ""
+                        groupAutoKeyPressEnabledDraft = false
+                        groupAutoKeyPressHotkeyDraft = AppBranchGroup.defaultAutoKeyPressHotkey
                         modalErrorMessage = nil
                         modal = .createGroup
                     }
@@ -321,6 +323,15 @@ extension AppEnhancementSettingsView {
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
 
+                if group.autoKeyPressEnabled {
+                    Label(
+                        "\(AppLocalization.localizedString("Auto Key")): \(HotkeyPreference.displayString(for: group.autoKeyPressHotkey, distinguishModifierSides: false))",
+                        systemImage: "keyboard"
+                    )
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+
                 Spacer()
 
                 Button(AppLocalization.localizedString("Copy")) {
@@ -331,6 +342,8 @@ extension AppEnhancementSettingsView {
                 Button(AppLocalization.localizedString("Edit")) {
                     groupNameDraft = group.name
                     groupPromptDraft = group.prompt
+                    groupAutoKeyPressEnabledDraft = group.autoKeyPressEnabled
+                    groupAutoKeyPressHotkeyDraft = group.autoKeyPressHotkey
                     modalErrorMessage = nil
                     modal = .editGroup(group.id)
                 }
@@ -410,6 +423,8 @@ extension AppEnhancementSettingsView {
                 actionTitle: currentModal.actionTitle,
                 name: $groupNameDraft,
                 prompt: $groupPromptDraft,
+                autoKeyPressEnabled: $groupAutoKeyPressEnabledDraft,
+                autoKeyPressHotkey: $groupAutoKeyPressHotkeyDraft,
                 errorMessage: modalErrorMessage,
                 onCancel: {
                     modal = nil

--- a/Voxt/Settings/AppEnhancement/AppEnhancementData.swift
+++ b/Voxt/Settings/AppEnhancement/AppEnhancementData.swift
@@ -152,6 +152,8 @@ extension AppEnhancementSettingsView {
             appBundleIDs: sourceGroup.appBundleIDs,
             appRefs: sourceGroup.appRefs,
             urlPatternIDs: sourceGroup.urlPatternIDs,
+            autoKeyPressEnabled: sourceGroup.autoKeyPressEnabled,
+            autoKeyPressHotkey: sourceGroup.autoKeyPressHotkey,
             isExpanded: true
         )
         groups.append(duplicatedGroup)
@@ -174,6 +176,8 @@ extension AppEnhancementSettingsView {
                     appBundleIDs: [],
                     appRefs: [],
                     urlPatternIDs: [],
+                    autoKeyPressEnabled: groupAutoKeyPressEnabledDraft,
+                    autoKeyPressHotkey: groupAutoKeyPressHotkeyDraft,
                     isExpanded: true
                 )
             )
@@ -181,6 +185,8 @@ extension AppEnhancementSettingsView {
             guard let index = groups.firstIndex(where: { $0.id == groupID }) else { break }
             groups[index].name = trimmedName
             groups[index].prompt = groupPromptDraft
+            groups[index].autoKeyPressEnabled = groupAutoKeyPressEnabledDraft
+            groups[index].autoKeyPressHotkey = groupAutoKeyPressHotkeyDraft
         default:
             break
         }

--- a/Voxt/Settings/AppEnhancement/AppEnhancementModels.swift
+++ b/Voxt/Settings/AppEnhancement/AppEnhancementModels.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 import AppKit
+import Carbon
 
 enum SourceTab: String, CaseIterable, Identifiable {
     case apps
@@ -43,7 +44,19 @@ struct AppBranchGroup: Identifiable, Codable, Equatable {
     var appBundleIDs: [String]
     var appRefs: [AppBranchAppRef]
     var urlPatternIDs: [UUID]
+    var autoKeyPressEnabled: Bool
+    var autoKeyPressHotkey: HotkeyPreference.Hotkey
     var isExpanded: Bool
+
+    static let defaultAutoKeyPressHotkey = HotkeyPreference.Hotkey(
+        keyCode: UInt16(kVK_Return),
+        modifiers: [],
+        sidedModifiers: []
+    )
+
+    var autoPressReturnEnabled: Bool {
+        autoKeyPressEnabled && autoKeyPressHotkey == Self.defaultAutoKeyPressHotkey
+    }
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -52,6 +65,9 @@ struct AppBranchGroup: Identifiable, Codable, Equatable {
         case appBundleIDs
         case appRefs
         case urlPatternIDs
+        case autoPressReturnEnabled
+        case autoKeyPressEnabled
+        case autoKeyPressHotkey
         case isExpanded
     }
 
@@ -62,6 +78,9 @@ struct AppBranchGroup: Identifiable, Codable, Equatable {
         appBundleIDs: [String],
         appRefs: [AppBranchAppRef],
         urlPatternIDs: [UUID],
+        autoPressReturnEnabled: Bool = false,
+        autoKeyPressEnabled: Bool? = nil,
+        autoKeyPressHotkey: HotkeyPreference.Hotkey = AppBranchGroup.defaultAutoKeyPressHotkey,
         isExpanded: Bool
     ) {
         self.id = id
@@ -70,6 +89,8 @@ struct AppBranchGroup: Identifiable, Codable, Equatable {
         self.appBundleIDs = appBundleIDs
         self.appRefs = appRefs
         self.urlPatternIDs = urlPatternIDs
+        self.autoKeyPressEnabled = autoKeyPressEnabled ?? autoPressReturnEnabled
+        self.autoKeyPressHotkey = autoKeyPressHotkey
         self.isExpanded = isExpanded
     }
 
@@ -86,7 +107,27 @@ struct AppBranchGroup: Identifiable, Codable, Equatable {
             appRefs = decodedRefs
         }
         urlPatternIDs = try container.decodeIfPresent([UUID].self, forKey: .urlPatternIDs) ?? []
+        let legacyAutoReturnEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoPressReturnEnabled) ?? false
+        autoKeyPressEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoKeyPressEnabled) ?? legacyAutoReturnEnabled
+        autoKeyPressHotkey = try container.decodeIfPresent(
+            HotkeyPreference.Hotkey.self,
+            forKey: .autoKeyPressHotkey
+        ) ?? Self.defaultAutoKeyPressHotkey
         isExpanded = try container.decodeIfPresent(Bool.self, forKey: .isExpanded) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(prompt, forKey: .prompt)
+        try container.encode(appBundleIDs, forKey: .appBundleIDs)
+        try container.encode(appRefs, forKey: .appRefs)
+        try container.encode(urlPatternIDs, forKey: .urlPatternIDs)
+        try container.encode(autoPressReturnEnabled, forKey: .autoPressReturnEnabled)
+        try container.encode(autoKeyPressEnabled, forKey: .autoKeyPressEnabled)
+        try container.encode(autoKeyPressHotkey, forKey: .autoKeyPressHotkey)
+        try container.encode(isExpanded, forKey: .isExpanded)
     }
 }
 

--- a/Voxt/Settings/AppEnhancement/AppEnhancementSettingsView.swift
+++ b/Voxt/Settings/AppEnhancement/AppEnhancementSettingsView.swift
@@ -20,6 +20,8 @@ struct AppEnhancementSettingsView: View {
     @State var modal: AppBranchModal?
     @State var groupNameDraft = ""
     @State var groupPromptDraft = ""
+    @State var groupAutoKeyPressEnabledDraft = false
+    @State var groupAutoKeyPressHotkeyDraft = AppBranchGroup.defaultAutoKeyPressHotkey
     @State var urlDraft = ""
     @State var modalErrorMessage: String?
 

--- a/Voxt/Settings/AppEnhancement/AppEnhancementSheets.swift
+++ b/Voxt/Settings/AppEnhancement/AppEnhancementSheets.swift
@@ -2,16 +2,21 @@
 // Provides App Enhancement Sheets for app enhancement settings.
 
 import SwiftUI
+import AppKit
 
 struct GroupEditorSheet: View {
     let title: String
     let actionTitle: String
     @Binding var name: String
     @Binding var prompt: String
+    @Binding var autoKeyPressEnabled: Bool
+    @Binding var autoKeyPressHotkey: HotkeyPreference.Hotkey
     let errorMessage: String?
     let onCancel: () -> Void
     let onSave: () -> Void
     @State private var selectedPresetID = Self.placeholderPresetID
+    @State private var isAutoKeyRecording = false
+    @State private var pendingAutoKeyHotkey: HotkeyPreference.Hotkey?
 
     private static let placeholderPresetID = "choose-template"
     private let dialogPadding: CGFloat = 0
@@ -105,6 +110,79 @@ struct GroupEditorSheet: View {
                     )
                 }
 
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(alignment: .center, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(AppLocalization.localizedString("Auto Key"))
+                                .font(.headline)
+
+                            Text(AppLocalization.localizedString("Automatically press this key after transcription ends."))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer(minLength: 0)
+
+                        if autoKeyPressEnabled {
+                            SettingsShortcutCaptureField(
+                                title: "",
+                                hotkey: pendingAutoKeyHotkey ?? autoKeyPressHotkey,
+                                isRecording: isAutoKeyRecording,
+                                isPendingConfirmation: pendingAutoKeyHotkey != nil,
+                                distinguishModifierSides: false,
+                                showsTitle: false,
+                                controlWidth: 240,
+                                onFocus: {
+                                    pendingAutoKeyHotkey = nil
+                                    isAutoKeyRecording = true
+                                },
+                                onReset: {
+                                    autoKeyPressHotkey = AppBranchGroup.defaultAutoKeyPressHotkey
+                                    pendingAutoKeyHotkey = nil
+                                    isAutoKeyRecording = false
+                                },
+                                onCancelPending: {
+                                    pendingAutoKeyHotkey = nil
+                                    isAutoKeyRecording = false
+                                },
+                                onConfirmPending: {
+                                    if let pendingAutoKeyHotkey {
+                                        autoKeyPressHotkey = pendingAutoKeyHotkey
+                                    }
+                                    pendingAutoKeyHotkey = nil
+                                    isAutoKeyRecording = false
+                                }
+                            )
+                        }
+
+                        Toggle("", isOn: $autoKeyPressEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .onChange(of: autoKeyPressEnabled) { _, enabled in
+                                if enabled, autoKeyPressHotkey.keyCode == HotkeyPreference.modifierOnlyKeyCode {
+                                    autoKeyPressHotkey = AppBranchGroup.defaultAutoKeyPressHotkey
+                                }
+                                if !enabled {
+                                    pendingAutoKeyHotkey = nil
+                                    isAutoKeyRecording = false
+                                }
+                            }
+                    }
+
+                    HotkeyRecorderView(
+                        isRecording: $isAutoKeyRecording,
+                        onCapture: { capturedHotkey in
+                            pendingAutoKeyHotkey = capturedHotkey
+                        },
+                        onCancelCapture: {
+                            pendingAutoKeyHotkey = nil
+                            isAutoKeyRecording = false
+                        },
+                        onRecorderMessageChange: { _ in }
+                    )
+                    .frame(width: 0, height: 0)
+                }
+
                 if let errorMessage, !errorMessage.isEmpty {
                     Text(errorMessage)
                         .font(.caption)
@@ -157,6 +235,10 @@ struct URLBatchEditorSheet: View {
     let onSave: () -> Void
     @State private var testInput = ""
     @State private var isTestInputHovered = false
+    @State private var testFaviconOrigin: String?
+    @State private var testFaviconImage: NSImage?
+    @State private var isLoadingTestFavicon = false
+    @State private var testFaviconLookupID = UUID()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -191,9 +273,19 @@ struct URLBatchEditorSheet: View {
                         .contentShape(RoundedRectangle(cornerRadius: SettingsUIStyle.controlCornerRadius, style: .continuous))
                         .onHover { isTestInputHovered = $0 }
 
-                    Text(testFeedbackText)
-                        .font(.caption)
-                        .foregroundStyle(testFeedbackColor)
+                    HStack(spacing: 6) {
+                        testFeedbackIcon
+
+                        Text(testFeedbackText)
+                            .font(.caption)
+                            .foregroundStyle(testFeedbackColor)
+                    }
+                    .onChange(of: testInput) { _, _ in
+                        refreshTestFavicon()
+                    }
+                    .onChange(of: text) { _, _ in
+                        refreshTestFavicon()
+                    }
                 }
             }
 
@@ -284,10 +376,87 @@ struct URLBatchEditorSheet: View {
         return AppLocalization.localizedString("No pattern matched.")
     }
 
+    @ViewBuilder
+    private var testFeedbackIcon: some View {
+        switch testStatus {
+        case .matched:
+            if let testFaviconImage {
+                Image(nsImage: testFaviconImage)
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+            } else if isLoadingTestFavicon {
+                ProgressView()
+                    .controlSize(.small)
+                    .scaleEffect(0.55)
+                    .frame(width: 16, height: 16)
+            } else {
+                Image(systemName: "globe")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(testFeedbackColor)
+                    .frame(width: 16, height: 16)
+            }
+        case .unmatched:
+            Image(systemName: "xmark.circle")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(testFeedbackColor)
+                .frame(width: 16, height: 16)
+        case .idle:
+            Image(systemName: "globe")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(testFeedbackColor)
+                .frame(width: 16, height: 16)
+        }
+    }
+
     private var testStatus: URLPatternTestStatus {
         guard !testInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return .idle }
         guard !normalizedPatterns.isEmpty, normalizedCandidate != nil else { return .idle }
         return matchedPattern == nil ? .unmatched : .matched
+    }
+
+    private var testFaviconOriginCandidate: String? {
+        guard testStatus == .matched else { return nil }
+        let trimmed = testInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let urlString = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        return EnhancementOverlayIconResolver.faviconOrigin(fromPageURL: urlString)
+    }
+
+    private func refreshTestFavicon() {
+        guard let origin = testFaviconOriginCandidate else {
+            testFaviconOrigin = nil
+            testFaviconImage = nil
+            isLoadingTestFavicon = false
+            testFaviconLookupID = UUID()
+            return
+        }
+
+        if origin == testFaviconOrigin, testFaviconImage != nil {
+            return
+        }
+
+        testFaviconOrigin = origin
+        testFaviconLookupID = UUID()
+        let lookupID = testFaviconLookupID
+
+        if let cached = EnhancementOverlayIconResolver.cachedFavicon(forOrigin: origin) {
+            testFaviconImage = cached
+            isLoadingTestFavicon = false
+            return
+        }
+
+        testFaviconImage = nil
+        isLoadingTestFavicon = true
+
+        Task {
+            let image = await EnhancementOverlayIconResolver.favicon(forOrigin: origin)
+            await MainActor.run {
+                guard testFaviconLookupID == lookupID else { return }
+                testFaviconImage = image
+                isLoadingTestFavicon = false
+            }
+        }
     }
 }
 

--- a/Voxt/Settings/Features/FeatureSettingsRows.swift
+++ b/Voxt/Settings/Features/FeatureSettingsRows.swift
@@ -380,6 +380,7 @@ struct SettingsShortcutCaptureField: View {
     var isReadOnly: Bool = false
     var modeButtonTitle: String? = nil
     var isModeButtonSelected = false
+    var showsTitle = true
     var onModeButtonToggle: (() -> Void)? = nil
     var controlWidth: CGFloat = 320
     let onFocus: () -> Void
@@ -390,10 +391,12 @@ struct SettingsShortcutCaptureField: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 18) {
-            Text(title)
-                .font(.body.weight(.semibold))
-                .foregroundStyle(.primary.opacity(0.92))
-            Spacer()
+            if showsTitle {
+                Text(title)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.primary.opacity(0.92))
+                Spacer()
+            }
 
             HStack(spacing: 8) {
                 if let modeButtonTitle, let onModeButtonToggle {

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -1937,6 +1937,11 @@
 "Keep this conservative for stable dictation output." = "Keep this conservative for stable dictation output.";
 "Automatic, zh, en" = "Automatic, zh, en";
 "Automatic, zh, en, yue, ja, ko" = "Automatic, zh, en, yue, ja, ko";
+"Auto Return" = "Auto Return";
+"Press Return automatically after Voxt inserts text for this group." = "Press Return automatically after Voxt inserts text for this group.";
+"Auto Key" = "Auto Key";
+"Press the configured key automatically after Voxt inserts text for this group. Defaults to Return." = "Press the configured key automatically after Voxt inserts text for this group. Defaults to Return.";
+"Automatically press this key after transcription ends." = "Automatically press this key after transcription ends.";
 "Context On" = "Context On";
 "Context Off" = "Context Off";
 "ITN On" = "ITN On";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -1895,6 +1895,11 @@
 "Keep this conservative for stable dictation output." = "安定したディクテーション出力のため、控えめな設定にしてください。";
 "Automatic, zh, en" = "自動、zh、en";
 "Automatic, zh, en, yue, ja, ko" = "自動、zh、en、yue、ja、ko";
+"Auto Return" = "自動 Return";
+"Press Return automatically after Voxt inserts text for this group." = "このグループで Voxt がテキストを挿入した後、自動的に Return キーを押します。";
+"Auto Key" = "自動キー";
+"Press the configured key automatically after Voxt inserts text for this group. Defaults to Return." = "このグループで Voxt がテキストを挿入した後、設定したキーを自動的に押します。デフォルトは Return です。";
+"Automatically press this key after transcription ends." = "文字起こし終了後にこのキーを自動的に押します。";
 "Context On" = "コンテキストオン";
 "Context Off" = "コンテキストオフ";
 "ITN On" = "ITN オン";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -1937,6 +1937,11 @@
 "Keep this conservative for stable dictation output." = "为保证听写输出稳定，建议保持保守设置。";
 "Automatic, zh, en" = "自动、zh、en";
 "Automatic, zh, en, yue, ja, ko" = "自动、zh、en、yue、ja、ko";
+"Auto Return" = "自动回车";
+"Press Return automatically after Voxt inserts text for this group." = "Voxt 为该分组插入文本后，自动按下回车键。";
+"Auto Key" = "自动按键";
+"Press the configured key automatically after Voxt inserts text for this group. Defaults to Return." = "Voxt 为该分组插入文本后，自动按下配置的按键。默认是回车。";
+"Automatically press this key after transcription ends." = "转录结束后会自动按下该按键。";
 "Context On" = "上下文开";
 "Context Off" = "上下文关";
 "ITN On" = "ITN 开";

--- a/VoxtTests/EnhancementPromptResolverTests.swift
+++ b/VoxtTests/EnhancementPromptResolverTests.swift
@@ -2,6 +2,7 @@
 // Provides Enhancement Prompt Resolver Tests for Voxt test coverage.
 
 import XCTest
+import Carbon
 @testable import Voxt
 
 final class EnhancementPromptResolverTests: XCTestCase {
@@ -260,6 +261,70 @@ final class EnhancementPromptResolverTests: XCTestCase {
         XCTAssertContains(output.content, "Docs cleanup")
         XCTAssertContains(output.content, "Other user languages: None.")
         XCTAssertContains(output.content, "It is guidance only, not a translation target.")
+    }
+
+    func testAppBranchGroupDecodesMissingAutoReturnAsDisabled() throws {
+        let json = """
+        [{
+            "id": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+            "name": "Chat",
+            "prompt": "",
+            "appBundleIDs": ["com.example.chat"],
+            "appRefs": [{"bundleID": "com.example.chat", "displayName": "Chat"}],
+            "urlPatternIDs": [],
+            "isExpanded": true
+        }]
+        """
+
+        let groups = try JSONDecoder().decode([AppBranchGroup].self, from: Data(json.utf8))
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertFalse(groups[0].autoPressReturnEnabled)
+        XCTAssertFalse(groups[0].autoKeyPressEnabled)
+        XCTAssertEqual(groups[0].autoKeyPressHotkey, AppBranchGroup.defaultAutoKeyPressHotkey)
+    }
+
+    func testAppBranchGroupMigratesLegacyAutoReturnSetting() throws {
+        let json = """
+        [{
+            "id": "\(UUID().uuidString)",
+            "name": "Chat",
+            "prompt": "",
+            "appBundleIDs": ["com.example.chat"],
+            "appRefs": [{"bundleID": "com.example.chat", "displayName": "Chat"}],
+            "urlPatternIDs": [],
+            "autoPressReturnEnabled": true,
+            "isExpanded": true
+        }]
+        """
+
+        let groups = try JSONDecoder().decode([AppBranchGroup].self, from: Data(json.utf8))
+
+        XCTAssertTrue(groups[0].autoKeyPressEnabled)
+        XCTAssertEqual(groups[0].autoKeyPressHotkey, AppBranchGroup.defaultAutoKeyPressHotkey)
+        XCTAssertTrue(groups[0].autoPressReturnEnabled)
+    }
+
+    func testAppBranchGroupPreservesAutoKeyPressSetting() throws {
+        let customHotkey = HotkeyPreference.Hotkey(
+            keyCode: UInt16(kVK_Return),
+            modifiers: [.control],
+            sidedModifiers: []
+        )
+        let group = TestFactories.makeAppBranchGroup(
+            name: "Chat",
+            prompt: "",
+            appBundleIDs: ["com.example.chat"],
+            autoKeyPressEnabled: true,
+            autoKeyPressHotkey: customHotkey
+        )
+
+        let data = try JSONEncoder().encode([group])
+        let decoded = try JSONDecoder().decode([AppBranchGroup].self, from: data)
+
+        XCTAssertTrue(decoded[0].autoKeyPressEnabled)
+        XCTAssertEqual(decoded[0].autoKeyPressHotkey, customHotkey)
+        XCTAssertFalse(decoded[0].autoPressReturnEnabled)
     }
 
     func testFaviconOriginKeepsSchemeAndHostOnly() {

--- a/VoxtTests/TestSupport/TestFactories.swift
+++ b/VoxtTests/TestSupport/TestFactories.swift
@@ -93,7 +93,10 @@ enum TestFactories {
         name: String,
         prompt: String,
         appBundleIDs: [String] = [],
-        urlPatternIDs: [UUID] = []
+        urlPatternIDs: [UUID] = [],
+        autoPressReturnEnabled: Bool = false,
+        autoKeyPressEnabled: Bool? = nil,
+        autoKeyPressHotkey: HotkeyPreference.Hotkey = AppBranchGroup.defaultAutoKeyPressHotkey
     ) -> AppBranchGroup {
         AppBranchGroup(
             id: id,
@@ -102,6 +105,9 @@ enum TestFactories {
             appBundleIDs: appBundleIDs,
             appRefs: appBundleIDs.map { AppBranchAppRef(bundleID: $0, displayName: $0) },
             urlPatternIDs: urlPatternIDs,
+            autoPressReturnEnabled: autoPressReturnEnabled,
+            autoKeyPressEnabled: autoKeyPressEnabled,
+            autoKeyPressHotkey: autoKeyPressHotkey,
             isExpanded: true
         )
     }


### PR DESCRIPTION
## 背景

本 PR 基于 #106 的 `feat/pr-101-103-104-integration` 分支，不是基于 `main`。

## 改动内容

- 在应用增强分组中新增「自动按键」能力，替代原来的单一「自动回车」。
- 自动按键开启后默认使用 Return，也支持用户录入自定义组合键，例如 Control + Return。
- 转录文本注入成功后，会自动触发该分组配置的按键。
- 当 prompt 为空但自动按键开启时，仍按应用增强业务处理，Overlay 会展示对应 APP / URL 图标。
- URL Pattern 测试区域在匹配成功后会获取测试网址的 favicon，并复用现有内存和磁盘缓存。
- 兼容旧的 `autoPressReturnEnabled` 配置，自动迁移为「自动按键 + Return」。

## 说明

- 本次没有额外执行构建或测试。
