### PR TITLE
Fix Create Hot Word triggering SQLite duplicate-scope error

### DIFF
--- a/Voxt/Core/Dictionary/DictionaryStore.swift
+++ b/Voxt/Core/Dictionary/DictionaryStore.swift
@@ -839,14 +839,13 @@ final class DictionaryStore: ObservableObject {
         groupID: UUID?,
         groupNameSnapshot: String?
     ) throws {
-        try createEntry(
+        _ = try createOrReinforceManualEntry(
             term: term,
             replacementTerms: replacementTerms,
             categoryID: categoryID,
             categoryNameSnapshot: categoryNameSnapshot,
             groupID: groupID,
-            groupNameSnapshot: groupNameSnapshot,
-            source: .manual
+            groupNameSnapshot: groupNameSnapshot
         )
     }
 

--- a/VoxtTests/DictionaryStoreAsyncTests.swift
+++ b/VoxtTests/DictionaryStoreAsyncTests.swift
@@ -102,6 +102,32 @@ final class DictionaryStoreAsyncTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(10))
         }
     }
+
+    func testCreateManualEntryReinforcesExistingTermInsteadOfFailing() async throws {
+        let repository = try makeFixture()
+        try repository.upsert(makeEntry(term: "Hello"))
+        let store = DictionaryStore(
+            defaults: UserDefaults(suiteName: "DictionaryStoreAsyncTests.\(UUID().uuidString)")!,
+            fileManager: .default,
+            repository: repository
+        )
+        await drainMainQueue()
+
+        // A second manual entry whose normalized form already exists in the same scope
+        // must not raise SQLite error 19 (idx_dictionary_normalized_scope); it reinforces.
+        try store.createManualEntry(
+            term: "hello",
+            groupID: nil,
+            groupNameSnapshot: nil
+        )
+        await drainMainQueue()
+
+        let persisted = try repository.allEntries()
+        XCTAssertEqual(persisted.count, 1)
+        XCTAssertEqual(Set(store.entries.map(\.term)), Set(["Hello"]))
+        XCTAssertEqual(persisted.first?.matchCount, 1)
+        XCTAssertNotNil(persisted.first?.lastMatchedAt)
+    }
 }
 
 private final class BlockingDictionaryRepository: DictionaryRepositoryProtocol, @unchecked Sendable {


### PR DESCRIPTION
Fix https://github.com/hehehai/voxt/issues/128 

Submitting a hot word whose normalized form already existed in the same scope (same groupID/NIL) raised "SQLite error 19: UNIQUE constraint failed: index 'idx_dictionary_normalized_scope'" because createManualEntry -> createEntry inserted a row with a fresh UUID, so the ON CONFLICT(id) target never fired and the normalized-scope unique index caught the collision.

Route createManualEntry through createOrReinforceManualEntry, which checks existingTermIndex first: an existing same-scope term is reinforced (matchCount + 1, lastMatchedAt updated) instead of erroring, matching the end-state "no error" behavior. SQL schema and the unique index are left unchanged as the intentional invariant.

Add regression test testCreateManualEntryReinforcesExistingTermInsteadOfFailing.