### PR TITLE
Add remote ASR upload VAD preprocessing

### DIFF
--- a/Voxt/App/Recording/RecordingCaptureFlow.swift
+++ b/Voxt/App/Recording/RecordingCaptureFlow.swift
@@ -168,6 +168,7 @@ extension AppDelegate {
             }
             self.remoteASRTranscriber.transcribedText = ""
             self.remoteASRTranscriber.sessionAllowsRealtimeTextDisplay = self.transcriptionCapturePipeline.usesLiveDisplay
+            self.remoteASRTranscriber.voiceActivityUseCase = self.voiceActivityUseCase
             self.remoteASRTranscriber.onTranscriptionFinished = { [weak self] text in
                 self?.stashPendingCompletedHistoryAudioArchive(self?.remoteASRTranscriber.consumeCompletedAudioArchiveURL())
                 self?.processTranscription(text, sessionID: sessionID)

--- a/Voxt/Core/Transcription/ASRVoiceActivitySampleFilter.swift
+++ b/Voxt/Core/Transcription/ASRVoiceActivitySampleFilter.swift
@@ -1,0 +1,160 @@
+// ASRVoiceActivitySampleFilter.swift
+// Provides reusable VAD-based audio sample filtering for ASR upload preparation.
+
+import Foundation
+
+nonisolated struct ASRVoiceActivitySampleFilterResult: Equatable, Sendable {
+    let samples: [Float]
+    let observedFrames: Bool
+    let observedSpeech: Bool
+    let speechSegments: [ASRVoiceActivitySegment]
+    let originalDurationSeconds: TimeInterval
+    let filteredDurationSeconds: TimeInterval
+
+    var reductionRatio: Double {
+        guard originalDurationSeconds > 0 else { return 0 }
+        return max(0, min(1, 1 - (filteredDurationSeconds / originalDurationSeconds)))
+    }
+}
+
+nonisolated enum ASRVoiceActivitySampleFilter {
+    nonisolated static let defaultMaximumJoinGapSeconds: TimeInterval = 0.25
+
+    nonisolated static func filter(
+        samples: [Float],
+        sampleRate: Double,
+        decisions: [ASRVoiceActivityFrameDecision],
+        configuration: ASRVoiceActivityConfiguration,
+        maximumJoinGapSeconds: TimeInterval = defaultMaximumJoinGapSeconds
+    ) -> ASRVoiceActivitySampleFilterResult {
+        let safeRate = sampleRate.isFinite ? max(0, sampleRate) : 0
+        let originalDuration = safeRate > 0 ? Double(samples.count) / safeRate : 0
+        guard !samples.isEmpty, safeRate > 0 else {
+            return ASRVoiceActivitySampleFilterResult(
+                samples: [],
+                observedFrames: false,
+                observedSpeech: false,
+                speechSegments: [],
+                originalDurationSeconds: originalDuration,
+                filteredDurationSeconds: 0
+            )
+        }
+
+        var segmenter = ASRVoiceActivitySegmenter(configuration: configuration)
+        var segments: [ASRVoiceActivitySegment] = []
+        var observedFrames = false
+        var observedSpeech = false
+
+        for decision in decisions where decision.endSeconds > decision.startSeconds {
+            observedFrames = true
+            let result = segmenter.appendWithResolvedSpeechState(decision)
+            if result.isSpeech {
+                observedSpeech = true
+            }
+            for event in result.events {
+                if let segment = acceptedSegment(from: event) {
+                    segments.append(segment)
+                }
+            }
+        }
+
+        if let event = segmenter.finish(at: originalDuration),
+           let segment = acceptedSegment(from: event) {
+            segments.append(segment)
+        }
+
+        let mergedSegments = mergeSegments(
+            segments,
+            maximumJoinGapSeconds: maximumJoinGapSeconds,
+            originalDurationSeconds: originalDuration
+        )
+        let filtered = samplesForSegments(
+            mergedSegments,
+            from: samples,
+            sampleRate: safeRate
+        )
+        let filteredDuration = safeRate > 0 ? Double(filtered.count) / safeRate : 0
+
+        return ASRVoiceActivitySampleFilterResult(
+            samples: filtered,
+            observedFrames: observedFrames,
+            observedSpeech: observedSpeech,
+            speechSegments: mergedSegments,
+            originalDurationSeconds: originalDuration,
+            filteredDurationSeconds: filteredDuration
+        )
+    }
+
+    private nonisolated static func acceptedSegment(
+        from event: ASRVoiceActivityEvent
+    ) -> ASRVoiceActivitySegment? {
+        switch event {
+        case .speechEnded(let segment), .speechForced(let segment):
+            return segment
+        case .speechRejected, .speechStarted:
+            return nil
+        }
+    }
+
+    private nonisolated static func mergeSegments(
+        _ segments: [ASRVoiceActivitySegment],
+        maximumJoinGapSeconds: TimeInterval,
+        originalDurationSeconds: TimeInterval
+    ) -> [ASRVoiceActivitySegment] {
+        let sorted = segments
+            .filter { $0.endSeconds > $0.startSeconds }
+            .sorted { lhs, rhs in
+                if lhs.startSeconds == rhs.startSeconds {
+                    return lhs.endSeconds < rhs.endSeconds
+                }
+                return lhs.startSeconds < rhs.startSeconds
+            }
+        guard var current = sorted.first else { return [] }
+
+        var merged: [ASRVoiceActivitySegment] = []
+        for segment in sorted.dropFirst() {
+            let gap = segment.startSeconds - current.endSeconds
+            if gap <= max(0, maximumJoinGapSeconds) {
+                current = ASRVoiceActivitySegment(
+                    startSeconds: current.startSeconds,
+                    endSeconds: min(max(current.endSeconds, segment.endSeconds), originalDurationSeconds),
+                    speechSeconds: current.speechSeconds + segment.speechSeconds,
+                    frameCount: current.frameCount + segment.frameCount
+                )
+            } else {
+                merged.append(clamped(current, originalDurationSeconds: originalDurationSeconds))
+                current = segment
+            }
+        }
+        merged.append(clamped(current, originalDurationSeconds: originalDurationSeconds))
+        return merged
+    }
+
+    private nonisolated static func clamped(
+        _ segment: ASRVoiceActivitySegment,
+        originalDurationSeconds: TimeInterval
+    ) -> ASRVoiceActivitySegment {
+        ASRVoiceActivitySegment(
+            startSeconds: min(max(0, segment.startSeconds), originalDurationSeconds),
+            endSeconds: min(max(0, segment.endSeconds), originalDurationSeconds),
+            speechSeconds: segment.speechSeconds,
+            frameCount: segment.frameCount
+        )
+    }
+
+    private nonisolated static func samplesForSegments(
+        _ segments: [ASRVoiceActivitySegment],
+        from samples: [Float],
+        sampleRate: Double
+    ) -> [Float] {
+        guard sampleRate > 0, !samples.isEmpty else { return [] }
+        var output: [Float] = []
+        for segment in segments {
+            let startIndex = max(0, min(samples.count, Int((segment.startSeconds * sampleRate).rounded(.down))))
+            let endIndex = max(startIndex, min(samples.count, Int((segment.endSeconds * sampleRate).rounded(.up))))
+            guard startIndex < endIndex else { continue }
+            output.append(contentsOf: samples[startIndex..<endIndex])
+        }
+        return output
+    }
+}

--- a/Voxt/Transcription/RemoteASR/RemoteASRAudioUploadPreprocessing.swift
+++ b/Voxt/Transcription/RemoteASR/RemoteASRAudioUploadPreprocessing.swift
@@ -1,0 +1,326 @@
+// RemoteASRAudioUploadPreprocessing.swift
+// Provides remote ASR upload audio policy and client-side VAD preprocessing.
+
+import Foundation
+
+enum RemoteASRAudioUploadVADPolicy: Equatable, Sendable {
+    case disabled(reason: String)
+    case fileUploadClientVAD
+    case realtimeServerVAD
+    case realtimeUnchanged(reason: String)
+
+    var usesFileUploadClientVAD: Bool {
+        if case .fileUploadClientVAD = self {
+            return true
+        }
+        return false
+    }
+
+    var telemetryName: String {
+        switch self {
+        case .disabled(let reason):
+            return "disabled:\(reason)"
+        case .fileUploadClientVAD:
+            return "file-upload-client-vad"
+        case .realtimeServerVAD:
+            return "realtime-server-vad"
+        case .realtimeUnchanged(let reason):
+            return "realtime-unchanged:\(reason)"
+        }
+    }
+}
+
+enum RemoteASRAudioUploadVADPolicyResolver {
+    static func policy(
+        provider: RemoteASRProvider,
+        model: String,
+        localVADMode: LocalVADMode
+    ) -> RemoteASRAudioUploadVADPolicy {
+        guard localVADMode != .off else {
+            return .disabled(reason: "local-vad-off")
+        }
+
+        let resolvedModel = model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? provider.suggestedModel
+            : model
+        switch provider {
+        case .openAIWhisper, .glmASR, .xiaomiMiMoASR:
+            return .fileUploadClientVAD
+        case .stepFunASR:
+            if RemoteASRRealtimeSupport.isStepFunRealtimeModel(resolvedModel) {
+                return .realtimeServerVAD
+            }
+            return .fileUploadClientVAD
+        case .aliyunBailianASR:
+            if RemoteASREndpointSupport.aliyunQwenRealtimeSessionKind(for: resolvedModel) != nil {
+                return .realtimeServerVAD
+            }
+            if RemoteASREndpointSupport.isAliyunFunRealtimeModel(resolvedModel) {
+                return .realtimeUnchanged(reason: "aliyun-fun-realtime")
+            }
+            if RemoteASREndpointSupport.isAliyunFileTranscriptionModel(resolvedModel) {
+                return .fileUploadClientVAD
+            }
+            return .disabled(reason: "unsupported-aliyun-route")
+        case .doubaoASR:
+            return .realtimeUnchanged(reason: "doubao-streaming")
+        }
+    }
+}
+
+struct RemoteASRAudioUploadPreparation: Sendable {
+    let uploadFileURL: URL
+    let temporaryUploadFileURL: URL?
+    let policy: RemoteASRAudioUploadVADPolicy
+    let originalDurationSeconds: TimeInterval?
+    let uploadDurationSeconds: TimeInterval?
+    let speechSegmentCount: Int
+    let observedSpeech: Bool?
+
+    var shouldRequestRemoteASR: Bool {
+        observedSpeech != false
+    }
+
+    func cleanupTemporaryUploadFileIfNeeded() {
+        guard let temporaryUploadFileURL else { return }
+        try? FileManager.default.removeItem(at: temporaryUploadFileURL)
+    }
+
+    static func original(
+        fileURL: URL,
+        policy: RemoteASRAudioUploadVADPolicy,
+        originalDurationSeconds: TimeInterval? = nil,
+        observedSpeech: Bool? = nil
+    ) -> RemoteASRAudioUploadPreparation {
+        RemoteASRAudioUploadPreparation(
+            uploadFileURL: fileURL,
+            temporaryUploadFileURL: nil,
+            policy: policy,
+            originalDurationSeconds: originalDurationSeconds,
+            uploadDurationSeconds: originalDurationSeconds,
+            speechSegmentCount: 0,
+            observedSpeech: observedSpeech
+        )
+    }
+}
+
+enum RemoteASRAudioUploadPreprocessor {
+    nonisolated static let minimumAudioDurationSeconds: TimeInterval = 3.0
+    nonisolated static let minimumReductionRatioForFilteredUpload: Double = 0.15
+    nonisolated static let defaultEnergyThreshold: Float = 0.06
+    nonisolated static let frameSize = 1_024
+
+    static func prepareUploadAudio(
+        originalFileURL: URL,
+        provider: RemoteASRProvider,
+        configuration: RemoteProviderConfiguration,
+        localVADMode: LocalVADMode,
+        useCase: ASRVoiceActivityUseCase,
+        energyThreshold: Float = defaultEnergyThreshold
+    ) async throws -> RemoteASRAudioUploadPreparation {
+        let policy = RemoteASRAudioUploadVADPolicyResolver.policy(
+            provider: provider,
+            model: configuration.model,
+            localVADMode: localVADMode
+        )
+        guard policy.usesFileUploadClientVAD else {
+            return .original(fileURL: originalFileURL, policy: policy)
+        }
+
+        let samples = try HistoryAudioArchiveSupport.readWAVSamples(from: originalFileURL)
+        let sampleRate = HistoryAudioArchiveSupport.targetSampleRate
+        let originalDurationSeconds = Double(samples.count) / sampleRate
+        guard originalDurationSeconds >= minimumAudioDurationSeconds else {
+            return .original(
+                fileURL: originalFileURL,
+                policy: .disabled(reason: "short-audio"),
+                originalDurationSeconds: originalDurationSeconds
+            )
+        }
+
+        let decisions = await voiceActivityDecisions(
+            samples: samples,
+            sampleRate: sampleRate,
+            mode: localVADMode,
+            useCase: useCase,
+            energyThreshold: energyThreshold
+        )
+        let result = ASRVoiceActivitySampleFilter.filter(
+            samples: samples,
+            sampleRate: sampleRate,
+            decisions: decisions,
+            configuration: ASRVoiceActivityConfiguration.profile(for: useCase)
+        )
+
+        guard result.observedFrames else {
+            return .original(
+                fileURL: originalFileURL,
+                policy: .disabled(reason: "no-vad-frames"),
+                originalDurationSeconds: originalDurationSeconds
+            )
+        }
+        guard result.observedSpeech else {
+            return RemoteASRAudioUploadPreparation(
+                uploadFileURL: originalFileURL,
+                temporaryUploadFileURL: nil,
+                policy: policy,
+                originalDurationSeconds: result.originalDurationSeconds,
+                uploadDurationSeconds: 0,
+                speechSegmentCount: 0,
+                observedSpeech: false
+            )
+        }
+        guard !result.samples.isEmpty,
+              result.reductionRatio >= minimumReductionRatioForFilteredUpload
+        else {
+            return .original(
+                fileURL: originalFileURL,
+                policy: .disabled(reason: "low-reduction"),
+                originalDurationSeconds: result.originalDurationSeconds,
+                observedSpeech: true
+            )
+        }
+
+        let uploadURL = HistoryAudioArchiveSupport.temporaryArchiveURL(prefix: "voxt-remote-asr-upload-vad")
+        do {
+            let didExport = try HistoryAudioArchiveSupport.exportWAV(
+                samples: result.samples,
+                sampleRate: sampleRate,
+                to: uploadURL
+            )
+            guard didExport else {
+                return .original(
+                    fileURL: originalFileURL,
+                    policy: .disabled(reason: "empty-export"),
+                    originalDurationSeconds: result.originalDurationSeconds,
+                    observedSpeech: true
+                )
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: uploadURL)
+            throw error
+        }
+
+        return RemoteASRAudioUploadPreparation(
+            uploadFileURL: uploadURL,
+            temporaryUploadFileURL: uploadURL,
+            policy: policy,
+            originalDurationSeconds: result.originalDurationSeconds,
+            uploadDurationSeconds: result.filteredDurationSeconds,
+            speechSegmentCount: result.speechSegments.count,
+            observedSpeech: true
+        )
+    }
+
+    private static func voiceActivityDecisions(
+        samples: [Float],
+        sampleRate: Double,
+        mode: LocalVADMode,
+        useCase: ASRVoiceActivityUseCase,
+        energyThreshold: Float
+    ) async -> [ASRVoiceActivityFrameDecision] {
+        let decider = RemoteASRAudioUploadVADFrameDecider(
+            mode: mode,
+            useCase: useCase,
+            energyThreshold: energyThreshold
+        )
+        var decisions: [ASRVoiceActivityFrameDecision] = []
+        decisions.reserveCapacity(max(samples.count / frameSize, 1))
+
+        var index = 0
+        while index < samples.count {
+            let endIndex = min(samples.count, index + frameSize)
+            let frameSamples = Array(samples[index..<endIndex])
+            let startSeconds = Double(index) / sampleRate
+            let endSeconds = Double(endIndex) / sampleRate
+            let level = AudioLevelMeter.normalizedLevel(fromSamples: frameSamples)
+            let frame = ASRVoiceActivityAudioFrame(
+                samples: frameSamples,
+                sampleRate: sampleRate,
+                startSeconds: startSeconds,
+                endSeconds: endSeconds,
+                level: level
+            )
+            if let decision = await decider.decision(for: frame) {
+                decisions.append(decision)
+            }
+            index = endIndex
+        }
+        return decisions
+    }
+}
+
+private actor RemoteASRAudioUploadVADFrameDecider {
+    private let mode: LocalVADMode
+    private let useCase: ASRVoiceActivityUseCase
+    private let energyBackend: ASREnergyVoiceActivityBackend
+    private let sileroThreshold: Float
+    private let sileroDetector = ASRSileroStreamingVoiceActivityDetector()
+    private var sileroFallbackWarningLogged = false
+
+    init(
+        mode: LocalVADMode,
+        useCase: ASRVoiceActivityUseCase,
+        energyThreshold: Float
+    ) {
+        self.mode = mode
+        self.useCase = useCase
+        self.energyBackend = ASREnergyVoiceActivityBackend(threshold: energyThreshold)
+        self.sileroThreshold = ASRVoiceActivityConfiguration.profile(for: useCase).onsetProbabilityThreshold
+    }
+
+    func decision(for frame: ASRVoiceActivityAudioFrame) async -> ASRVoiceActivityFrameDecision? {
+        switch ASRVoiceActivityRuntimePolicy.effectiveBackend(mode: mode, useCase: useCase) {
+        case .off:
+            return nil
+        case .energy:
+            return energyDecision(for: frame)
+        case .mlxSilero:
+            return await sileroDecision(for: frame) ?? energyDecision(for: frame)
+        }
+    }
+
+    private func sileroDecision(for frame: ASRVoiceActivityAudioFrame) async -> ASRVoiceActivityFrameDecision? {
+        do {
+            if let probability = try await sileroDetector.probability(
+                samples: frame.samples,
+                sampleRate: frame.sampleRate,
+                streamID: "remote-upload-\(useCase.rawValue)"
+            ) {
+                return ASRVoiceActivityFrameDecision(
+                    startSeconds: frame.startSeconds,
+                    endSeconds: frame.endSeconds,
+                    isSpeech: probability >= sileroThreshold,
+                    probability: probability
+                )
+            }
+        } catch {
+            if shouldLogSileroFallback(error) {
+                VoxtLog.asrWarning("Remote upload Silero VAD failed; falling back to energy VAD. error=\(error.localizedDescription)")
+                sileroFallbackWarningLogged = true
+            }
+            await sileroDetector.reset()
+        }
+        return nil
+    }
+
+    private func energyDecision(for frame: ASRVoiceActivityAudioFrame) -> ASRVoiceActivityFrameDecision? {
+        let level = frame.level ?? 0
+        return ASRVoiceActivityFrameDecision(
+            startSeconds: frame.startSeconds,
+            endSeconds: frame.endSeconds,
+            isSpeech: level >= energyBackend.threshold,
+            probability: nil
+        )
+    }
+
+    private func shouldLogSileroFallback(_ error: Error) -> Bool {
+        if let modelError = error as? MeetingVADModelError {
+            switch modelError {
+            case .modelNotDownloaded, .runtimeUnavailable:
+                return false
+            }
+        }
+        return !sileroFallbackWarningLogged
+    }
+}

--- a/Voxt/Transcription/RemoteASR/RemoteASRTranscriber.swift
+++ b/Voxt/Transcription/RemoteASR/RemoteASRTranscriber.swift
@@ -45,6 +45,7 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
     var onRuntimeFailure: ((String) -> Void)?
     var dictionaryEntryProvider: (() -> [DictionaryEntry])?
     var doubaoDictionaryEntryProvider: (() -> [DictionaryEntry])?
+    var voiceActivityUseCase: ASRVoiceActivityUseCase = .transcription
 
     private var recorder: AVAudioRecorder?
     let audioEngine = AVAudioEngine()
@@ -301,8 +302,25 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         isRequesting = true
         transcribeTask = Task { [weak self] in
             guard let self else { return }
+            let uploadPreparation = await self.prepareUploadAudioForRemoteASR(originalFileURL: fileURL)
+            defer {
+                uploadPreparation.cleanupTemporaryUploadFileIfNeeded()
+            }
+            guard uploadPreparation.shouldRequestRemoteASR else {
+                await MainActor.run {
+                    guard self.isCurrentGeneration(generationID) else { return }
+                    VoxtLog.asr(
+                        "Remote ASR request skipped because upload VAD observed no speech. provider=\((self.activeProvider ?? self.selectedProvider).rawValue), originalSec=\(Self.telemetrySeconds(uploadPreparation.originalDurationSeconds))",
+                        verbose: true
+                    )
+                    self.completedAudioArchiveURL = fileURL
+                    self.transcribedText = ""
+                    self.finish(with: "", generationID: generationID)
+                }
+                return
+            }
             do {
-                let result = try await self.transcribeRecordedAudio(fileURL: fileURL)
+                let result = try await self.transcribeRecordedAudio(fileURL: uploadPreparation.uploadFileURL)
                 await MainActor.run {
                     guard self.isCurrentGeneration(generationID) else { return }
                     self.transcribedText = result
@@ -318,6 +336,38 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
                     self.finish(with: self.transcribedText, generationID: generationID)
                 }
             }
+        }
+    }
+
+    private func prepareUploadAudioForRemoteASR(originalFileURL: URL) async -> RemoteASRAudioUploadPreparation {
+        let provider = activeProvider ?? selectedProvider
+        let configuration = selectedProviderConfiguration(for: provider)
+        let localVADMode = LocalVADMode.stored()
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        do {
+            let preparation = try await RemoteASRAudioUploadPreprocessor.prepareUploadAudio(
+                originalFileURL: originalFileURL,
+                provider: provider,
+                configuration: configuration,
+                localVADMode: localVADMode,
+                useCase: voiceActivityUseCase
+            )
+            let elapsed = max(0, ProcessInfo.processInfo.systemUptime - startedAt)
+            VoxtLog.asr(
+                """
+                Remote ASR upload audio prepared. provider=\(provider.rawValue), model=\(configuration.model), policy=\(preparation.policy.telemetryName), originalSec=\(Self.telemetrySeconds(preparation.originalDurationSeconds)), uploadSec=\(Self.telemetrySeconds(preparation.uploadDurationSeconds)), segments=\(preparation.speechSegmentCount), observedSpeech=\(preparation.observedSpeech.map(String.init(describing:)) ?? "nil"), elapsedMs=\(String(format: "%.1f", elapsed * 1000))
+                """,
+                verbose: true
+            )
+            return preparation
+        } catch {
+            VoxtLog.asrWarning(
+                "Remote ASR upload VAD preprocessing failed; using original audio. provider=\(provider.rawValue), model=\(configuration.model), error=\(error.localizedDescription)"
+            )
+            return .original(
+                fileURL: originalFileURL,
+                policy: .disabled(reason: "preprocessor-error")
+            )
         }
     }
 
