### PR TITLE
转录热键支持选中文本添加词汇

### DIFF
--- a/Voxt/App/DictionaryFlow.swift
+++ b/Voxt/App/DictionaryFlow.swift
@@ -3,7 +3,55 @@
 
 import Foundation
 
+enum SelectedTextDictionaryHotkeySupport {
+    static let maxCharacterCount = 30
+
+    static func candidateTerm(from selectedText: String?) -> String? {
+        let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty, trimmed.count <= maxCharacterCount else { return nil }
+        return trimmed
+    }
+}
+
 extension AppDelegate {
+    @discardableResult
+    func addSelectedShortTextToDictionaryIfPossible() -> Bool {
+        guard !isSessionActive, pendingTranscriptionStartTask == nil else { return false }
+        guard let term = SelectedTextDictionaryHotkeySupport.candidateTerm(
+            from: selectedTextFromSystemSelection()
+        ) else {
+            return false
+        }
+
+        let scope = currentDictionaryScope()
+        let category = dictionaryStore.ensureCategory(id: scope.groupID, name: scope.groupName)
+
+        do {
+            let result = try dictionaryStore.createOrReinforceAutoEntry(
+                term: term,
+                categoryID: category.id,
+                categoryNameSnapshot: category.name,
+                groupID: scope.groupID,
+                groupNameSnapshot: scope.groupName
+            )
+            let message = result.added
+                ? AppLocalization.format("Added to Dictionary: %@", result.term)
+                : AppLocalization.format("Already in Dictionary: %@", result.term)
+            showFloatingToast(message)
+            VoxtLog.dictionary(
+                "Selected text dictionary hotkey handled. added=\(result.added), termChars=\(term.count), groupID=\(scope.groupID?.uuidString ?? "nil")"
+            )
+        } catch {
+            showFloatingToast(
+                AppLocalization.localizedString("Failed to add to Dictionary."),
+                kind: .warning
+            )
+            VoxtLog.dictionaryWarning("Selected text dictionary hotkey failed: \(error)")
+        }
+
+        return true
+    }
+
     func dictionaryGlossaryText(
         for sourceText: String,
         purpose: DictionaryGlossaryPurpose,

--- a/Voxt/App/HotkeyLifecycle.swift
+++ b/Voxt/App/HotkeyLifecycle.swift
@@ -202,6 +202,7 @@ extension AppDelegate {
             endRecording()
             return
         }
+        guard !addSelectedShortTextToDictionaryIfPossible() else { return }
         pendingTranscriptionHotkeyStartBehavior = .tap
         beginRecording(outputMode: .transcription)
     }
@@ -311,6 +312,10 @@ extension AppDelegate {
                 canStopTapSession: !shouldIgnoreTapStop() && !isSessionStopInProgress
             )
         )
