### PR TITLE
fix(deps): pin mlx-swift-lm weight loading fix

### DIFF
--- a/Voxt.xcodeproj/project.pbxproj
+++ b/Voxt.xcodeproj/project.pbxproj
@@ -1047,7 +1047,7 @@
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm.git";
 			requirement = {
 				kind = revision;
-				revision = 124880582175726b709015a632c5ba9f3069a319;
+				revision = f5f18ed9d3373b21874bd43da34922377c6da0fb;
 			};
 		};
 		E2A1C3B4D5F60718293A4B70 /* XCRemoteSwiftPackageReference "PermissionFlow" */ = {

--- a/Voxt.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Voxt.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "124880582175726b709015a632c5ba9f3069a319"
+        "revision" : "f5f18ed9d3373b21874bd43da34922377c6da0fb"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Pin `mlx-swift-lm` to upstream commit `f5f18ed9d3373b21874bd43da34922377c6da0fb`.
- Include the merged safetensors-index loading fix from ml-explore/mlx-swift-lm#408.
- Restore coherent output for the Qwen3.5 4B OptiQ local model.

The upstream fix has been merged but is not yet part of a tagged `mlx-swift-lm` release, so this temporarily points the package to the fixed commit.

## Validation

- Full `Voxt` test suite: 1,398 passed, 19 skipped, 0 failed.
- Two independent English local-LLM smoke runs returned the expected sentence.

Fixes #125