@@ -3199,6 +3249,11 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         withUnsafeBytes(of: bytes) { raw in
             data.replaceSubrange(offset..<(offset + 4), with: raw)
         }
+    }
+
+    private nonisolated static func telemetrySeconds(_ value: TimeInterval?) -> String {
+        guard let value, value.isFinite else { return "nil" }
+        return String(format: "%.3f", value)
     }
 
     private func finish(with text: String, generationID: UUID) {

--- a/VoxtTests/ASRVoiceActivityPlanningTests.swift
+++ b/VoxtTests/ASRVoiceActivityPlanningTests.swift
@@ -696,4 +696,61 @@ final class ASRVoiceActivityPlanningTests: XCTestCase {
         XCTAssertEqual(rejectedSegments.count, burstCount)
         XCTAssertNil(segmenter.finish(at: Double(burstCount) * cycleSeconds))
     }
+
+    func testSampleFilterKeepsOnlySpeechSegments() {
+        let samples = Array(repeating: Float(0), count: 50)
+        let decisions = [
+            ASRVoiceActivityFrameDecision(startSeconds: 0, endSeconds: 1, isSpeech: false),
+            ASRVoiceActivityFrameDecision(startSeconds: 1, endSeconds: 2, isSpeech: true),
+            ASRVoiceActivityFrameDecision(startSeconds: 2, endSeconds: 3, isSpeech: false),
+            ASRVoiceActivityFrameDecision(startSeconds: 3, endSeconds: 5, isSpeech: false)
+        ]
+        let result = ASRVoiceActivitySampleFilter.filter(
+            samples: samples,
+            sampleRate: 10,
+            decisions: decisions,
+            configuration: ASRVoiceActivityConfiguration(
+                onsetProbabilityThreshold: 0.5,
+                offsetProbabilityThreshold: 0.35,
+                minSpeechSeconds: 0.2,
+                minSilenceSeconds: 0.5,
+                speechPadSeconds: 0,
+                maxSegmentSeconds: nil
+            )
+        )
+
+        XCTAssertTrue(result.observedFrames)
+        XCTAssertTrue(result.observedSpeech)
+        XCTAssertEqual(result.speechSegments.count, 1)
+        XCTAssertEqual(result.samples.count, 10)
+        XCTAssertEqual(result.originalDurationSeconds, 5, accuracy: 0.001)
+        XCTAssertEqual(result.filteredDurationSeconds, 1, accuracy: 0.001)
+    }
+
+    func testSampleFilterReturnsEmptyWhenNoSpeechObserved() {
+        let samples = Array(repeating: Float(0), count: 40)
+        let decisions = [
+            ASRVoiceActivityFrameDecision(startSeconds: 0, endSeconds: 1, isSpeech: false),
+            ASRVoiceActivityFrameDecision(startSeconds: 1, endSeconds: 2, isSpeech: false),
+            ASRVoiceActivityFrameDecision(startSeconds: 2, endSeconds: 4, isSpeech: false)
+        ]
+        let result = ASRVoiceActivitySampleFilter.filter(
+            samples: samples,
+            sampleRate: 10,
+            decisions: decisions,
+            configuration: ASRVoiceActivityConfiguration(
+                onsetProbabilityThreshold: 0.5,
+                offsetProbabilityThreshold: 0.35,
+                minSpeechSeconds: 0.2,
+                minSilenceSeconds: 0.5,
+                speechPadSeconds: 0,
+                maxSegmentSeconds: nil
+            )
+        )
+
+        XCTAssertTrue(result.observedFrames)
+        XCTAssertFalse(result.observedSpeech)
+        XCTAssertTrue(result.speechSegments.isEmpty)
+        XCTAssertTrue(result.samples.isEmpty)
+    }
 }