+        if actions.contains(where: { $0 == .startTranscription || $0 == .scheduleTranscriptionStart }),
+           addSelectedShortTextToDictionaryIfPossible() {
+            return
+        }
         for action in actions {
             if action == .scheduleTranscriptionStart, let pendingStartDelay {
                 pendingTranscriptionHotkeyStartBehavior = triggerBehavior

--- a/Voxt/App/Recording/RecordingOverlayFlow.swift
+++ b/Voxt/App/Recording/RecordingOverlayFlow.swift
@@ -37,6 +37,22 @@ extension AppDelegate {
         }
     }
 
+    func showFloatingToast(
+        _ message: String,
+        kind: FloatingToastKind = .success,
+        clearAfter seconds: TimeInterval = 1.8
+    ) {
+        toastDismissTask?.cancel()
+        toastWindow.show(message: message, kind: kind, position: overlayPosition)
+        toastDismissTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .seconds(seconds))
+            guard !Task.isCancelled else { return }
+            self.toastWindow.hide()
+            self.toastDismissTask = nil
+        }
+    }
+
     func setEnhancingState(_ isEnhancing: Bool) {
         overlayState.isEnhancing = isEnhancing
         if overlayState.displayMode != .answer {

--- a/Voxt/App/VoxtApp.swift
+++ b/Voxt/App/VoxtApp.swift
@@ -128,6 +128,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     let hotkeyManager = HotkeyManager()
     let overlayWindow = RecordingOverlayWindow()
+    let toastWindow = FloatingToastWindow()
     let meetingOverlayWindow = MeetingOverlayWindow()
     let meetingDetailWindowManager = MeetingDetailWindowManager.shared
     let overlayState = OverlayState()
@@ -193,6 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var remoteLLMWarmupTasksByKey: [String: Task<Void, Never>] = [:]
     var overlayReminderTask: Task<Void, Never>?
     var overlayStatusClearTask: Task<Void, Never>?
+    var toastDismissTask: Task<Void, Never>?
     var pendingSystemAudioMuteTask: Task<Void, Never>?
     var pendingSelectedTextTranslationRefreshTask: Task<Void, Never>?
     var pendingMeetingStartupTask: Task<Void, Never>?

--- a/Voxt/Settings/AppEnhancement/AppEnhancementCards.swift
+++ b/Voxt/Settings/AppEnhancement/AppEnhancementCards.swift
@@ -256,7 +256,7 @@ extension AppEnhancementSettingsView {
         return VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
                 Image(systemName: "globe")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 24, height: 24)
                 Text(item.pattern)

--- a/Voxt/Settings/ReportSettingsView.swift
+++ b/Voxt/Settings/ReportSettingsView.swift
@@ -354,6 +354,8 @@ private struct BranchRankingRow: View {
 private struct BranchMetricIcon: View {
     let item: HistoryBranchMetricItem
     @State private var image: NSImage?
+    private var imageSize: CGFloat { item.kind == .url ? 14 : 18 }
+    private var cornerRadius: CGFloat { item.kind == .url ? 3 : 4 }
 
     var body: some View {
         Group {
@@ -361,13 +363,15 @@ private struct BranchMetricIcon: View {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+                    .frame(width: imageSize, height: imageSize)
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             } else {
                 Image(systemName: item.kind == .url ? "globe" : "app.dashed")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: item.kind == .url ? 10 : 12, weight: .semibold))
                     .foregroundStyle(.secondary)
             }
         }
+        .frame(width: 18, height: 18)
         .task(id: item.id) {
             await loadImage()
         }

--- a/Voxt/Windows/RecordingOverlayWindow.swift
+++ b/Voxt/Windows/RecordingOverlayWindow.swift
@@ -225,6 +225,143 @@ class RecordingOverlayWindow: NSPanel {
     }
 }
 
+enum FloatingToastKind {
+    case success
+    case warning
+
+    var systemImageName: String {
+        switch self {
+        case .success:
+            return "checkmark.circle.fill"
+        case .warning:
+            return "exclamationmark.circle.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .success:
+            return Color(nsColor: .systemGreen)
+        case .warning:
+            return Color(nsColor: .systemOrange)
+        }
+    }
+}
+
+class FloatingToastWindow: NSPanel {
+    private var hostingView: NSHostingView<FloatingToastContent>?
+    private let panelSize = CGSize(width: 240, height: 52)
+
+    init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        level = .floating
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        isMovableByWindowBackground = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        ignoresMouseEvents = true
+    }
+
+    override var canBecomeKey: Bool { false }
+
+    func show(message: String, kind: FloatingToastKind, position: OverlayPosition) {
+        let content = FloatingToastContent(message: message, kind: kind)
+        if let hostingView {
+            hostingView.rootView = content
+        } else {
+            let hosting = NSHostingView(rootView: content)
+            hosting.translatesAutoresizingMaskIntoConstraints = true
+            hosting.autoresizingMask = [.width, .height]
+            contentView = hosting
+            hostingView = hosting
+        }
+
+        setFrame(frame(for: panelSize, position: position), display: true)
+        alphaValue = 1
+        orderFrontRegardless()
+    }
+
+    func hide() {
+        orderOut(nil)
+    }
+
+    private func frame(for size: CGSize, position: OverlayPosition) -> CGRect {
+        let visibleFrame = NSScreen.main?.visibleFrame ?? .zero
+        guard !visibleFrame.isEmpty else {
+            return CGRect(origin: frame.origin, size: size)
+        }
+
+        let edgeInset = overlayScreenEdgeInset
+        let x = visibleFrame.midX - size.width / 2
+        let y: CGFloat
+        switch position {
+        case .bottom:
+            y = visibleFrame.minY + edgeInset
+        case .top:
+            y = visibleFrame.maxY - size.height - edgeInset
+        }
+        return CGRect(origin: CGPoint(x: x, y: y), size: size)
+    }
+
+    private var overlayScreenEdgeInset: CGFloat {
+        let storedValue = UserDefaults.standard.object(forKey: AppPreferenceKey.overlayScreenEdgeInset) as? Int ?? 30
+        return CGFloat(min(max(storedValue, 0), 120))
+    }
+}
+
+private struct FloatingToastContent: View {
+    @AppStorage(AppPreferenceKey.overlayCardOpacity) private var overlayCardOpacity = 82
+    @AppStorage(AppPreferenceKey.overlayCardCornerRadius) private var overlayCardCornerRadius = 24
+
+    let message: String
+    let kind: FloatingToastKind
+    @State private var appeared = false
+
+    private var cornerRadius: CGFloat { CGFloat(min(max(overlayCardCornerRadius, 0), 40)) }
+    private var cardOpacity: Double { Double(min(max(overlayCardOpacity, 0), 100)) / 100.0 }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: kind.systemImageName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(kind.color)
+            Text(message)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(.white.opacity(0.94))
+        }
+        .frame(width: 240, height: 52)
+        .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .shadow(color: .black.opacity(0.18), radius: 18, y: 10)
+        .scaleEffect(appeared ? 1.0 : 0.88, anchor: .bottom)
+        .opacity(appeared ? 1.0 : 0.0)
+        .animation(.spring(response: 0.35, dampingFraction: 0.62, blendDuration: 0.1), value: appeared)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                appeared = true
+            }
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(.black.opacity(cardOpacity))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+            )
+    }
+}
+
 private extension CGRect {
     func isApproximatelyEqual(to other: CGRect, tolerance: CGFloat = 0.5) -> Bool {
         abs(origin.x - other.origin.x) <= tolerance &&

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -128,6 +128,9 @@
 "Thanks" = "Thanks";
 "Logs" = "Logs";
 "View Logs" = "View Logs";
+"Added to Dictionary: %@" = "Added: %@";
+"Already in Dictionary: %@" = "Already added: %@";
+"Failed to add to Dictionary." = "Failed to add to Dictionary.";
 "Export Latest Logs (2000)" = "Export Latest Logs (2000)";
 "No logs yet" = "No logs yet";
 "Export canceled" = "Export canceled";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -123,6 +123,9 @@
 "Thanks" = "謝辞";
 "Logs" = "ログ";
 "View Logs" = "ログを表示";
+"Added to Dictionary: %@" = "追加済み: %@";
+"Already in Dictionary: %@" = "登録済み: %@";
+"Failed to add to Dictionary." = "辞書への追加に失敗しました。";
 "Export Latest Logs (2000)" = "最新ログをエクスポート（2000件）";
 "No logs yet" = "ログはまだありません";
 "Export canceled" = "エクスポートをキャンセルしました";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -128,6 +128,9 @@
 "Thanks" = "感谢";
 "Logs" = "日志";
 "View Logs" = "查看日志";
+"Added to Dictionary: %@" = "已添加：%@";
+"Already in Dictionary: %@" = "已存在：%@";
+"Failed to add to Dictionary." = "添加到词典失败。";
 "Export Latest Logs (2000)" = "导出最新日志（2000条）";
 "No logs yet" = "暂无日志";
 "Export canceled" = "导出已取消";

--- a/VoxtTests/SessionTextIOTests.swift
+++ b/VoxtTests/SessionTextIOTests.swift
@@ -6,6 +6,28 @@ import XCTest
 
 @MainActor
 final class SessionTextIOTests: XCTestCase {
+    func testSelectedTextDictionaryHotkeyAcceptsThirtyCharacters() {
+        let candidate = String(repeating: "词", count: 30)
+        XCTAssertEqual(SelectedTextDictionaryHotkeySupport.candidateTerm(from: candidate), candidate)
+    }
+
+    func testSelectedTextDictionaryHotkeyRejectsMoreThanThirtyCharacters() {
+        let candidate = String(repeating: "词", count: 31)
+        XCTAssertNil(SelectedTextDictionaryHotkeySupport.candidateTerm(from: candidate))
+    }
+
+    func testSelectedTextDictionaryHotkeyTrimsWhitespace() {
+        XCTAssertEqual(
+            SelectedTextDictionaryHotkeySupport.candidateTerm(from: "  OpenAI\n"),
+            "OpenAI"
+        )
+    }
+
+    func testSelectedTextDictionaryHotkeyRejectsEmptySelection() {
+        XCTAssertNil(SelectedTextDictionaryHotkeySupport.candidateTerm(from: " \n "))
+        XCTAssertNil(SelectedTextDictionaryHotkeySupport.candidateTerm(from: nil))
+    }
+
     func testRewriteAlwaysPresentsAnswerOverlay() {
         XCTAssertTrue(
             AppDelegate.shouldPresentRewriteAnswerOverlay(


### PR DESCRIPTION
## 变更说明

- 转录热键在未录音时会优先检查当前选中文本；若文本不为空且不超过 30 个字符，则直接添加或强化到词典，不启动转录。
- 新增迷你浮动 toast，复用现有 overlay 卡片视觉风格，用于提示词汇添加、已存在或失败状态。
- 调整首页增强统计和自定义增强 URL 图标尺寸，使 URL favicon 与 App 图标视觉更协调。

## 测试

- [x] xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/SessionTextIOTests

## 基础分支

本 PR 基于 #106 的分支：feat/pr-101-103-104-integration。