--- a/VoxtTests/RemoteASRSupportTests.swift
+++ b/VoxtTests/RemoteASRSupportTests.swift
@@ -37,6 +37,118 @@ final class RemoteASRSupportTests: XCTestCase {
         XCTAssertNil(fields["stream"])
     }
 
+    func testRemoteUploadVADPolicyUsesClientVADForFileUploadProviders() {
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .openAIWhisper,
+                model: "gpt-4o-mini-transcribe",
+                localVADMode: .energy
+            ),
+            .fileUploadClientVAD
+        )
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .glmASR,
+                model: "glm-asr-1",
+                localVADMode: .energy
+            ),
+            .fileUploadClientVAD
+        )
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .xiaomiMiMoASR,
+                model: "mimo-v2.5-asr",
+                localVADMode: .energy
+            ),
+            .fileUploadClientVAD
+        )
+    }
+
+    func testRemoteUploadVADPolicyDoesNotClientTrimRealtimeServerVADProviders() {
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .aliyunBailianASR,
+                model: "qwen3-asr-flash-realtime",
+                localVADMode: .energy
+            ),
+            .realtimeServerVAD
+        )
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .stepFunASR,
+                model: "step-asr-1.1-stream",
+                localVADMode: .energy
+            ),
+            .realtimeServerVAD
+        )
+    }
+
+    func testRemoteUploadVADPolicyLeavesRealtimeStreamingProvidersUnchanged() {
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .doubaoASR,
+                model: DoubaoASRConfiguration.modelV2,
+                localVADMode: .energy
+            ),
+            .realtimeUnchanged(reason: "doubao-streaming")
+        )
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .aliyunBailianASR,
+                model: "fun-asr-realtime",
+                localVADMode: .energy
+            ),
+            .realtimeUnchanged(reason: "aliyun-fun-realtime")
+        )
+    }
+
+    func testRemoteUploadVADPolicyDisablesWhenLocalVADIsOff() {
+        XCTAssertEqual(
+            RemoteASRAudioUploadVADPolicyResolver.policy(
+                provider: .openAIWhisper,
+                model: "gpt-4o-mini-transcribe",
+                localVADMode: .off
+            ),
+            .disabled(reason: "local-vad-off")
+        )
+    }
+
+    func testRemoteUploadPreprocessorExportsShorterClientVADUploadAudio() async throws {
+        let sourceURL = HistoryAudioArchiveSupport.temporaryArchiveURL(prefix: "remote-upload-vad-test-source")
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let sampleRate = HistoryAudioArchiveSupport.targetSampleRate
+        let leadingSilence = Array(repeating: Float(0), count: Int(sampleRate * 2))
+        let speech = Array(repeating: Float(0.35), count: Int(sampleRate))
+        let trailingSilence = Array(repeating: Float(0), count: Int(sampleRate * 2))
+        let samples = leadingSilence + speech + trailingSilence
+        XCTAssertTrue(try HistoryAudioArchiveSupport.exportWAV(samples: samples, sampleRate: sampleRate, to: sourceURL))
+
+        let preparation = try await RemoteASRAudioUploadPreprocessor.prepareUploadAudio(
+            originalFileURL: sourceURL,
+            provider: .openAIWhisper,
+            configuration: RemoteProviderConfiguration(
+                providerID: RemoteASRProvider.openAIWhisper.rawValue,
+                model: "gpt-4o-mini-transcribe",
+                endpoint: "",
+                apiKey: "test"
+            ),
+            localVADMode: .energy,
+            useCase: .transcription
+        )
+        defer { preparation.cleanupTemporaryUploadFileIfNeeded() }
+
+        XCTAssertTrue(preparation.shouldRequestRemoteASR)
+        XCTAssertEqual(preparation.policy, .fileUploadClientVAD)
+        XCTAssertNotNil(preparation.temporaryUploadFileURL)
+        XCTAssertLessThan(preparation.uploadDurationSeconds ?? 0, preparation.originalDurationSeconds ?? 0)
+        XCTAssertGreaterThan(preparation.speechSegmentCount, 0)
+
+        let uploadSamples = try HistoryAudioArchiveSupport.readWAVSamples(from: preparation.uploadFileURL)
+        XCTAssertLessThan(uploadSamples.count, samples.count)
+        XCTAssertGreaterThan(uploadSamples.count, 0)
+    }
+
     func testExtractStreamErrorMessageReadsNestedErrorPayload() {
         let message = RemoteASRTextSupport.extractStreamErrorMessage(
             fromLine: #"{"error":{"code":"invalid_api_key","message":"API key is invalid"}}"#


### PR DESCRIPTION
## Summary
- Add client-side VAD preprocessing for remote ASR file-upload providers so silent/non-speech regions are removed before upload.
- Keep realtime remote ASR paths unchanged and route server-VAD-capable realtime models away from client-side trimming.
- Preserve original history audio archives while using temporary filtered WAV files for upload, with policy and preprocessing telemetry.

## Test Plan
- [x] `git diff --check`
- [x] `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/ASRVoiceActivityPlanningTests -only-testing:VoxtTests/RemoteASRSupportTests`
- [x] `xcodebuild build -project Voxt.xcodeproj -scheme Voxt -destination platform=macOS CODE_SIGNING_ALLOWED=NO`