### PR TITLE
改进选中文本探测：兼容网页与 AX 受限应用

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,18 @@ A macOS voice input and translation app with context-aware text enhancement acro
 
 - Live transcription while you speak, with real-time text preview
 
-<video src="https://github.com/user-attachments/assets/75f08906-3e69-4ab5-9b29-f5c3745cebac">
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/75f08906-3e69-4ab5-9b29-f5c3745cebac" width="500px"></video>
+</p>
 
 **Translate — text translation**
 
 - AI translation after you finish speaking
 - Selected-text translation: highlight text and translate it with a shortcut
 
-<video src="https://github.com/user-attachments/assets/e69c2737-5d8c-4bd6-9f5b-1123947c7e39">
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/e69c2737-5d8c-4bd6-9f5b-1123947c7e39" width="500px"></video>
+</p>
 
 **Rewrite — voice prompts with enhanced results**
 

--- a/Voxt/App/DictionaryFlow.swift
+++ b/Voxt/App/DictionaryFlow.swift
@@ -16,12 +16,23 @@ enum SelectedTextDictionaryHotkeySupport {
 extension AppDelegate {
     @discardableResult
     func addSelectedShortTextToDictionaryIfPossible() -> Bool {
-        guard !isSessionActive, pendingTranscriptionStartTask == nil else { return false }
-        guard let term = SelectedTextDictionaryHotkeySupport.candidateTerm(
-            from: selectedTextFromSystemSelection()
-        ) else {
+        guard !isSessionActive, pendingTranscriptionStartTask == nil else {
+            VoxtLog.dictionary(
+                "selectionProbe.dictionary: skipped sessionActive=\(isSessionActive) pendingStart=\(pendingTranscriptionStartTask != nil)"
+            )
             return false
         }
+        let selected = selectedTextFromSystemSelection()
+        let trimmed = selected?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard let term = SelectedTextDictionaryHotkeySupport.candidateTerm(from: selected) else {
+            VoxtLog.dictionary(
+                "selectionProbe.dictionary: rejected chars=\(trimmed.count) max=\(SelectedTextDictionaryHotkeySupport.maxCharacterCount) preview=\(trimmed.isEmpty ? "empty" : String(trimmed.prefix(48)))"
+            )
+            return false
+        }
+        VoxtLog.dictionary(
+            "selectionProbe.dictionary: accepted chars=\(term.count) preview=\(String(term.prefix(48)))"
+        )
 
         let scope = currentDictionaryScope()
         let category = dictionaryStore.ensureCategory(id: scope.groupID, name: scope.groupName)

--- a/Voxt/App/NoteFlow.swift
+++ b/Voxt/App/NoteFlow.swift
@@ -48,6 +48,9 @@ extension AppDelegate {
             selectedTextFromSystemSelection()?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         }
+        VoxtLog.hotkey(
+            "selectionProbe.note: sessionActive=\(isSessionActive) selectedChars=\(selectedText?.count ?? 0) preview=\(selectedText.map { String($0.prefix(48)) } ?? "nil") panelVisible=\(noteWindowManager.isVisible)"
+        )
 
         let action = NoteHotkeyActionResolver.resolve(
             state: .init(
@@ -58,6 +61,7 @@ extension AppDelegate {
                 hasSelectedText: selectedText?.isEmpty == false
             )
         )
+        VoxtLog.hotkey("selectionProbe.note.action=\(action)")
         switch action {
         case .captureSelectedText:
             guard let selectedText, !selectedText.isEmpty else { return }

--- a/Voxt/App/SelectedTextProbe.swift
+++ b/Voxt/App/SelectedTextProbe.swift
@@ -32,7 +32,8 @@ extension AppDelegate {
             return nil
         }
 
-        let focusedElement = focusedElementForSystemSelection()
+        let focusResolve = resolveFocusForSystemSelection()
+        let focusedElement = focusResolve.focusedElement
         logSelectionFocusedElement(focusedElement)
 
         let rawSelectedRange = focusedElement.flatMap {
@@ -70,7 +71,8 @@ extension AppDelegate {
             focusedElement: focusedElement,
             rawSelectedRange: rawSelectedRange,
             isBrowser: isBrowser,
-            appBundleID: appBundleID
+            appBundleID: appBundleID,
+            axWindowCandidatesAvailable: focusResolve.candidateWindowCount > 0
         )
     }
 
@@ -172,7 +174,8 @@ extension AppDelegate {
         focusedElement: AXUIElement?,
         rawSelectedRange: CFRange?,
         isBrowser: Bool,
-        appBundleID: String
+        appBundleID: String,
+        axWindowCandidatesAvailable: Bool
     ) -> String? {
         let copiesLineOnEmptySelection = SelectedTextSystemSelectionSupport
             .copiesCurrentLineWhenSelectionEmpty(bundleID: appBundleID)
@@ -182,8 +185,13 @@ extension AppDelegate {
             isBrowser: isBrowser,
             copiesLineOnEmptySelection: copiesLineOnEmptySelection
         )
+        let allowBlackoutProbe = SelectedTextSystemSelectionSupport.shouldAttemptAXBlackoutClipboardProbe(
+            focusedElementAvailable: focusedElement != nil,
+            axWindowCandidatesAvailable: axWindowCandidatesAvailable,
+            copiesLineOnEmptySelection: copiesLineOnEmptySelection
+        )
         VoxtLog.input(
-            "selectionProbe.copy.policy: allow=\(allowCopy) focused=\(focusedElement != nil) range=\(selectionRangeDescription(rawSelectedRange)) browser=\(isBrowser) copiesLineOnEmpty=\(copiesLineOnEmptySelection)"
+            "selectionProbe.copy.policy: allow=\(allowCopy) blackoutProbe=\(allowBlackoutProbe) focused=\(focusedElement != nil) windows=\(axWindowCandidatesAvailable) range=\(selectionRangeDescription(rawSelectedRange)) browser=\(isBrowser) copiesLineOnEmpty=\(copiesLineOnEmptySelection)"
         )
 
         if allowCopy, let text = selectedTextBySimulatedCopy(reason: "policyAllowed") {
@@ -195,6 +203,36 @@ extension AppDelegate {
                 detail: "chars=\(text.count)"
             )
             return text
+        }
+
+        if allowBlackoutProbe {
+            VoxtLog.input("selectionProbe.copy.blackoutProbe: begin")
+            if let capture = captureTextBySimulatedCopy(reason: "axBlackoutLineCopyEditor") {
+                if SelectedTextSystemSelectionSupport.looksLikeEmptySelectionLineCopy(
+                    rawClipboardText: capture.raw
+                ) {
+                    VoxtLog.input(
+                        "selectionProbe.copy.blackoutProbe: rejected-likely-line-copy chars=\(capture.trimmed.count) preview=\(selectionPreview(capture.raw))"
+                    )
+                    logSelectionProbeResult(
+                        range: rawSelectedRange,
+                        textSource: "nil",
+                        app: appBundleID,
+                        isBrowser: isBrowser,
+                        detail: "ax-blackout-rejected-line-copy"
+                    )
+                    return nil
+                }
+                logSelectionProbeResult(
+                    range: rawSelectedRange,
+                    textSource: "copyBlackoutFiltered",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(capture.trimmed.count)"
+                )
+                return capture.trimmed
+            }
+            VoxtLog.input("selectionProbe.copy.blackoutProbe: copy-missed")
         }
 
         let denyDetail = SelectedTextSystemSelectionSupport.denialDetail(
@@ -216,30 +254,35 @@ extension AppDelegate {
 
     // MARK: - Focus resolve
 
-    private func focusedElementForSystemSelection() -> AXUIElement? {
+    private struct SystemSelectionFocusResolve {
+        let focusedElement: AXUIElement?
+        let candidateWindowCount: Int
+    }
+
+    private func resolveFocusForSystemSelection() -> SystemSelectionFocusResolve {
         // Actual focused element only — never best-editable / leftover-field fallbacks.
         if let systemFocused = copyFocusedUIElement(
             from: AXUIElementCreateSystemWide(),
             source: "systemWide"
         ) {
-            return systemFocused
+            return SystemSelectionFocusResolve(focusedElement: systemFocused, candidateWindowCount: 0)
         }
 
         guard let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
             VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed no-frontmost-app")
-            return nil
+            return SystemSelectionFocusResolve(focusedElement: nil, candidateWindowCount: 0)
         }
 
         let appElement = AXUIElementCreateApplication(processID)
         if let appFocused = copyFocusedUIElement(from: appElement, source: "frontmostApp") {
-            return appFocused
+            return SystemSelectionFocusResolve(focusedElement: appFocused, candidateWindowCount: 0)
         }
 
         let candidateWindows = selectionProbeCandidateWindows(from: appElement)
         if candidateWindows.isEmpty {
             VoxtLog.input("selectionProbe.focusedResolve: no candidate windows")
             VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed")
-            return nil
+            return SystemSelectionFocusResolve(focusedElement: nil, candidateWindowCount: 0)
         }
 
         for (index, window) in candidateWindows.enumerated() {
@@ -247,7 +290,10 @@ extension AppDelegate {
                 VoxtLog.input(
                     "selectionProbe.focusedResolve: source=candidateWindowDescendant[\(index)] ok"
                 )
-                return descendant
+                return SystemSelectionFocusResolve(
+                    focusedElement: descendant,
+                    candidateWindowCount: candidateWindows.count
+                )
             }
         }
 
@@ -255,7 +301,10 @@ extension AppDelegate {
             "selectionProbe.focusedResolve: candidate windows=\(candidateWindows.count) but no focused descendant"
         )
         VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed")
-        return nil
+        return SystemSelectionFocusResolve(
+            focusedElement: nil,
+            candidateWindowCount: candidateWindows.count
+        )
     }
 
     private func selectionProbeCandidateWindows(from appElement: AXUIElement) -> [AXUIElement] {
@@ -523,7 +572,19 @@ extension AppDelegate {
         return nil
     }
 
+    private struct SimulatedCopyCapture {
+        let raw: String
+
+        var trimmed: String {
+            raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
     private func selectedTextBySimulatedCopy(reason: String = "unspecified") -> String? {
+        captureTextBySimulatedCopy(reason: reason)?.trimmed
+    }
+
+    private func captureTextBySimulatedCopy(reason: String = "unspecified") -> SimulatedCopyCapture? {
         VoxtLog.input("selectionProbe.copy.begin: reason=\(reason)")
         guard AccessibilityPermissionManager.isTrusted() else {
             VoxtLog.input("selectionProbe.copy.miss: accessibility-not-trusted")
@@ -570,24 +631,24 @@ extension AppDelegate {
             return nil
         }
 
-        let copied = readStringFromPasteboard(pasteboard)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let raw = readStringFromPasteboard(pasteboard) ?? ""
 
         pasteboard.clearContents()
         if let previous, !previous.isEmpty {
             pasteboard.setString(previous, forType: .string)
         }
 
-        guard let copied, !copied.isEmpty else {
+        let capture = SimulatedCopyCapture(raw: raw)
+        guard !capture.trimmed.isEmpty else {
             VoxtLog.input(
                 "selectionProbe.copy.miss: empty-after-change changeCount=\(copiedChangeCount)"
             )
             return nil
         }
         VoxtLog.input(
-            "selectionProbe.copy.ok: reason=\(reason) chars=\(copied.count) preview=\(selectionPreview(copied))"
+            "selectionProbe.copy.ok: reason=\(reason) chars=\(capture.trimmed.count) preview=\(selectionPreview(capture.raw))"
         )
-        return copied
+        return capture
     }
 
     // MARK: - Logging helpers

--- a/Voxt/App/SelectedTextProbe.swift
+++ b/Voxt/App/SelectedTextProbe.swift
@@ -1,0 +1,650 @@
+// SelectedTextProbe.swift
+// System selection probe for dictionary / note / translation hotkeys.
+
+import Foundation
+import AppKit
+import ApplicationServices
+import Carbon
+
+extension AppDelegate {
+    private static let selectionAXFocusTimeout: Float = 0.2
+    /// After primary FocusedUIElement failed, keep secondary AX cheap.
+    private static let selectionAXFallbackTimeout: Float = 0.05
+
+    func selectedTextFromSystemSelection() -> String? {
+        let appBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+        let appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "unknown"
+        let isBrowser = isBrowserBundleID(appBundleID == "unknown" ? nil : appBundleID)
+        let axTrusted = AccessibilityPermissionManager.isTrusted()
+
+        VoxtLog.input(
+            "selectionProbe.begin: app=\(appBundleID) name=\(appName) browser=\(isBrowser) axTrusted=\(axTrusted)"
+        )
+
+        guard axTrusted else {
+            logSelectionProbeResult(
+                range: nil,
+                textSource: "nil",
+                app: appBundleID,
+                isBrowser: isBrowser,
+                detail: "accessibility-not-trusted"
+            )
+            return nil
+        }
+
+        let focusedElement = focusedElementForSystemSelection()
+        logSelectionFocusedElement(focusedElement)
+
+        let rawSelectedRange = focusedElement.flatMap {
+            axRangeAttribute(
+                kAXSelectedTextRangeAttribute as CFString,
+                for: $0,
+                timeout: Self.selectionAXFocusTimeout
+            )
+        }
+        VoxtLog.input(
+            "selectionProbe.range: raw=\(selectionRangeDescription(rawSelectedRange)) nonEmpty=\(nonEmptySelectedTextRange(rawSelectedRange) != nil)"
+        )
+
+        if SelectedTextSystemSelectionSupport.isConfirmedCaretOnly(selectedTextRange: rawSelectedRange) {
+            logSelectionProbeResult(
+                range: rawSelectedRange,
+                textSource: "nil",
+                app: appBundleID,
+                isBrowser: isBrowser,
+                detail: "confirmed-caret-only"
+            )
+            return nil
+        }
+
+        if let text = readSelectedTextNonDestructively(
+            focusedElement: focusedElement,
+            rawSelectedRange: rawSelectedRange,
+            isBrowser: isBrowser,
+            appBundleID: appBundleID
+        ) {
+            return text
+        }
+
+        return readSelectedTextBySimulatedCopyIfAllowed(
+            focusedElement: focusedElement,
+            rawSelectedRange: rawSelectedRange,
+            isBrowser: isBrowser,
+            appBundleID: appBundleID
+        )
+    }
+
+    // MARK: - Non-destructive reads
+
+    private func readSelectedTextNonDestructively(
+        focusedElement: AXUIElement?,
+        rawSelectedRange: CFRange?,
+        isBrowser: Bool,
+        appBundleID: String
+    ) -> String? {
+        if let focusedElement {
+            let axSelectedResult = probeAXSelectedText(from: focusedElement)
+            VoxtLog.input(
+                "selectionProbe.read.axSelected: status=\(axSelectedResult.status) chars=\(axSelectedResult.characterCount) preview=\(selectionPreview(axSelectedResult.text))"
+            )
+            if let text = axSelectedResult.text {
+                logSelectionProbeResult(
+                    range: rawSelectedRange,
+                    textSource: "axSelected",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(text.count)"
+                )
+                return text
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.axSelected: skipped focused=nil")
+        }
+
+        if let focusedElement,
+           let selectedRange = nonEmptySelectedTextRange(rawSelectedRange) {
+            let rangeText = axParameterizedString(
+                kAXStringForRangeParameterizedAttribute as CFString,
+                range: selectedRange,
+                for: focusedElement,
+                timeout: Self.selectionAXFocusTimeout
+            )
+            let trimmedRangeText = rangeText?.trimmingCharacters(in: .whitespacesAndNewlines)
+            VoxtLog.input(
+                "selectionProbe.read.stringForRange: chars=\(trimmedRangeText?.count ?? 0) preview=\(selectionPreview(trimmedRangeText))"
+            )
+            if let trimmedRangeText, !trimmedRangeText.isEmpty {
+                logSelectionProbeResult(
+                    range: selectedRange,
+                    textSource: "stringForRange",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(trimmedRangeText.count)"
+                )
+                return rangeText
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.stringForRange: skipped")
+        }
+
+        if let focusedElement {
+            let markerText = selectedTextFromAXTextMarker(startingAt: focusedElement)
+            VoxtLog.input(
+                "selectionProbe.read.textMarker: chars=\(markerText?.count ?? 0) preview=\(selectionPreview(markerText))"
+            )
+            if let text = markerText {
+                logSelectionProbeResult(
+                    range: rawSelectedRange,
+                    textSource: "textMarker",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(text.count)"
+                )
+                return text
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.textMarker: skipped focused=nil")
+        }
+
+        if isBrowser {
+            let scriptText = selectedTextFromBrowserAppleScript(bundleID: appBundleID)
+            VoxtLog.input(
+                "selectionProbe.read.appleScript: chars=\(scriptText?.count ?? 0) preview=\(selectionPreview(scriptText))"
+            )
+            if let text = scriptText {
+                logSelectionProbeResult(
+                    range: rawSelectedRange,
+                    textSource: "appleScript",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(text.count)"
+                )
+                return text
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.appleScript: skipped not-browser")
+        }
+
+        return nil
+    }
+
+    private func readSelectedTextBySimulatedCopyIfAllowed(
+        focusedElement: AXUIElement?,
+        rawSelectedRange: CFRange?,
+        isBrowser: Bool,
+        appBundleID: String
+    ) -> String? {
+        let copiesLineOnEmptySelection = SelectedTextSystemSelectionSupport
+            .copiesCurrentLineWhenSelectionEmpty(bundleID: appBundleID)
+        let allowCopy = SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+            focusedElementAvailable: focusedElement != nil,
+            selectedTextRange: rawSelectedRange,
+            isBrowser: isBrowser,
+            copiesLineOnEmptySelection: copiesLineOnEmptySelection
+        )
+        VoxtLog.input(
+            "selectionProbe.copy.policy: allow=\(allowCopy) focused=\(focusedElement != nil) range=\(selectionRangeDescription(rawSelectedRange)) browser=\(isBrowser) copiesLineOnEmpty=\(copiesLineOnEmptySelection)"
+        )
+
+        if allowCopy, let text = selectedTextBySimulatedCopy(reason: "policyAllowed") {
+            logSelectionProbeResult(
+                range: rawSelectedRange,
+                textSource: "copy",
+                app: appBundleID,
+                isBrowser: isBrowser,
+                detail: "chars=\(text.count)"
+            )
+            return text
+        }
+
+        let denyDetail = SelectedTextSystemSelectionSupport.denialDetail(
+            allowCopy: allowCopy,
+            focusedElementAvailable: focusedElement != nil,
+            selectedTextRange: rawSelectedRange,
+            isBrowser: isBrowser,
+            copiesLineOnEmptySelection: copiesLineOnEmptySelection
+        )
+        logSelectionProbeResult(
+            range: rawSelectedRange,
+            textSource: "nil",
+            app: appBundleID,
+            isBrowser: isBrowser,
+            detail: denyDetail
+        )
+        return nil
+    }
+
+    // MARK: - Focus resolve
+
+    private func focusedElementForSystemSelection() -> AXUIElement? {
+        // Actual focused element only — never best-editable / leftover-field fallbacks.
+        if let systemFocused = copyFocusedUIElement(
+            from: AXUIElementCreateSystemWide(),
+            source: "systemWide"
+        ) {
+            return systemFocused
+        }
+
+        guard let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
+            VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed no-frontmost-app")
+            return nil
+        }
+
+        let appElement = AXUIElementCreateApplication(processID)
+        if let appFocused = copyFocusedUIElement(from: appElement, source: "frontmostApp") {
+            return appFocused
+        }
+
+        let candidateWindows = selectionProbeCandidateWindows(from: appElement)
+        if candidateWindows.isEmpty {
+            VoxtLog.input("selectionProbe.focusedResolve: no candidate windows")
+            VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed")
+            return nil
+        }
+
+        for (index, window) in candidateWindows.enumerated() {
+            if let descendant = findFocusedDescendant(in: window, depthRemaining: 6) {
+                VoxtLog.input(
+                    "selectionProbe.focusedResolve: source=candidateWindowDescendant[\(index)] ok"
+                )
+                return descendant
+            }
+        }
+
+        VoxtLog.input(
+            "selectionProbe.focusedResolve: candidate windows=\(candidateWindows.count) but no focused descendant"
+        )
+        VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed")
+        return nil
+    }
+
+    private func selectionProbeCandidateWindows(from appElement: AXUIElement) -> [AXUIElement] {
+        var windows: [AXUIElement] = []
+
+        func appendUnique(_ window: AXUIElement) {
+            for existing in windows where CFEqual(existing, window) {
+                return
+            }
+            windows.append(window)
+        }
+
+        var hadFocusedWindow = false
+        if let focusedWindow = axElementAttribute(
+            kAXFocusedWindowAttribute as CFString,
+            for: appElement,
+            timeout: Self.selectionAXFallbackTimeout
+        ) {
+            hadFocusedWindow = true
+            appendUnique(focusedWindow)
+        }
+        if let mainWindow = axElementAttribute(
+            kAXMainWindowAttribute as CFString,
+            for: appElement,
+            timeout: Self.selectionAXFallbackTimeout
+        ) {
+            appendUnique(mainWindow)
+        }
+        let listedWindows = axElementArrayAttribute(
+            kAXWindowsAttribute as CFString,
+            for: appElement,
+            timeout: Self.selectionAXFallbackTimeout
+        )
+        for window in listedWindows.prefix(3) {
+            appendUnique(window)
+        }
+        VoxtLog.input(
+            "selectionProbe.windows: hadFocused=\(hadFocusedWindow) totalCandidates=\(windows.count) listed=\(listedWindows.count)"
+        )
+        return windows
+    }
+
+    private func copyFocusedUIElement(from root: AXUIElement, source: String) -> AXUIElement? {
+        AXUIElementSetMessagingTimeout(root, Self.selectionAXFocusTimeout)
+        var focusedElementRef: CFTypeRef?
+        let focusedStatus = AXUIElementCopyAttributeValue(
+            root,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElementRef
+        )
+        guard focusedStatus == .success,
+              let focusedElementRef,
+              CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID() else {
+            VoxtLog.input(
+                "selectionProbe.focusedResolve: source=\(source) failed status=\(focusedStatus.rawValue) timeoutSec=\(Self.selectionAXFocusTimeout)"
+            )
+            return nil
+        }
+        VoxtLog.input("selectionProbe.focusedResolve: source=\(source) ok")
+        return unsafeBitCast(focusedElementRef, to: AXUIElement.self)
+    }
+
+    // MARK: - AX / AppleScript / clipboard readers
+
+    private struct AXSelectedTextProbeResult {
+        let text: String?
+        let status: String
+        let characterCount: Int
+    }
+
+    private func probeAXSelectedText(from element: AXUIElement) -> AXSelectedTextProbeResult {
+        AXUIElementSetMessagingTimeout(element, Self.selectionAXFocusTimeout)
+        var selectedTextRef: CFTypeRef?
+        let selectedStatus = AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            &selectedTextRef
+        )
+        guard selectedStatus == .success, let selectedTextRef else {
+            return AXSelectedTextProbeResult(
+                text: nil,
+                status: "ax-error-\(selectedStatus.rawValue)",
+                characterCount: 0
+            )
+        }
+
+        let selectedText: String?
+        let typeName: String
+        if let text = selectedTextRef as? String {
+            selectedText = text
+            typeName = "String"
+        } else if let attributed = selectedTextRef as? NSAttributedString {
+            selectedText = attributed.string
+            typeName = "NSAttributedString"
+        } else {
+            selectedText = nil
+            typeName = "unsupported(\(CFGetTypeID(selectedTextRef)))"
+        }
+
+        let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            return AXSelectedTextProbeResult(
+                text: nil,
+                status: "empty-\(typeName)",
+                characterCount: selectedText?.count ?? 0
+            )
+        }
+        return AXSelectedTextProbeResult(
+            text: selectedText,
+            status: "ok-\(typeName)",
+            characterCount: selectedText?.count ?? 0
+        )
+    }
+
+    private func selectedTextFromAXTextMarker(startingAt element: AXUIElement) -> String? {
+        var current: AXUIElement? = element
+        for depth in 0..<6 {
+            guard let currentElement = current else { break }
+            let role = axStringAttribute(
+                kAXRoleAttribute as CFString,
+                for: currentElement,
+                timeout: Self.selectionAXFocusTimeout
+            ) ?? "nil"
+            let result = selectedTextFromAXTextMarkerRange(on: currentElement)
+            VoxtLog.input(
+                "selectionProbe.textMarker.depth=\(depth) role=\(role) status=\(result.status) chars=\(result.text?.count ?? 0)"
+            )
+            if let text = result.text {
+                return text
+            }
+            current = axElementAttribute(
+                kAXParentAttribute as CFString,
+                for: currentElement,
+                timeout: Self.selectionAXFocusTimeout
+            )
+        }
+        return nil
+    }
+
+    private struct TextMarkerProbeResult {
+        let text: String?
+        let status: String
+    }
+
+    private func selectedTextFromAXTextMarkerRange(on element: AXUIElement) -> TextMarkerProbeResult {
+        AXUIElementSetMessagingTimeout(element, Self.selectionAXFocusTimeout)
+        var markerRangeRef: CFTypeRef?
+        let markerStatus = AXUIElementCopyAttributeValue(
+            element,
+            "AXSelectedTextMarkerRange" as CFString,
+            &markerRangeRef
+        )
+        guard markerStatus == .success, let markerRangeRef else {
+            return TextMarkerProbeResult(text: nil, status: "marker-error-\(markerStatus.rawValue)")
+        }
+
+        var stringRef: CFTypeRef?
+        let stringStatus = AXUIElementCopyParameterizedAttributeValue(
+            element,
+            "AXStringForTextMarkerRange" as CFString,
+            markerRangeRef,
+            &stringRef
+        )
+        if stringStatus == .success,
+           let text = stringRef as? String,
+           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return TextMarkerProbeResult(text: text, status: "string-ok")
+        }
+
+        var attributedRef: CFTypeRef?
+        let attributedStatus = AXUIElementCopyParameterizedAttributeValue(
+            element,
+            "AXAttributedStringForTextMarkerRange" as CFString,
+            markerRangeRef,
+            &attributedRef
+        )
+        if attributedStatus == .success {
+            if let attributed = attributedRef as? NSAttributedString,
+               !attributed.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return TextMarkerProbeResult(text: attributed.string, status: "attributed-ok")
+            }
+            if let text = attributedRef as? String,
+               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return TextMarkerProbeResult(text: text, status: "attributed-string-ok")
+            }
+            return TextMarkerProbeResult(
+                text: nil,
+                status: "marker-present-empty stringStatus=\(stringStatus.rawValue) attributedStatus=\(attributedStatus.rawValue)"
+            )
+        }
+        return TextMarkerProbeResult(
+            text: nil,
+            status: "resolve-failed stringStatus=\(stringStatus.rawValue) attributedStatus=\(attributedStatus.rawValue)"
+        )
+    }
+
+    private func selectedTextFromBrowserAppleScript(bundleID: String) -> String? {
+        if let deniedUntil = browserAutomationDeniedUntilByBundleID[bundleID],
+           deniedUntil > Date() {
+            let remaining = Int(deniedUntil.timeIntervalSinceNow)
+            VoxtLog.input(
+                "selectionProbe.appleScript: skipped denied-cache bundleID=\(bundleID) remainingSec=\(remaining)"
+            )
+            return nil
+        }
+
+        let displayName = browserScriptProvider(for: bundleID)?.name
+        let scripts = BrowserAutomationScriptBuilder.selectionScripts(
+            bundleID: bundleID,
+            displayName: displayName
+        )
+        VoxtLog.input(
+            "selectionProbe.appleScript: candidates=\(scripts.count) provider=\(displayName ?? "nil") bundleID=\(bundleID)"
+        )
+        for (index, source) in scripts.enumerated() {
+            var executionError: NSDictionary?
+            let startedAt = Date()
+            // `runAppleScript` ceilings fractional timeouts to whole seconds; pass 1 explicitly.
+            let rawOutput = runAppleScript(
+                source,
+                error: &executionError,
+                logFailure: false,
+                timeout: 1
+            )
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+
+            if SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: rawOutput,
+                hadExecutionError: executionError != nil
+            ) {
+                VoxtLog.input(
+                    "selectionProbe.appleScript.candidate=\(index + 1): empty-selection elapsedMs=\(elapsedMs)"
+                )
+                return nil
+            }
+
+            let trimmed = rawOutput?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let trimmed, !trimmed.isEmpty {
+                VoxtLog.input(
+                    "selectionProbe.appleScript.candidate=\(index + 1): ok chars=\(trimmed.count) elapsedMs=\(elapsedMs) preview=\(selectionPreview(trimmed))"
+                )
+                return trimmed
+            }
+
+            let errorNumber = executionError?["NSAppleScriptErrorNumber"] as? Int
+            let errorMessage = executionError?["NSAppleScriptErrorMessage"] as? String ?? "nil"
+            VoxtLog.input(
+                "selectionProbe.appleScript.candidate=\(index + 1): miss elapsedMs=\(elapsedMs) errorNumber=\(errorNumber.map(String.init) ?? "nil") message=\(errorMessage)"
+            )
+
+            if let errorNumber {
+                if errorNumber == -1743 || errorNumber == -10004 {
+                    browserAutomationDeniedUntilByBundleID[bundleID] = Date().addingTimeInterval(300)
+                    VoxtLog.input(
+                        "selectionProbe.appleScript: caching denial for 300s bundleID=\(bundleID) error=\(errorNumber)"
+                    )
+                    break
+                }
+                if errorNumber == -600 {
+                    VoxtLog.input("selectionProbe.appleScript: app not running error=-600")
+                    break
+                }
+            }
+        }
+        return nil
+    }
+
+    private func selectedTextBySimulatedCopy(reason: String = "unspecified") -> String? {
+        VoxtLog.input("selectionProbe.copy.begin: reason=\(reason)")
+        guard AccessibilityPermissionManager.isTrusted() else {
+            VoxtLog.input("selectionProbe.copy.miss: accessibility-not-trusted")
+            return nil
+        }
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            VoxtLog.input("selectionProbe.copy.miss: no-event-source")
+            return nil
+        }
+
+        let pasteboard = NSPasteboard.general
+        let previous = readStringFromPasteboard(pasteboard)
+        let originalChangeCount = pasteboard.changeCount
+        VoxtLog.input(
+            "selectionProbe.copy.pasteboard: changeCount=\(originalChangeCount) previousChars=\(previous?.count ?? 0)"
+        )
+
+        let cKeyCode: CGKeyCode = 0x08
+        let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: true)
+        cmdDown?.flags = .maskCommand
+        let cmdUp = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: false)
+        cmdUp?.flags = .maskCommand
+        guard cmdDown != nil, cmdUp != nil else {
+            VoxtLog.input("selectionProbe.copy.miss: failed-to-create-key-events")
+            return nil
+        }
+
+        HotkeyEventSupport.markAsVoxtInjected(cmdDown)
+        HotkeyEventSupport.markAsVoxtInjected(cmdUp)
+        cmdDown?.post(tap: .cgAnnotatedSessionEventTap)
+        cmdUp?.post(tap: .cgAnnotatedSessionEventTap)
+
+        let waitSeconds: TimeInterval = 0.15
+        let deadline = Date().addingTimeInterval(waitSeconds)
+        while pasteboard.changeCount == originalChangeCount, Date() < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+
+        let copiedChangeCount = pasteboard.changeCount
+        guard copiedChangeCount != originalChangeCount else {
+            VoxtLog.input(
+                "selectionProbe.copy.miss: pasteboard-unchanged changeCount=\(copiedChangeCount) waitedSec=\(waitSeconds) reason=\(reason)"
+            )
+            return nil
+        }
+
+        let copied = readStringFromPasteboard(pasteboard)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        pasteboard.clearContents()
+        if let previous, !previous.isEmpty {
+            pasteboard.setString(previous, forType: .string)
+        }
+
+        guard let copied, !copied.isEmpty else {
+            VoxtLog.input(
+                "selectionProbe.copy.miss: empty-after-change changeCount=\(copiedChangeCount)"
+            )
+            return nil
+        }
+        VoxtLog.input(
+            "selectionProbe.copy.ok: reason=\(reason) chars=\(copied.count) preview=\(selectionPreview(copied))"
+        )
+        return copied
+    }
+
+    // MARK: - Logging helpers
+
+    private func logSelectionFocusedElement(_ focusedElement: AXUIElement?) {
+        guard let focusedElement else {
+            VoxtLog.input("selectionProbe.focused: element=nil")
+            return
+        }
+        let role = axStringAttribute(
+            kAXRoleAttribute as CFString,
+            for: focusedElement,
+            timeout: Self.selectionAXFocusTimeout
+        ) ?? "nil"
+        let subrole = axStringAttribute(
+            kAXSubroleAttribute as CFString,
+            for: focusedElement,
+            timeout: Self.selectionAXFocusTimeout
+        ) ?? "nil"
+        VoxtLog.input("selectionProbe.focused: role=\(role) subrole=\(subrole)")
+    }
+
+    private func nonEmptySelectedTextRange(_ range: CFRange?) -> CFRange? {
+        guard let range,
+              SelectedTextSystemSelectionSupport.hasNonEmptySelectedTextRange(length: range.length) else {
+            return nil
+        }
+        return range
+    }
+
+    private func logSelectionProbeResult(
+        range: CFRange?,
+        textSource: String,
+        app: String,
+        isBrowser: Bool,
+        detail: String = ""
+    ) {
+        let rangeDescription = selectionRangeDescription(range)
+        let suffix = detail.isEmpty ? "" : " detail=\(detail)"
+        VoxtLog.input(
+            "selectionProbe.result: range=\(rangeDescription) textSource=\(textSource) browser=\(isBrowser) app=\(app)\(suffix)"
+        )
+    }
+
+    private func selectionRangeDescription(_ range: CFRange?) -> String {
+        range.map { "{\($0.location),\($0.length)}" } ?? "nil"
+    }
+
+    private func selectionPreview(_ text: String?) -> String {
+        guard let text else { return "nil" }
+        let collapsed = text
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\t", with: "\\t")
+        if collapsed.count <= 48 {
+            return "\"\(collapsed)\""
+        }
+        let prefix = collapsed.prefix(48)
+        return "\"\(prefix)…\"(+\(collapsed.count - 48))"
+    }
+}

--- a/Voxt/App/TextInputIO.swift
+++ b/Voxt/App/TextInputIO.swift
@@ -6,116 +6,8 @@ import AppKit
 import ApplicationServices
 import Carbon
 
-enum SelectedTextSystemSelectionSupport {
-    /// Hard gate: a caret-only range (`length == 0`) must not count as a selection.
-    static func hasNonEmptySelectedTextRange(length: CFIndex) -> Bool {
-        length > 0
-    }
-
-    /// Editors that implement "Cmd+C with no selection copies the current line"
-    /// (VS Code `editor.emptySelectionClipboard`, Sublime, Zed, JetBrains, etc.).
-    ///
-    /// This is a clipboard-semantics capability class. Many of these apps also
-    /// fail AX focus lookup with `kAXErrorCannotComplete` (-25204), so
-    /// "focused == nil" alone cannot mean "safe to Cmd+C" — that path remains
-    /// necessary for AX-dead apps such as WeChat, but must stay denied here.
-    static func copiesCurrentLineWhenSelectionEmpty(bundleID: String?) -> Bool {
-        guard let bundleID, !bundleID.isEmpty else { return false }
-
-        // Stable first-party / well-known IDs.
-        let exactIDs: Set<String> = [
-            // Microsoft / OSS VS Code
-            "com.microsoft.VSCode",
-            "com.microsoft.VSCodeInsiders",
-            "com.microsoft.VSCodeExploration",
-            "com.visualstudio.code.oss",
-            "com.visualstudio.code",
-            "com.vscodium",
-            // Google Antigravity (VS Code-based)
-            "com.google.antigravity",
-            // Sublime
-            "com.sublimetext.3",
-            "com.sublimetext.4",
-            // Zed
-            "dev.zed.Zed",
-            "dev.zed.Zed-Preview",
-            // Trae / Qoder (VS Code forks)
-            "com.trae.app",
-            "com.trae.solo.app",
-            "cn.trae.app",
-            "com.qoder.app"
-        ]
-        if exactIDs.contains(bundleID) {
-            return true
-        }
-
-        // Family prefixes: ToDesktop-packaged Electron IDEs (Cursor, etc.),
-        // JetBrains suite, Windsurf/Codeium, Trae/Qoder variants.
-        let prefixes = [
-            "com.todesktop.",
-            "com.jetbrains.",
-            "com.exafunction.",
-            "com.trae.",
-            "cn.trae.",
-            "com.qoder."
-        ]
-        if prefixes.contains(where: bundleID.hasPrefix) {
-            return true
-        }
-
-        // Catch less common VS Code forks that keep "VSCode" in the bundle ID.
-        let lowered = bundleID.lowercased()
-        if lowered.contains("vscode") || lowered.contains("vscodium") {
-            return true
-        }
-        return false
-    }
-
-    /// Whether Cmd+C may run after all non-destructive reads missed.
-    ///
-    /// - caret-only range (`length == 0`) → deny
-    /// - non-empty range → allow (recover text when attributes are empty)
-    /// - no focused element:
-    ///   - deny when app copies the current line on empty selection
-    ///   - allow otherwise (AX-dead apps such as WeChat)
-    /// - focused element but no range attribute:
-    ///   - browser → allow
-    ///   - otherwise → deny
-    static func shouldAttemptSimulatedCopy(
-        focusedElementAvailable: Bool,
-        selectedTextRange: CFRange?,
-        isBrowser: Bool,
-        copiesLineOnEmptySelection: Bool
-    ) -> Bool {
-        if focusedElementAvailable, let selectedTextRange {
-            return selectedTextRange.length > 0
-        }
-        if !focusedElementAvailable {
-            return !copiesLineOnEmptySelection
-        }
-        return isBrowser
-    }
-
-    /// Range attribute present with `length == 0` means caret-only; further probes cannot help.
-    static func isConfirmedCaretOnly(selectedTextRange: CFRange?) -> Bool {
-        guard let selectedTextRange else { return false }
-        return selectedTextRange.length == 0
-    }
-
-    /// AppleScript ran without an execution error and returned empty/whitespace selection text.
-    /// Dialect retries are only useful when the script form itself fails.
-    static func isDefinitiveEmptyBrowserSelection(output: String?, hadExecutionError: Bool) -> Bool {
-        guard !hadExecutionError, let output else { return false }
-        return output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-}
-
 extension AppDelegate {
     private static let axMessagingTimeout: Float = 0.05
-    /// Selection probe uses a modestly longer AX timeout than injection helpers.
-    /// Keep this well under 1s: AX-dead apps (WeChat/Cursor) often still return
-    /// `kAXErrorCannotComplete` (-25204), and each focus lookup pays the full timeout.
-    private static let selectionAXMessagingTimeout: Float = 0.2
     private static let automaticDictionaryLearningSnippetBeforeCursor = 4_000
     private static let automaticDictionaryLearningSnippetAfterCursor = 1_000
     private static let nativeWritableTextRoles: Set<String> = [
@@ -157,554 +49,6 @@ extension AppDelegate {
         let selectedRange: NSRange?
         let failureReason: String?
         let textSource: String?
-    }
-
-    func selectedTextFromSystemSelection() -> String? {
-        let appBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
-        let appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "unknown"
-        let isBrowser = isBrowserBundleID(appBundleID == "unknown" ? nil : appBundleID)
-        let axTrusted = AccessibilityPermissionManager.isTrusted()
-
-        VoxtLog.input(
-            "selectionProbe.begin: app=\(appBundleID) name=\(appName) browser=\(isBrowser) axTrusted=\(axTrusted)"
-        )
-
-        guard axTrusted else {
-            logSelectionProbe(
-                range: nil,
-                textSource: "nil",
-                app: appBundleID,
-                isBrowser: isBrowser,
-                detail: "accessibility-not-trusted"
-            )
-            return nil
-        }
-
-        // Phase 1: resolve focus and gather non-destructive evidence.
-        let focusedElement = focusedElementForSystemSelection()
-        if let focusedElement {
-            let role = axStringAttribute(
-                kAXRoleAttribute as CFString,
-                for: focusedElement,
-                timeout: Self.selectionAXMessagingTimeout
-            ) ?? "nil"
-            let subrole = axStringAttribute(
-                kAXSubroleAttribute as CFString,
-                for: focusedElement,
-                timeout: Self.selectionAXMessagingTimeout
-            ) ?? "nil"
-            VoxtLog.input("selectionProbe.focused: role=\(role) subrole=\(subrole)")
-        } else {
-            VoxtLog.input("selectionProbe.focused: element=nil")
-        }
-
-        let rawSelectedRange = focusedElement.flatMap {
-            axRangeAttribute(
-                kAXSelectedTextRangeAttribute as CFString,
-                for: $0,
-                timeout: Self.selectionAXMessagingTimeout
-            )
-        }
-        VoxtLog.input(
-            "selectionProbe.range: raw=\(selectionRangeDescription(rawSelectedRange)) nonEmpty=\(nonEmptySelectedTextRange(rawSelectedRange) != nil)"
-        )
-
-        // Confirmed caret-only: skip TextMarker / AppleScript / Cmd+C entirely.
-        if SelectedTextSystemSelectionSupport.isConfirmedCaretOnly(selectedTextRange: rawSelectedRange) {
-            logSelectionProbe(
-                range: rawSelectedRange,
-                textSource: "nil",
-                app: appBundleID,
-                isBrowser: isBrowser,
-                detail: "confirmed-caret-only"
-            )
-            return nil
-        }
-
-        // Phase 2: non-destructive text reads (never mutate pasteboard).
-        if let focusedElement {
-            let axSelectedResult = probeAXSelectedText(from: focusedElement)
-            VoxtLog.input(
-                "selectionProbe.read.axSelected: status=\(axSelectedResult.status) chars=\(axSelectedResult.characterCount) preview=\(selectionPreview(axSelectedResult.text))"
-            )
-            if let text = axSelectedResult.text {
-                logSelectionProbe(
-                    range: rawSelectedRange,
-                    textSource: "axSelected",
-                    app: appBundleID,
-                    isBrowser: isBrowser,
-                    detail: "chars=\(text.count)"
-                )
-                return text
-            }
-        } else {
-            VoxtLog.input("selectionProbe.read.axSelected: skipped focused=nil")
-        }
-
-        if let focusedElement,
-           let selectedRange = nonEmptySelectedTextRange(rawSelectedRange) {
-            let rangeText = axParameterizedString(
-                kAXStringForRangeParameterizedAttribute as CFString,
-                range: selectedRange,
-                for: focusedElement,
-                timeout: Self.selectionAXMessagingTimeout
-            )
-            let trimmedRangeText = rangeText?.trimmingCharacters(in: .whitespacesAndNewlines)
-            VoxtLog.input(
-                "selectionProbe.read.stringForRange: chars=\(trimmedRangeText?.count ?? 0) preview=\(selectionPreview(trimmedRangeText))"
-            )
-            if let trimmedRangeText, !trimmedRangeText.isEmpty {
-                logSelectionProbe(
-                    range: selectedRange,
-                    textSource: "stringForRange",
-                    app: appBundleID,
-                    isBrowser: isBrowser,
-                    detail: "chars=\(trimmedRangeText.count)"
-                )
-                return rangeText
-            }
-        } else {
-            VoxtLog.input("selectionProbe.read.stringForRange: skipped")
-        }
-
-        if let focusedElement {
-            let markerText = selectedTextFromAXTextMarker(startingAt: focusedElement)
-            VoxtLog.input(
-                "selectionProbe.read.textMarker: chars=\(markerText?.count ?? 0) preview=\(selectionPreview(markerText))"
-            )
-            if let text = markerText {
-                logSelectionProbe(
-                    range: rawSelectedRange,
-                    textSource: "textMarker",
-                    app: appBundleID,
-                    isBrowser: isBrowser,
-                    detail: "chars=\(text.count)"
-                )
-                return text
-            }
-        } else {
-            VoxtLog.input("selectionProbe.read.textMarker: skipped focused=nil")
-        }
-
-        // Browser AppleScript is still non-destructive and often better than Cmd+C on Safari.
-        if isBrowser {
-            let scriptText = selectedTextFromBrowserAppleScript(bundleID: appBundleID)
-            VoxtLog.input(
-                "selectionProbe.read.appleScript: chars=\(scriptText?.count ?? 0) preview=\(selectionPreview(scriptText))"
-            )
-            if let text = scriptText {
-                logSelectionProbe(
-                    range: rawSelectedRange,
-                    textSource: "appleScript",
-                    app: appBundleID,
-                    isBrowser: isBrowser,
-                    detail: "chars=\(text.count)"
-                )
-                return text
-            }
-        } else {
-            VoxtLog.input("selectionProbe.read.appleScript: skipped not-browser")
-        }
-
-        // Phase 3: Cmd+C only with evidence-based policy (see shouldAttemptSimulatedCopy).
-        let copiesLineOnEmptySelection = SelectedTextSystemSelectionSupport
-            .copiesCurrentLineWhenSelectionEmpty(bundleID: appBundleID)
-        let allowCopy = SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
-            focusedElementAvailable: focusedElement != nil,
-            selectedTextRange: rawSelectedRange,
-            isBrowser: isBrowser,
-            copiesLineOnEmptySelection: copiesLineOnEmptySelection
-        )
-        VoxtLog.input(
-            "selectionProbe.copy.policy: allow=\(allowCopy) focused=\(focusedElement != nil) range=\(selectionRangeDescription(rawSelectedRange)) browser=\(isBrowser) copiesLineOnEmpty=\(copiesLineOnEmptySelection)"
-        )
-        if allowCopy, let text = selectedTextBySimulatedCopy(reason: "policyAllowed") {
-            logSelectionProbe(
-                range: rawSelectedRange,
-                textSource: "copy",
-                app: appBundleID,
-                isBrowser: isBrowser,
-                detail: "chars=\(text.count)"
-            )
-            return text
-        }
-
-        let denyDetail: String
-        if allowCopy {
-            denyDetail = "copy-missed"
-        } else if focusedElement == nil, copiesLineOnEmptySelection {
-            denyDetail = "ax-focus-unavailable-line-copy-editor"
-        } else if focusedElement != nil, rawSelectedRange?.length == 0 {
-            denyDetail = "confirmed-caret-only"
-        } else if focusedElement != nil, rawSelectedRange == nil, !isBrowser {
-            denyDetail = "focused-without-range-non-browser"
-        } else {
-            denyDetail = "copy-denied"
-        }
-        logSelectionProbe(
-            range: rawSelectedRange,
-            textSource: "nil",
-            app: appBundleID,
-            isBrowser: isBrowser,
-            detail: denyDetail
-        )
-        return nil
-    }
-
-    private func focusedElementForSystemSelection() -> AXUIElement? {
-        // Selection must come from the actual focused element only.
-        // Do not reuse writable-input focus resolution (best-editable / window fallbacks),
-        // which can probe a different field with a leftover selection.
-        if let systemFocused = copyFocusedUIElement(
-            from: AXUIElementCreateSystemWide(),
-            source: "systemWide"
-        ) {
-            return systemFocused
-        }
-
-        if let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier,
-           let appFocused = copyFocusedUIElement(
-            from: AXUIElementCreateApplication(processID),
-            source: "frontmostApp"
-           ) {
-            return appFocused
-        }
-
-        VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed")
-        return nil
-    }
-
-    private func copyFocusedUIElement(from root: AXUIElement, source: String) -> AXUIElement? {
-        AXUIElementSetMessagingTimeout(root, Self.selectionAXMessagingTimeout)
-        var focusedElementRef: CFTypeRef?
-        let focusedStatus = AXUIElementCopyAttributeValue(
-            root,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedElementRef
-        )
-        guard focusedStatus == .success,
-              let focusedElementRef,
-              CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID() else {
-            VoxtLog.input(
-                "selectionProbe.focusedResolve: source=\(source) failed status=\(focusedStatus.rawValue) timeoutSec=\(Self.selectionAXMessagingTimeout)"
-            )
-            return nil
-        }
-        VoxtLog.input("selectionProbe.focusedResolve: source=\(source) ok")
-        return unsafeBitCast(focusedElementRef, to: AXUIElement.self)
-    }
-
-    private struct AXSelectedTextProbeResult {
-        let text: String?
-        let status: String
-        let characterCount: Int
-    }
-
-    private func probeAXSelectedText(from element: AXUIElement) -> AXSelectedTextProbeResult {
-        AXUIElementSetMessagingTimeout(element, Self.selectionAXMessagingTimeout)
-        var selectedTextRef: CFTypeRef?
-        let selectedStatus = AXUIElementCopyAttributeValue(
-            element,
-            kAXSelectedTextAttribute as CFString,
-            &selectedTextRef
-        )
-        guard selectedStatus == .success, let selectedTextRef else {
-            return AXSelectedTextProbeResult(
-                text: nil,
-                status: "ax-error-\(selectedStatus.rawValue)",
-                characterCount: 0
-            )
-        }
-
-        let selectedText: String?
-        let typeName: String
-        if let text = selectedTextRef as? String {
-            selectedText = text
-            typeName = "String"
-        } else if let attributed = selectedTextRef as? NSAttributedString {
-            selectedText = attributed.string
-            typeName = "NSAttributedString"
-        } else {
-            selectedText = nil
-            typeName = "unsupported(\(CFGetTypeID(selectedTextRef)))"
-        }
-
-        let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if trimmed.isEmpty {
-            return AXSelectedTextProbeResult(
-                text: nil,
-                status: "empty-\(typeName)",
-                characterCount: selectedText?.count ?? 0
-            )
-        }
-        return AXSelectedTextProbeResult(
-            text: selectedText,
-            status: "ok-\(typeName)",
-            characterCount: selectedText?.count ?? 0
-        )
-    }
-
-    private func nonEmptyAXSelectedText(from element: AXUIElement) -> String? {
-        probeAXSelectedText(from: element).text
-    }
-
-    private func selectedTextFromAXTextMarker(startingAt element: AXUIElement) -> String? {
-        var current: AXUIElement? = element
-        for depth in 0..<6 {
-            guard let currentElement = current else { break }
-            let role = axStringAttribute(
-                kAXRoleAttribute as CFString,
-                for: currentElement,
-                timeout: Self.selectionAXMessagingTimeout
-            ) ?? "nil"
-            let result = selectedTextFromAXTextMarkerRange(on: currentElement)
-            VoxtLog.input(
-                "selectionProbe.textMarker.depth=\(depth) role=\(role) status=\(result.status) chars=\(result.text?.count ?? 0)"
-            )
-            if let text = result.text {
-                return text
-            }
-            current = axElementAttribute(
-                kAXParentAttribute as CFString,
-                for: currentElement,
-                timeout: Self.selectionAXMessagingTimeout
-            )
-        }
-        return nil
-    }
-
-    private struct TextMarkerProbeResult {
-        let text: String?
-        let status: String
-    }
-
-    private func selectedTextFromAXTextMarkerRange(on element: AXUIElement) -> TextMarkerProbeResult {
-        AXUIElementSetMessagingTimeout(element, Self.selectionAXMessagingTimeout)
-        var markerRangeRef: CFTypeRef?
-        let markerStatus = AXUIElementCopyAttributeValue(
-            element,
-            "AXSelectedTextMarkerRange" as CFString,
-            &markerRangeRef
-        )
-        guard markerStatus == .success, let markerRangeRef else {
-            return TextMarkerProbeResult(text: nil, status: "marker-error-\(markerStatus.rawValue)")
-        }
-
-        var stringRef: CFTypeRef?
-        let stringStatus = AXUIElementCopyParameterizedAttributeValue(
-            element,
-            "AXStringForTextMarkerRange" as CFString,
-            markerRangeRef,
-            &stringRef
-        )
-        if stringStatus == .success,
-           let text = stringRef as? String,
-           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return TextMarkerProbeResult(text: text, status: "string-ok")
-        }
-
-        var attributedRef: CFTypeRef?
-        let attributedStatus = AXUIElementCopyParameterizedAttributeValue(
-            element,
-            "AXAttributedStringForTextMarkerRange" as CFString,
-            markerRangeRef,
-            &attributedRef
-        )
-        if attributedStatus == .success {
-            if let attributed = attributedRef as? NSAttributedString,
-               !attributed.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return TextMarkerProbeResult(text: attributed.string, status: "attributed-ok")
-            }
-            if let text = attributedRef as? String,
-               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return TextMarkerProbeResult(text: text, status: "attributed-string-ok")
-            }
-            return TextMarkerProbeResult(
-                text: nil,
-                status: "marker-present-empty stringStatus=\(stringStatus.rawValue) attributedStatus=\(attributedStatus.rawValue)"
-            )
-        }
-        return TextMarkerProbeResult(
-            text: nil,
-            status: "resolve-failed stringStatus=\(stringStatus.rawValue) attributedStatus=\(attributedStatus.rawValue)"
-        )
-    }
-
-    private func selectedTextFromBrowserAppleScript(bundleID: String) -> String? {
-        if let deniedUntil = browserAutomationDeniedUntilByBundleID[bundleID],
-           deniedUntil > Date() {
-            let remaining = Int(deniedUntil.timeIntervalSinceNow)
-            VoxtLog.input(
-                "selectionProbe.appleScript: skipped denied-cache bundleID=\(bundleID) remainingSec=\(remaining)"
-            )
-            return nil
-        }
-
-        let displayName = browserScriptProvider(for: bundleID)?.name
-        let scripts = BrowserAutomationScriptBuilder.selectionScripts(
-            bundleID: bundleID,
-            displayName: displayName
-        )
-        VoxtLog.input(
-            "selectionProbe.appleScript: candidates=\(scripts.count) provider=\(displayName ?? "nil") bundleID=\(bundleID)"
-        )
-        for (index, source) in scripts.enumerated() {
-            var executionError: NSDictionary?
-            let startedAt = Date()
-            // `runAppleScript` ceilings fractional timeouts to whole seconds; pass 1 explicitly.
-            let rawOutput = runAppleScript(
-                source,
-                error: &executionError,
-                logFailure: false,
-                timeout: 1
-            )
-            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-
-            if SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
-                output: rawOutput,
-                hadExecutionError: executionError != nil
-            ) {
-                VoxtLog.input(
-                    "selectionProbe.appleScript.candidate=\(index + 1): empty-selection elapsedMs=\(elapsedMs)"
-                )
-                return nil
-            }
-
-            let trimmed = rawOutput?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let trimmed, !trimmed.isEmpty {
-                VoxtLog.input(
-                    "selectionProbe.appleScript.candidate=\(index + 1): ok chars=\(trimmed.count) elapsedMs=\(elapsedMs) preview=\(selectionPreview(trimmed))"
-                )
-                return trimmed
-            }
-
-            let errorNumber = executionError?["NSAppleScriptErrorNumber"] as? Int
-            let errorMessage = executionError?["NSAppleScriptErrorMessage"] as? String ?? "nil"
-            VoxtLog.input(
-                "selectionProbe.appleScript.candidate=\(index + 1): miss elapsedMs=\(elapsedMs) errorNumber=\(errorNumber.map(String.init) ?? "nil") message=\(errorMessage)"
-            )
-
-            if let errorNumber {
-                if errorNumber == -1743 || errorNumber == -10004 {
-                    browserAutomationDeniedUntilByBundleID[bundleID] = Date().addingTimeInterval(300)
-                    VoxtLog.input(
-                        "selectionProbe.appleScript: caching denial for 300s bundleID=\(bundleID) error=\(errorNumber)"
-                    )
-                    break
-                }
-                if errorNumber == -600 {
-                    VoxtLog.input("selectionProbe.appleScript: app not running error=-600")
-                    break
-                }
-            }
-        }
-        return nil
-    }
-
-    private func nonEmptySelectedTextRange(_ range: CFRange?) -> CFRange? {
-        guard let range,
-              SelectedTextSystemSelectionSupport.hasNonEmptySelectedTextRange(length: range.length) else {
-            return nil
-        }
-        return range
-    }
-
-    private func logSelectionProbe(
-        range: CFRange?,
-        textSource: String,
-        app: String,
-        isBrowser: Bool,
-        detail: String = ""
-    ) {
-        let rangeDescription = selectionRangeDescription(range)
-        let suffix = detail.isEmpty ? "" : " detail=\(detail)"
-        VoxtLog.input(
-            "selectionProbe.result: range=\(rangeDescription) textSource=\(textSource) browser=\(isBrowser) app=\(app)\(suffix)"
-        )
-    }
-
-    private func selectionRangeDescription(_ range: CFRange?) -> String {
-        range.map { "{\($0.location),\($0.length)}" } ?? "nil"
-    }
-
-    private func selectionPreview(_ text: String?) -> String {
-        guard let text else { return "nil" }
-        let collapsed = text
-            .replacingOccurrences(of: "\n", with: "\\n")
-            .replacingOccurrences(of: "\t", with: "\\t")
-        if collapsed.count <= 48 {
-            return "\"\(collapsed)\""
-        }
-        let prefix = collapsed.prefix(48)
-        return "\"\(prefix)…\"(+\(collapsed.count - 48))"
-    }
-
-    private func selectedTextBySimulatedCopy(reason: String = "unspecified") -> String? {
-        VoxtLog.input("selectionProbe.copy.begin: reason=\(reason)")
-        guard AccessibilityPermissionManager.isTrusted() else {
-            VoxtLog.input("selectionProbe.copy.miss: accessibility-not-trusted")
-            return nil
-        }
-        guard let source = CGEventSource(stateID: .hidSystemState) else {
-            VoxtLog.input("selectionProbe.copy.miss: no-event-source")
-            return nil
-        }
-
-        let pasteboard = NSPasteboard.general
-        let previous = readStringFromPasteboard(pasteboard)
-        let originalChangeCount = pasteboard.changeCount
-        VoxtLog.input(
-            "selectionProbe.copy.pasteboard: changeCount=\(originalChangeCount) previousChars=\(previous?.count ?? 0)"
-        )
-
-        let cKeyCode: CGKeyCode = 0x08
-        let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: true)
-        cmdDown?.flags = .maskCommand
-        let cmdUp = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: false)
-        cmdUp?.flags = .maskCommand
-        guard cmdDown != nil, cmdUp != nil else {
-            VoxtLog.input("selectionProbe.copy.miss: failed-to-create-key-events")
-            return nil
-        }
-
-        HotkeyEventSupport.markAsVoxtInjected(cmdDown)
-        HotkeyEventSupport.markAsVoxtInjected(cmdUp)
-        cmdDown?.post(tap: .cgAnnotatedSessionEventTap)
-        cmdUp?.post(tap: .cgAnnotatedSessionEventTap)
-
-        // AX-poor apps (WeChat, some web views) can take longer to honor Cmd+C.
-        let waitSeconds: TimeInterval = 0.15
-        let deadline = Date().addingTimeInterval(waitSeconds)
-        while pasteboard.changeCount == originalChangeCount, Date() < deadline {
-            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
-        }
-
-        let copiedChangeCount = pasteboard.changeCount
-        guard copiedChangeCount != originalChangeCount else {
-            VoxtLog.input(
-                "selectionProbe.copy.miss: pasteboard-unchanged changeCount=\(copiedChangeCount) waitedSec=\(waitSeconds) reason=\(reason)"
-            )
-            return nil
-        }
-
-        let copied = readStringFromPasteboard(pasteboard)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        pasteboard.clearContents()
-        if let previous, !previous.isEmpty {
-            pasteboard.setString(previous, forType: .string)
-        }
-
-        guard let copied, !copied.isEmpty else {
-            VoxtLog.input(
-                "selectionProbe.copy.miss: empty-after-change changeCount=\(copiedChangeCount)"
-            )
-            return nil
-        }
-        VoxtLog.input(
-            "selectionProbe.copy.ok: reason=\(reason) chars=\(copied.count) preview=\(selectionPreview(copied))"
-        )
-        return copied
     }
 
     func hasWritableFocusedTextInput() -> Bool {
@@ -1084,11 +428,11 @@ extension AppDelegate {
         return nil
     }
 
-    private func axStringAttribute(_ attribute: CFString, for element: AXUIElement) -> String? {
+    func axStringAttribute(_ attribute: CFString, for element: AXUIElement) -> String? {
         axStringAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
     }
 
-    private func axStringAttribute(
+    func axStringAttribute(
         _ attribute: CFString,
         for element: AXUIElement,
         timeout: Float
@@ -1117,11 +461,11 @@ extension AppDelegate {
         return nil
     }
 
-    private func axRangeAttribute(_ attribute: CFString, for element: AXUIElement) -> CFRange? {
+    func axRangeAttribute(_ attribute: CFString, for element: AXUIElement) -> CFRange? {
         axRangeAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
     }
 
-    private func axRangeAttribute(
+    func axRangeAttribute(
         _ attribute: CFString,
         for element: AXUIElement,
         timeout: Float
@@ -1159,7 +503,7 @@ extension AppDelegate {
         axRangeAttribute(kAXSelectedTextRangeAttribute as CFString, for: element) != nil
     }
 
-    private func axParameterizedString(
+    func axParameterizedString(
         _ attribute: CFString,
         range: CFRange,
         for element: AXUIElement
@@ -1167,7 +511,7 @@ extension AppDelegate {
         axParameterizedString(attribute, range: range, for: element, timeout: Self.axMessagingTimeout)
     }
 
-    private func axParameterizedString(
+    func axParameterizedString(
         _ attribute: CFString,
         range: CFRange,
         for element: AXUIElement,
@@ -1259,11 +603,11 @@ extension AppDelegate {
         return nil
     }
 
-    private func axElementAttribute(_ attribute: CFString, for element: AXUIElement) -> AXUIElement? {
+    func axElementAttribute(_ attribute: CFString, for element: AXUIElement) -> AXUIElement? {
         axElementAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
     }
 
-    private func axElementAttribute(
+    func axElementAttribute(
         _ attribute: CFString,
         for element: AXUIElement,
         timeout: Float
@@ -1280,8 +624,16 @@ extension AppDelegate {
         return unsafeBitCast(valueRef, to: AXUIElement.self)
     }
 
-    private func axElementArrayAttribute(_ attribute: CFString, for element: AXUIElement) -> [AXUIElement] {
-        AXUIElementSetMessagingTimeout(element, Self.axMessagingTimeout)
+    func axElementArrayAttribute(_ attribute: CFString, for element: AXUIElement) -> [AXUIElement] {
+        axElementArrayAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
+    }
+
+    func axElementArrayAttribute(
+        _ attribute: CFString,
+        for element: AXUIElement,
+        timeout: Float
+    ) -> [AXUIElement] {
+        AXUIElementSetMessagingTimeout(element, timeout)
         var valueRef: CFTypeRef?
         let status = AXUIElementCopyAttributeValue(element, attribute, &valueRef)
         guard status == .success,
@@ -1368,7 +720,7 @@ extension AppDelegate {
         return element
     }
 
-    private func findFocusedDescendant(in element: AXUIElement, depthRemaining: Int) -> AXUIElement? {
+    func findFocusedDescendant(in element: AXUIElement, depthRemaining: Int) -> AXUIElement? {
         guard depthRemaining >= 0 else { return nil }
 
         if axBoolAttribute(kAXFocusedAttribute as CFString, for: element) == true {

--- a/Voxt/App/TextInputIO.swift
+++ b/Voxt/App/TextInputIO.swift
@@ -11,10 +11,111 @@ enum SelectedTextSystemSelectionSupport {
     static func hasNonEmptySelectedTextRange(length: CFIndex) -> Bool {
         length > 0
     }
+
+    /// Editors that implement "Cmd+C with no selection copies the current line"
+    /// (VS Code `editor.emptySelectionClipboard`, Sublime, Zed, JetBrains, etc.).
+    ///
+    /// This is a clipboard-semantics capability class. Many of these apps also
+    /// fail AX focus lookup with `kAXErrorCannotComplete` (-25204), so
+    /// "focused == nil" alone cannot mean "safe to Cmd+C" — that path remains
+    /// necessary for AX-dead apps such as WeChat, but must stay denied here.
+    static func copiesCurrentLineWhenSelectionEmpty(bundleID: String?) -> Bool {
+        guard let bundleID, !bundleID.isEmpty else { return false }
+
+        // Stable first-party / well-known IDs.
+        let exactIDs: Set<String> = [
+            // Microsoft / OSS VS Code
+            "com.microsoft.VSCode",
+            "com.microsoft.VSCodeInsiders",
+            "com.microsoft.VSCodeExploration",
+            "com.visualstudio.code.oss",
+            "com.visualstudio.code",
+            "com.vscodium",
+            // Google Antigravity (VS Code-based)
+            "com.google.antigravity",
+            // Sublime
+            "com.sublimetext.3",
+            "com.sublimetext.4",
+            // Zed
+            "dev.zed.Zed",
+            "dev.zed.Zed-Preview",
+            // Trae / Qoder (VS Code forks)
+            "com.trae.app",
+            "com.trae.solo.app",
+            "cn.trae.app",
+            "com.qoder.app"
+        ]
+        if exactIDs.contains(bundleID) {
+            return true
+        }
+
+        // Family prefixes: ToDesktop-packaged Electron IDEs (Cursor, etc.),
+        // JetBrains suite, Windsurf/Codeium, Trae/Qoder variants.
+        let prefixes = [
+            "com.todesktop.",
+            "com.jetbrains.",
+            "com.exafunction.",
+            "com.trae.",
+            "cn.trae.",
+            "com.qoder."
+        ]
+        if prefixes.contains(where: bundleID.hasPrefix) {
+            return true
+        }
+
+        // Catch less common VS Code forks that keep "VSCode" in the bundle ID.
+        let lowered = bundleID.lowercased()
+        if lowered.contains("vscode") || lowered.contains("vscodium") {
+            return true
+        }
+        return false
+    }
+
+    /// Whether Cmd+C may run after all non-destructive reads missed.
+    ///
+    /// - caret-only range (`length == 0`) → deny
+    /// - non-empty range → allow (recover text when attributes are empty)
+    /// - no focused element:
+    ///   - deny when app copies the current line on empty selection
+    ///   - allow otherwise (AX-dead apps such as WeChat)
+    /// - focused element but no range attribute:
+    ///   - browser → allow
+    ///   - otherwise → deny
+    static func shouldAttemptSimulatedCopy(
+        focusedElementAvailable: Bool,
+        selectedTextRange: CFRange?,
+        isBrowser: Bool,
+        copiesLineOnEmptySelection: Bool
+    ) -> Bool {
+        if focusedElementAvailable, let selectedTextRange {
+            return selectedTextRange.length > 0
+        }
+        if !focusedElementAvailable {
+            return !copiesLineOnEmptySelection
+        }
+        return isBrowser
+    }
+
+    /// Range attribute present with `length == 0` means caret-only; further probes cannot help.
+    static func isConfirmedCaretOnly(selectedTextRange: CFRange?) -> Bool {
+        guard let selectedTextRange else { return false }
+        return selectedTextRange.length == 0
+    }
+
+    /// AppleScript ran without an execution error and returned empty/whitespace selection text.
+    /// Dialect retries are only useful when the script form itself fails.
+    static func isDefinitiveEmptyBrowserSelection(output: String?, hadExecutionError: Bool) -> Bool {
+        guard !hadExecutionError, let output else { return false }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 }
 
 extension AppDelegate {
     private static let axMessagingTimeout: Float = 0.05
+    /// Selection probe uses a modestly longer AX timeout than injection helpers.
+    /// Keep this well under 1s: AX-dead apps (WeChat/Cursor) often still return
+    /// `kAXErrorCannotComplete` (-25204), and each focus lookup pays the full timeout.
+    private static let selectionAXMessagingTimeout: Float = 0.2
     private static let automaticDictionaryLearningSnippetBeforeCursor = 4_000
     private static let automaticDictionaryLearningSnippetAfterCursor = 1_000
     private static let nativeWritableTextRoles: Set<String> = [
@@ -60,48 +161,193 @@ extension AppDelegate {
 
     func selectedTextFromSystemSelection() -> String? {
         let appBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+        let appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "unknown"
+        let isBrowser = isBrowserBundleID(appBundleID == "unknown" ? nil : appBundleID)
+        let axTrusted = AccessibilityPermissionManager.isTrusted()
 
-        guard AccessibilityPermissionManager.isTrusted() else {
-            logSelectionProbe(range: nil, textSource: "nil", app: appBundleID)
-            return nil
-        }
-
-        guard let focusedElement = focusedElementForSystemSelection() else {
-            logSelectionProbe(range: nil, textSource: "nil", app: appBundleID)
-            return nil
-        }
-
-        let rawSelectedRange = axRangeAttribute(
-            kAXSelectedTextRangeAttribute as CFString,
-            for: focusedElement
+        VoxtLog.input(
+            "selectionProbe.begin: app=\(appBundleID) name=\(appName) browser=\(isBrowser) axTrusted=\(axTrusted)"
         )
-        guard let selectedRange = nonEmptySelectedTextRange(rawSelectedRange) else {
-            logSelectionProbe(range: rawSelectedRange, textSource: "nil", app: appBundleID)
+
+        guard axTrusted else {
+            logSelectionProbe(
+                range: nil,
+                textSource: "nil",
+                app: appBundleID,
+                isBrowser: isBrowser,
+                detail: "accessibility-not-trusted"
+            )
             return nil
         }
 
-        if let text = nonEmptyAXSelectedText(from: focusedElement) {
-            logSelectionProbe(range: selectedRange, textSource: "axSelected", app: appBundleID)
+        // Phase 1: resolve focus and gather non-destructive evidence.
+        let focusedElement = focusedElementForSystemSelection()
+        if let focusedElement {
+            let role = axStringAttribute(
+                kAXRoleAttribute as CFString,
+                for: focusedElement,
+                timeout: Self.selectionAXMessagingTimeout
+            ) ?? "nil"
+            let subrole = axStringAttribute(
+                kAXSubroleAttribute as CFString,
+                for: focusedElement,
+                timeout: Self.selectionAXMessagingTimeout
+            ) ?? "nil"
+            VoxtLog.input("selectionProbe.focused: role=\(role) subrole=\(subrole)")
+        } else {
+            VoxtLog.input("selectionProbe.focused: element=nil")
+        }
+
+        let rawSelectedRange = focusedElement.flatMap {
+            axRangeAttribute(
+                kAXSelectedTextRangeAttribute as CFString,
+                for: $0,
+                timeout: Self.selectionAXMessagingTimeout
+            )
+        }
+        VoxtLog.input(
+            "selectionProbe.range: raw=\(selectionRangeDescription(rawSelectedRange)) nonEmpty=\(nonEmptySelectedTextRange(rawSelectedRange) != nil)"
+        )
+
+        // Confirmed caret-only: skip TextMarker / AppleScript / Cmd+C entirely.
+        if SelectedTextSystemSelectionSupport.isConfirmedCaretOnly(selectedTextRange: rawSelectedRange) {
+            logSelectionProbe(
+                range: rawSelectedRange,
+                textSource: "nil",
+                app: appBundleID,
+                isBrowser: isBrowser,
+                detail: "confirmed-caret-only"
+            )
+            return nil
+        }
+
+        // Phase 2: non-destructive text reads (never mutate pasteboard).
+        if let focusedElement {
+            let axSelectedResult = probeAXSelectedText(from: focusedElement)
+            VoxtLog.input(
+                "selectionProbe.read.axSelected: status=\(axSelectedResult.status) chars=\(axSelectedResult.characterCount) preview=\(selectionPreview(axSelectedResult.text))"
+            )
+            if let text = axSelectedResult.text {
+                logSelectionProbe(
+                    range: rawSelectedRange,
+                    textSource: "axSelected",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(text.count)"
+                )
+                return text
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.axSelected: skipped focused=nil")
+        }
+
+        if let focusedElement,
+           let selectedRange = nonEmptySelectedTextRange(rawSelectedRange) {
+            let rangeText = axParameterizedString(
+                kAXStringForRangeParameterizedAttribute as CFString,
+                range: selectedRange,
+                for: focusedElement,
+                timeout: Self.selectionAXMessagingTimeout
+            )
+            let trimmedRangeText = rangeText?.trimmingCharacters(in: .whitespacesAndNewlines)
+            VoxtLog.input(
+                "selectionProbe.read.stringForRange: chars=\(trimmedRangeText?.count ?? 0) preview=\(selectionPreview(trimmedRangeText))"
+            )
+            if let trimmedRangeText, !trimmedRangeText.isEmpty {
+                logSelectionProbe(
+                    range: selectedRange,
+                    textSource: "stringForRange",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(trimmedRangeText.count)"
+                )
+                return rangeText
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.stringForRange: skipped")
+        }
+
+        if let focusedElement {
+            let markerText = selectedTextFromAXTextMarker(startingAt: focusedElement)
+            VoxtLog.input(
+                "selectionProbe.read.textMarker: chars=\(markerText?.count ?? 0) preview=\(selectionPreview(markerText))"
+            )
+            if let text = markerText {
+                logSelectionProbe(
+                    range: rawSelectedRange,
+                    textSource: "textMarker",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(text.count)"
+                )
+                return text
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.textMarker: skipped focused=nil")
+        }
+
+        // Browser AppleScript is still non-destructive and often better than Cmd+C on Safari.
+        if isBrowser {
+            let scriptText = selectedTextFromBrowserAppleScript(bundleID: appBundleID)
+            VoxtLog.input(
+                "selectionProbe.read.appleScript: chars=\(scriptText?.count ?? 0) preview=\(selectionPreview(scriptText))"
+            )
+            if let text = scriptText {
+                logSelectionProbe(
+                    range: rawSelectedRange,
+                    textSource: "appleScript",
+                    app: appBundleID,
+                    isBrowser: isBrowser,
+                    detail: "chars=\(text.count)"
+                )
+                return text
+            }
+        } else {
+            VoxtLog.input("selectionProbe.read.appleScript: skipped not-browser")
+        }
+
+        // Phase 3: Cmd+C only with evidence-based policy (see shouldAttemptSimulatedCopy).
+        let copiesLineOnEmptySelection = SelectedTextSystemSelectionSupport
+            .copiesCurrentLineWhenSelectionEmpty(bundleID: appBundleID)
+        let allowCopy = SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+            focusedElementAvailable: focusedElement != nil,
+            selectedTextRange: rawSelectedRange,
+            isBrowser: isBrowser,
+            copiesLineOnEmptySelection: copiesLineOnEmptySelection
+        )
+        VoxtLog.input(
+            "selectionProbe.copy.policy: allow=\(allowCopy) focused=\(focusedElement != nil) range=\(selectionRangeDescription(rawSelectedRange)) browser=\(isBrowser) copiesLineOnEmpty=\(copiesLineOnEmptySelection)"
+        )
+        if allowCopy, let text = selectedTextBySimulatedCopy(reason: "policyAllowed") {
+            logSelectionProbe(
+                range: rawSelectedRange,
+                textSource: "copy",
+                app: appBundleID,
+                isBrowser: isBrowser,
+                detail: "chars=\(text.count)"
+            )
             return text
         }
 
-        if let text = axParameterizedString(
-            kAXStringForRangeParameterizedAttribute as CFString,
-            range: selectedRange,
-            for: focusedElement
-        ), !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            logSelectionProbe(range: selectedRange, textSource: "stringForRange", app: appBundleID)
-            return text
+        let denyDetail: String
+        if allowCopy {
+            denyDetail = "copy-missed"
+        } else if focusedElement == nil, copiesLineOnEmptySelection {
+            denyDetail = "ax-focus-unavailable-line-copy-editor"
+        } else if focusedElement != nil, rawSelectedRange?.length == 0 {
+            denyDetail = "confirmed-caret-only"
+        } else if focusedElement != nil, rawSelectedRange == nil, !isBrowser {
+            denyDetail = "focused-without-range-non-browser"
+        } else {
+            denyDetail = "copy-denied"
         }
-
-        // Only simulate Cmd+C after AX confirms a non-empty selection range.
-        // This avoids editors (e.g. VS Code) that copy the current line when nothing is selected.
-        if let text = selectedTextBySimulatedCopy() {
-            logSelectionProbe(range: selectedRange, textSource: "copy", app: appBundleID)
-            return text
-        }
-
-        logSelectionProbe(range: selectedRange, textSource: "nil", app: appBundleID)
+        logSelectionProbe(
+            range: rawSelectedRange,
+            textSource: "nil",
+            app: appBundleID,
+            isBrowser: isBrowser,
+            detail: denyDetail
+        )
         return nil
     }
 
@@ -109,24 +355,53 @@ extension AppDelegate {
         // Selection must come from the actual focused element only.
         // Do not reuse writable-input focus resolution (best-editable / window fallbacks),
         // which can probe a different field with a leftover selection.
-        let systemWide = AXUIElementCreateSystemWide()
-        AXUIElementSetMessagingTimeout(systemWide, Self.axMessagingTimeout)
+        if let systemFocused = copyFocusedUIElement(
+            from: AXUIElementCreateSystemWide(),
+            source: "systemWide"
+        ) {
+            return systemFocused
+        }
+
+        if let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier,
+           let appFocused = copyFocusedUIElement(
+            from: AXUIElementCreateApplication(processID),
+            source: "frontmostApp"
+           ) {
+            return appFocused
+        }
+
+        VoxtLog.input("selectionProbe.focusedResolve: all focus lookups failed")
+        return nil
+    }
+
+    private func copyFocusedUIElement(from root: AXUIElement, source: String) -> AXUIElement? {
+        AXUIElementSetMessagingTimeout(root, Self.selectionAXMessagingTimeout)
         var focusedElementRef: CFTypeRef?
         let focusedStatus = AXUIElementCopyAttributeValue(
-            systemWide,
+            root,
             kAXFocusedUIElementAttribute as CFString,
             &focusedElementRef
         )
         guard focusedStatus == .success,
               let focusedElementRef,
               CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID() else {
+            VoxtLog.input(
+                "selectionProbe.focusedResolve: source=\(source) failed status=\(focusedStatus.rawValue) timeoutSec=\(Self.selectionAXMessagingTimeout)"
+            )
             return nil
         }
+        VoxtLog.input("selectionProbe.focusedResolve: source=\(source) ok")
         return unsafeBitCast(focusedElementRef, to: AXUIElement.self)
     }
 
-    private func nonEmptyAXSelectedText(from element: AXUIElement) -> String? {
-        AXUIElementSetMessagingTimeout(element, Self.axMessagingTimeout)
+    private struct AXSelectedTextProbeResult {
+        let text: String?
+        let status: String
+        let characterCount: Int
+    }
+
+    private func probeAXSelectedText(from element: AXUIElement) -> AXSelectedTextProbeResult {
+        AXUIElementSetMessagingTimeout(element, Self.selectionAXMessagingTimeout)
         var selectedTextRef: CFTypeRef?
         let selectedStatus = AXUIElementCopyAttributeValue(
             element,
@@ -134,23 +409,196 @@ extension AppDelegate {
             &selectedTextRef
         )
         guard selectedStatus == .success, let selectedTextRef else {
-            return nil
+            return AXSelectedTextProbeResult(
+                text: nil,
+                status: "ax-error-\(selectedStatus.rawValue)",
+                characterCount: 0
+            )
         }
 
         let selectedText: String?
+        let typeName: String
         if let text = selectedTextRef as? String {
             selectedText = text
+            typeName = "String"
         } else if let attributed = selectedTextRef as? NSAttributedString {
             selectedText = attributed.string
+            typeName = "NSAttributedString"
         } else {
             selectedText = nil
+            typeName = "unsupported(\(CFGetTypeID(selectedTextRef)))"
         }
 
-        guard let selectedText,
-              !selectedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            return AXSelectedTextProbeResult(
+                text: nil,
+                status: "empty-\(typeName)",
+                characterCount: selectedText?.count ?? 0
+            )
+        }
+        return AXSelectedTextProbeResult(
+            text: selectedText,
+            status: "ok-\(typeName)",
+            characterCount: selectedText?.count ?? 0
+        )
+    }
+
+    private func nonEmptyAXSelectedText(from element: AXUIElement) -> String? {
+        probeAXSelectedText(from: element).text
+    }
+
+    private func selectedTextFromAXTextMarker(startingAt element: AXUIElement) -> String? {
+        var current: AXUIElement? = element
+        for depth in 0..<6 {
+            guard let currentElement = current else { break }
+            let role = axStringAttribute(
+                kAXRoleAttribute as CFString,
+                for: currentElement,
+                timeout: Self.selectionAXMessagingTimeout
+            ) ?? "nil"
+            let result = selectedTextFromAXTextMarkerRange(on: currentElement)
+            VoxtLog.input(
+                "selectionProbe.textMarker.depth=\(depth) role=\(role) status=\(result.status) chars=\(result.text?.count ?? 0)"
+            )
+            if let text = result.text {
+                return text
+            }
+            current = axElementAttribute(
+                kAXParentAttribute as CFString,
+                for: currentElement,
+                timeout: Self.selectionAXMessagingTimeout
+            )
+        }
+        return nil
+    }
+
+    private struct TextMarkerProbeResult {
+        let text: String?
+        let status: String
+    }
+
+    private func selectedTextFromAXTextMarkerRange(on element: AXUIElement) -> TextMarkerProbeResult {
+        AXUIElementSetMessagingTimeout(element, Self.selectionAXMessagingTimeout)
+        var markerRangeRef: CFTypeRef?
+        let markerStatus = AXUIElementCopyAttributeValue(
+            element,
+            "AXSelectedTextMarkerRange" as CFString,
+            &markerRangeRef
+        )
+        guard markerStatus == .success, let markerRangeRef else {
+            return TextMarkerProbeResult(text: nil, status: "marker-error-\(markerStatus.rawValue)")
+        }
+
+        var stringRef: CFTypeRef?
+        let stringStatus = AXUIElementCopyParameterizedAttributeValue(
+            element,
+            "AXStringForTextMarkerRange" as CFString,
+            markerRangeRef,
+            &stringRef
+        )
+        if stringStatus == .success,
+           let text = stringRef as? String,
+           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return TextMarkerProbeResult(text: text, status: "string-ok")
+        }
+
+        var attributedRef: CFTypeRef?
+        let attributedStatus = AXUIElementCopyParameterizedAttributeValue(
+            element,
+            "AXAttributedStringForTextMarkerRange" as CFString,
+            markerRangeRef,
+            &attributedRef
+        )
+        if attributedStatus == .success {
+            if let attributed = attributedRef as? NSAttributedString,
+               !attributed.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return TextMarkerProbeResult(text: attributed.string, status: "attributed-ok")
+            }
+            if let text = attributedRef as? String,
+               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return TextMarkerProbeResult(text: text, status: "attributed-string-ok")
+            }
+            return TextMarkerProbeResult(
+                text: nil,
+                status: "marker-present-empty stringStatus=\(stringStatus.rawValue) attributedStatus=\(attributedStatus.rawValue)"
+            )
+        }
+        return TextMarkerProbeResult(
+            text: nil,
+            status: "resolve-failed stringStatus=\(stringStatus.rawValue) attributedStatus=\(attributedStatus.rawValue)"
+        )
+    }
+
+    private func selectedTextFromBrowserAppleScript(bundleID: String) -> String? {
+        if let deniedUntil = browserAutomationDeniedUntilByBundleID[bundleID],
+           deniedUntil > Date() {
+            let remaining = Int(deniedUntil.timeIntervalSinceNow)
+            VoxtLog.input(
+                "selectionProbe.appleScript: skipped denied-cache bundleID=\(bundleID) remainingSec=\(remaining)"
+            )
             return nil
         }
-        return selectedText
+
+        let displayName = browserScriptProvider(for: bundleID)?.name
+        let scripts = BrowserAutomationScriptBuilder.selectionScripts(
+            bundleID: bundleID,
+            displayName: displayName
+        )
+        VoxtLog.input(
+            "selectionProbe.appleScript: candidates=\(scripts.count) provider=\(displayName ?? "nil") bundleID=\(bundleID)"
+        )
+        for (index, source) in scripts.enumerated() {
+            var executionError: NSDictionary?
+            let startedAt = Date()
+            // `runAppleScript` ceilings fractional timeouts to whole seconds; pass 1 explicitly.
+            let rawOutput = runAppleScript(
+                source,
+                error: &executionError,
+                logFailure: false,
+                timeout: 1
+            )
+            let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+
+            if SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: rawOutput,
+                hadExecutionError: executionError != nil
+            ) {
+                VoxtLog.input(
+                    "selectionProbe.appleScript.candidate=\(index + 1): empty-selection elapsedMs=\(elapsedMs)"
+                )
+                return nil
+            }
+
+            let trimmed = rawOutput?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let trimmed, !trimmed.isEmpty {
+                VoxtLog.input(
+                    "selectionProbe.appleScript.candidate=\(index + 1): ok chars=\(trimmed.count) elapsedMs=\(elapsedMs) preview=\(selectionPreview(trimmed))"
+                )
+                return trimmed
+            }
+
+            let errorNumber = executionError?["NSAppleScriptErrorNumber"] as? Int
+            let errorMessage = executionError?["NSAppleScriptErrorMessage"] as? String ?? "nil"
+            VoxtLog.input(
+                "selectionProbe.appleScript.candidate=\(index + 1): miss elapsedMs=\(elapsedMs) errorNumber=\(errorNumber.map(String.init) ?? "nil") message=\(errorMessage)"
+            )
+
+            if let errorNumber {
+                if errorNumber == -1743 || errorNumber == -10004 {
+                    browserAutomationDeniedUntilByBundleID[bundleID] = Date().addingTimeInterval(300)
+                    VoxtLog.input(
+                        "selectionProbe.appleScript: caching denial for 300s bundleID=\(bundleID) error=\(errorNumber)"
+                    )
+                    break
+                }
+                if errorNumber == -600 {
+                    VoxtLog.input("selectionProbe.appleScript: app not running error=-600")
+                    break
+                }
+            }
+        }
+        return nil
     }
 
     private func nonEmptySelectedTextRange(_ range: CFRange?) -> CFRange? {
@@ -161,40 +609,81 @@ extension AppDelegate {
         return range
     }
 
-    private func logSelectionProbe(range: CFRange?, textSource: String, app: String) {
-        let rangeDescription = range.map { "{\($0.location),\($0.length)}" } ?? "nil"
+    private func logSelectionProbe(
+        range: CFRange?,
+        textSource: String,
+        app: String,
+        isBrowser: Bool,
+        detail: String = ""
+    ) {
+        let rangeDescription = selectionRangeDescription(range)
+        let suffix = detail.isEmpty ? "" : " detail=\(detail)"
         VoxtLog.input(
-            "selectionProbe: range=\(rangeDescription) textSource=\(textSource) app=\(app)"
+            "selectionProbe.result: range=\(rangeDescription) textSource=\(textSource) browser=\(isBrowser) app=\(app)\(suffix)"
         )
     }
 
-    private func selectedTextBySimulatedCopy() -> String? {
-        guard AccessibilityPermissionManager.isTrusted() else { return nil }
-        guard let source = CGEventSource(stateID: .hidSystemState) else { return nil }
+    private func selectionRangeDescription(_ range: CFRange?) -> String {
+        range.map { "{\($0.location),\($0.length)}" } ?? "nil"
+    }
+
+    private func selectionPreview(_ text: String?) -> String {
+        guard let text else { return "nil" }
+        let collapsed = text
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\t", with: "\\t")
+        if collapsed.count <= 48 {
+            return "\"\(collapsed)\""
+        }
+        let prefix = collapsed.prefix(48)
+        return "\"\(prefix)…\"(+\(collapsed.count - 48))"
+    }
+
+    private func selectedTextBySimulatedCopy(reason: String = "unspecified") -> String? {
+        VoxtLog.input("selectionProbe.copy.begin: reason=\(reason)")
+        guard AccessibilityPermissionManager.isTrusted() else {
+            VoxtLog.input("selectionProbe.copy.miss: accessibility-not-trusted")
+            return nil
+        }
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            VoxtLog.input("selectionProbe.copy.miss: no-event-source")
+            return nil
+        }
 
         let pasteboard = NSPasteboard.general
         let previous = readStringFromPasteboard(pasteboard)
         let originalChangeCount = pasteboard.changeCount
+        VoxtLog.input(
+            "selectionProbe.copy.pasteboard: changeCount=\(originalChangeCount) previousChars=\(previous?.count ?? 0)"
+        )
 
         let cKeyCode: CGKeyCode = 0x08
         let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: true)
         cmdDown?.flags = .maskCommand
         let cmdUp = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: false)
         cmdUp?.flags = .maskCommand
-        guard cmdDown != nil, cmdUp != nil else { return nil }
+        guard cmdDown != nil, cmdUp != nil else {
+            VoxtLog.input("selectionProbe.copy.miss: failed-to-create-key-events")
+            return nil
+        }
 
         HotkeyEventSupport.markAsVoxtInjected(cmdDown)
         HotkeyEventSupport.markAsVoxtInjected(cmdUp)
         cmdDown?.post(tap: .cgAnnotatedSessionEventTap)
         cmdUp?.post(tap: .cgAnnotatedSessionEventTap)
 
-        let deadline = Date().addingTimeInterval(0.06)
+        // AX-poor apps (WeChat, some web views) can take longer to honor Cmd+C.
+        let waitSeconds: TimeInterval = 0.15
+        let deadline = Date().addingTimeInterval(waitSeconds)
         while pasteboard.changeCount == originalChangeCount, Date() < deadline {
             _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
         }
 
         let copiedChangeCount = pasteboard.changeCount
         guard copiedChangeCount != originalChangeCount else {
+            VoxtLog.input(
+                "selectionProbe.copy.miss: pasteboard-unchanged changeCount=\(copiedChangeCount) waitedSec=\(waitSeconds) reason=\(reason)"
+            )
             return nil
         }
 
@@ -206,7 +695,15 @@ extension AppDelegate {
             pasteboard.setString(previous, forType: .string)
         }
 
-        guard let copied, !copied.isEmpty else { return nil }
+        guard let copied, !copied.isEmpty else {
+            VoxtLog.input(
+                "selectionProbe.copy.miss: empty-after-change changeCount=\(copiedChangeCount)"
+            )
+            return nil
+        }
+        VoxtLog.input(
+            "selectionProbe.copy.ok: reason=\(reason) chars=\(copied.count) preview=\(selectionPreview(copied))"
+        )
         return copied
     }
 
@@ -588,7 +1085,15 @@ extension AppDelegate {
     }
 
     private func axStringAttribute(_ attribute: CFString, for element: AXUIElement) -> String? {
-        AXUIElementSetMessagingTimeout(element, Self.axMessagingTimeout)
+        axStringAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
+    }
+
+    private func axStringAttribute(
+        _ attribute: CFString,
+        for element: AXUIElement,
+        timeout: Float
+    ) -> String? {
+        AXUIElementSetMessagingTimeout(element, timeout)
         var valueRef: CFTypeRef?
         let status = AXUIElementCopyAttributeValue(element, attribute, &valueRef)
         guard status == .success else { return nil }
@@ -613,7 +1118,15 @@ extension AppDelegate {
     }
 
     private func axRangeAttribute(_ attribute: CFString, for element: AXUIElement) -> CFRange? {
-        AXUIElementSetMessagingTimeout(element, Self.axMessagingTimeout)
+        axRangeAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
+    }
+
+    private func axRangeAttribute(
+        _ attribute: CFString,
+        for element: AXUIElement,
+        timeout: Float
+    ) -> CFRange? {
+        AXUIElementSetMessagingTimeout(element, timeout)
         var valueRef: CFTypeRef?
         let status = AXUIElementCopyAttributeValue(element, attribute, &valueRef)
         guard status == .success,
@@ -651,11 +1164,20 @@ extension AppDelegate {
         range: CFRange,
         for element: AXUIElement
     ) -> String? {
+        axParameterizedString(attribute, range: range, for: element, timeout: Self.axMessagingTimeout)
+    }
+
+    private func axParameterizedString(
+        _ attribute: CFString,
+        range: CFRange,
+        for element: AXUIElement,
+        timeout: Float
+    ) -> String? {
         var mutableRange = range
         guard let rangeValue = AXValueCreate(.cfRange, &mutableRange) else {
             return nil
         }
-        AXUIElementSetMessagingTimeout(element, Self.axMessagingTimeout)
+        AXUIElementSetMessagingTimeout(element, timeout)
         var valueRef: CFTypeRef?
         let status = AXUIElementCopyParameterizedAttributeValue(
             element,
@@ -738,7 +1260,15 @@ extension AppDelegate {
     }
 
     private func axElementAttribute(_ attribute: CFString, for element: AXUIElement) -> AXUIElement? {
-        AXUIElementSetMessagingTimeout(element, Self.axMessagingTimeout)
+        axElementAttribute(attribute, for: element, timeout: Self.axMessagingTimeout)
+    }
+
+    private func axElementAttribute(
+        _ attribute: CFString,
+        for element: AXUIElement,
+        timeout: Float
+    ) -> AXUIElement? {
+        AXUIElementSetMessagingTimeout(element, timeout)
         var valueRef: CFTypeRef?
         let status = AXUIElementCopyAttributeValue(element, attribute, &valueRef)
         guard status == .success,

--- a/Voxt/App/TranslationFlow.swift
+++ b/Voxt/App/TranslationFlow.swift
@@ -135,12 +135,19 @@ extension AppDelegate {
     }
 
     func beginSelectedTextTranslationIfPossible() -> Bool {
-        guard !isSessionActive else { return false }
+        guard !isSessionActive else {
+            VoxtLog.hotkey("selectionProbe.translation: skipped sessionActive=true")
+            return false
+        }
         guard let selectedText = selectedTextFromSystemSelection(),
               !selectedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
+            VoxtLog.hotkey("selectionProbe.translation: no usable selected text")
             return false
         }
+        VoxtLog.hotkey(
+            "selectionProbe.translation: accepted chars=\(selectedText.count) preview=\(String(selectedText.prefix(48)))"
+        )
 
         pendingSessionFinishTask?.cancel()
         pendingSessionFinishTask = nil

--- a/Voxt/Core/Utilities/BrowserAutomationScriptBuilder.swift
+++ b/Voxt/Core/Utilities/BrowserAutomationScriptBuilder.swift
@@ -4,6 +4,47 @@
 import Foundation
 
 enum BrowserAutomationScriptBuilder {
+    private static let selectionJavaScript = "window.getSelection().toString()"
+
+    /// AppleScript candidates that read the current page selection via JavaScript.
+    /// Requires "Allow JavaScript from Apple Events" in the target browser.
+    static func selectionScripts(bundleID: String, displayName: String?) -> [String] {
+        let js = selectionJavaScript
+        let name = displayName ?? bundleID
+        switch bundleID {
+        case "com.apple.Safari", "com.apple.SafariTechnologyPreview":
+            return [
+                "tell application id \"\(bundleID)\" to tell front window to do JavaScript \"\(js)\" in current tab",
+                "tell application id \"\(bundleID)\" to do JavaScript \"\(js)\" in front document",
+                "tell application \"\(name)\" to tell front window to do JavaScript \"\(js)\" in current tab"
+            ]
+        case "com.google.Chrome",
+             "com.microsoft.edgemac",
+             "com.brave.Browser",
+             "company.thebrowser.Browser":
+            return chromiumSelectionScripts(bundleID: bundleID, displayName: name, javaScript: js)
+        default:
+            // Custom browsers: try Chromium then Safari-style forms.
+            return chromiumSelectionScripts(bundleID: bundleID, displayName: name, javaScript: js) + [
+                "tell application id \"\(bundleID)\" to tell front window to do JavaScript \"\(js)\" in current tab",
+                "tell application id \"\(bundleID)\" to do JavaScript \"\(js)\" in front document",
+                "tell application \"\(name)\" to tell front window to do JavaScript \"\(js)\" in current tab"
+            ]
+        }
+    }
+
+    private static func chromiumSelectionScripts(
+        bundleID: String,
+        displayName: String,
+        javaScript: String
+    ) -> [String] {
+        [
+            "tell application id \"\(bundleID)\" to tell active tab of front window to execute javascript \"\(javaScript)\"",
+            "tell application id \"\(bundleID)\" to tell active tab of window 1 to execute javascript \"\(javaScript)\"",
+            "tell application \"\(displayName)\" to tell active tab of front window to execute javascript \"\(javaScript)\""
+        ]
+    }
+
     static func customBrowserPermissionProbeScripts(bundleID: String, displayName: String) -> [String] {
         // Permission probes run inside Settings, where avoiding UI freezes is
         // more important than preserving runtime ordering. Try the tab-based

--- a/Voxt/Core/Utilities/SelectedTextSystemSelectionSupport.swift
+++ b/Voxt/Core/Utilities/SelectedTextSystemSelectionSupport.swift
@@ -1,0 +1,124 @@
+// SelectedTextSystemSelectionSupport.swift
+// Capability-based policy for system selection probing (no AppKit UI).
+
+import Foundation
+import ApplicationServices
+
+enum SelectedTextSystemSelectionSupport {
+    /// Hard gate: a caret-only range (`length == 0`) must not count as a selection.
+    static func hasNonEmptySelectedTextRange(length: CFIndex) -> Bool {
+        length > 0
+    }
+
+    /// Editors that implement "Cmd+C with no selection copies the current line"
+    /// (VS Code `editor.emptySelectionClipboard`, Sublime, Zed, JetBrains, etc.).
+    ///
+    /// This is a clipboard-semantics capability class. Many of these apps also
+    /// fail AX focus lookup with `kAXErrorCannotComplete` (-25204), so
+    /// "focused == nil" alone cannot mean "safe to Cmd+C" — that path remains
+    /// necessary for AX-dead apps such as WeChat, but must stay denied here.
+    static func copiesCurrentLineWhenSelectionEmpty(bundleID: String?) -> Bool {
+        guard let bundleID, !bundleID.isEmpty else { return false }
+
+        let exactIDs: Set<String> = [
+            "com.microsoft.VSCode",
+            "com.microsoft.VSCodeInsiders",
+            "com.microsoft.VSCodeExploration",
+            "com.visualstudio.code.oss",
+            "com.visualstudio.code",
+            "com.vscodium",
+            "com.google.antigravity",
+            "com.sublimetext.3",
+            "com.sublimetext.4",
+            "dev.zed.Zed",
+            "dev.zed.Zed-Preview",
+            "com.trae.app",
+            "com.trae.solo.app",
+            "cn.trae.app",
+            "com.qoder.app"
+        ]
+        if exactIDs.contains(bundleID) {
+            return true
+        }
+
+        let prefixes = [
+            "com.todesktop.",
+            "com.jetbrains.",
+            "com.exafunction.",
+            "com.trae.",
+            "cn.trae.",
+            "com.qoder."
+        ]
+        if prefixes.contains(where: bundleID.hasPrefix) {
+            return true
+        }
+
+        let lowered = bundleID.lowercased()
+        return lowered.contains("vscode") || lowered.contains("vscodium")
+    }
+
+    /// Whether Cmd+C may run after all non-destructive reads missed.
+    ///
+    /// Capability rule (not per-app special cases):
+    /// - caret-only range (`length == 0`) → deny
+    /// - non-empty range → allow (recover text when attributes are empty)
+    /// - no focused element:
+    ///   - deny when the frontmost app's clipboard class invents a line on empty selection
+    ///   - allow otherwise (AX-dead apps that do not invent clipboard content)
+    /// - focused element but no range attribute:
+    ///   - browser → allow
+    ///   - otherwise → deny
+    ///
+    /// Clipboard-shape heuristics are intentionally not used: they both miss real
+    /// whole-line selections and fail to catch empty-selection line copies without EOL.
+    static func shouldAttemptSimulatedCopy(
+        focusedElementAvailable: Bool,
+        selectedTextRange: CFRange?,
+        isBrowser: Bool,
+        copiesLineOnEmptySelection: Bool
+    ) -> Bool {
+        if focusedElementAvailable, let selectedTextRange {
+            return selectedTextRange.length > 0
+        }
+        if !focusedElementAvailable {
+            return !copiesLineOnEmptySelection
+        }
+        return isBrowser
+    }
+
+    /// Range attribute present with `length == 0` means caret-only; further probes cannot help.
+    static func isConfirmedCaretOnly(selectedTextRange: CFRange?) -> Bool {
+        guard let selectedTextRange else { return false }
+        return selectedTextRange.length == 0
+    }
+
+    /// AppleScript ran without an execution error and returned empty/whitespace selection text.
+    /// Dialect retries are only useful when the script form itself fails.
+    static func isDefinitiveEmptyBrowserSelection(output: String?, hadExecutionError: Bool) -> Bool {
+        guard !hadExecutionError, let output else { return false }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Stable deny reason for logs / diagnostics after copy policy rejects.
+    static func denialDetail(
+        allowCopy: Bool,
+        focusedElementAvailable: Bool,
+        selectedTextRange: CFRange?,
+        isBrowser: Bool,
+        copiesLineOnEmptySelection: Bool
+    ) -> String {
+        if allowCopy {
+            return "copy-missed"
+        }
+        if !focusedElementAvailable, copiesLineOnEmptySelection {
+            return "ax-focus-unavailable-line-copy-editor"
+        }
+        if focusedElementAvailable, selectedTextRange?.length == 0 {
+            return "confirmed-caret-only"
+        }
+        if focusedElementAvailable, selectedTextRange == nil, !isBrowser {
+            return "focused-without-range-non-browser"
+        }
+        return "copy-denied"
+    }
+}

--- a/Voxt/Core/Utilities/SelectedTextSystemSelectionSupport.swift
+++ b/Voxt/Core/Utilities/SelectedTextSystemSelectionSupport.swift
@@ -69,8 +69,8 @@ enum SelectedTextSystemSelectionSupport {
     ///   - browser → allow
     ///   - otherwise → deny
     ///
-    /// Clipboard-shape heuristics are intentionally not used: they both miss real
-    /// whole-line selections and fail to catch empty-selection line copies without EOL.
+    /// Line-copy editors with a total AX blackout use a separate filtered probe
+    /// (`shouldAttemptAXBlackoutClipboardProbe`); do not widen this gate for them.
     static func shouldAttemptSimulatedCopy(
         focusedElementAvailable: Bool,
         selectedTextRange: CFRange?,
@@ -84,6 +84,39 @@ enum SelectedTextSystemSelectionSupport {
             return !copiesLineOnEmptySelection
         }
         return isBrowser
+    }
+
+    /// Last-resort clipboard probe for the line-copy capability class when AX exposes
+    /// neither a focused element nor any window candidates.
+    ///
+    /// Without this path, Electron editors that fail FocusedUIElement (-25204) and
+    /// return an empty AX window list can never recover a real selection. Results must
+    /// still pass `looksLikeEmptySelectionLineCopy` filtering.
+    static func shouldAttemptAXBlackoutClipboardProbe(
+        focusedElementAvailable: Bool,
+        axWindowCandidatesAvailable: Bool,
+        copiesLineOnEmptySelection: Bool
+    ) -> Bool {
+        copiesLineOnEmptySelection
+            && !focusedElementAvailable
+            && !axWindowCandidatesAvailable
+    }
+
+    /// Best-effort filter for `emptySelectionClipboard`-style payloads:
+    /// exactly one line plus a trailing newline. Mid-line selections usually omit
+    /// that trailing newline; multi-line selections contain interior newlines.
+    ///
+    /// Residual risk: last lines without EOL may false-accept; intentional whole-line
+    /// selections that include EOL may false-reject.
+    static func looksLikeEmptySelectionLineCopy(rawClipboardText: String) -> Bool {
+        let normalized = rawClipboardText
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let trimmed = normalized.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        guard normalized.hasSuffix("\n") else { return false }
+        let body = String(normalized.dropLast())
+        return !body.contains("\n")
     }
 
     /// Range attribute present with `length == 0` means caret-only; further probes cannot help.

--- a/VoxtTests/SessionTextIOTests.swift
+++ b/VoxtTests/SessionTextIOTests.swift
@@ -37,6 +37,175 @@ final class SessionTextIOTests: XCTestCase {
         XCTAssertTrue(SelectedTextSystemSelectionSupport.hasNonEmptySelectedTextRange(length: 12))
     }
 
+    func testSimulatedCopyPolicyByAXEvidenceClass() {
+        // Caret-only range: deny.
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+                focusedElementAvailable: true,
+                selectedTextRange: CFRange(location: 12, length: 0),
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            )
+        )
+
+        // Non-empty range: allow recovery copy.
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+                focusedElementAvailable: true,
+                selectedTextRange: CFRange(location: 0, length: 4),
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            )
+        )
+
+        // AX focus dead, but app does not invent a line copy (e.g. WeChat).
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+                focusedElementAvailable: false,
+                selectedTextRange: nil,
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            )
+        )
+
+        // AX focus dead + line-copy editor (Cursor / VS Code): deny.
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+                focusedElementAvailable: false,
+                selectedTextRange: nil,
+                isBrowser: false,
+                copiesLineOnEmptySelection: true
+            )
+        )
+
+        // Focused editor without range attribute: deny.
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+                focusedElementAvailable: true,
+                selectedTextRange: nil,
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            )
+        )
+
+        // Browser focused without range attribute: allow.
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.shouldAttemptSimulatedCopy(
+                focusedElementAvailable: true,
+                selectedTextRange: nil,
+                isBrowser: true,
+                copiesLineOnEmptySelection: false
+            )
+        )
+    }
+
+    func testCopiesCurrentLineWhenSelectionEmptyRecognizesEditorFamilies() {
+        let lineCopyEditors = [
+            "com.microsoft.VSCode",
+            "com.microsoft.VSCodeInsiders",
+            "com.vscodium",
+            "com.todesktop.230313mzl4w4u92", // Cursor
+            "com.exafunction.windsurf",
+            "com.google.antigravity",
+            "com.jetbrains.intellij",
+            "com.jetbrains.WebStorm",
+            "com.sublimetext.4",
+            "dev.zed.Zed",
+            "com.trae.app",
+            "cn.trae.app",
+            "com.qoder.app",
+            "org.example.MyVSCodeFork"
+        ]
+        for bundleID in lineCopyEditors {
+            XCTAssertTrue(
+                SelectedTextSystemSelectionSupport.copiesCurrentLineWhenSelectionEmpty(bundleID: bundleID),
+                "Expected line-copy editor classification for \(bundleID)"
+            )
+        }
+
+        let safeApps = [
+            "com.tencent.xinWeChat",
+            "com.apple.Safari",
+            "com.google.Chrome",
+            "com.apple.TextEdit",
+            "com.apple.Notes",
+            "com.tinyspeck.slackmacgap"
+        ]
+        for bundleID in safeApps {
+            XCTAssertFalse(
+                SelectedTextSystemSelectionSupport.copiesCurrentLineWhenSelectionEmpty(bundleID: bundleID),
+                "Expected non-line-copy classification for \(bundleID)"
+            )
+        }
+    }
+
+    func testBrowserSelectionScriptsIncludeJavaScriptSelection() {
+        let safariScripts = BrowserAutomationScriptBuilder.selectionScripts(
+            bundleID: "com.apple.Safari",
+            displayName: "Safari"
+        )
+        XCTAssertFalse(safariScripts.isEmpty)
+        XCTAssertTrue(safariScripts.contains(where: { $0.contains("window.getSelection().toString()") }))
+        XCTAssertTrue(safariScripts.contains(where: { $0.contains("do JavaScript") }))
+
+        let chromeScripts = BrowserAutomationScriptBuilder.selectionScripts(
+            bundleID: "com.google.Chrome",
+            displayName: "Google Chrome"
+        )
+        XCTAssertFalse(chromeScripts.isEmpty)
+        XCTAssertTrue(chromeScripts.contains(where: { $0.contains("execute javascript") }))
+    }
+
+    func testConfirmedCaretOnlyShortCircuitsFurtherSelectionProbes() {
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.isConfirmedCaretOnly(
+                selectedTextRange: CFRange(location: 8, length: 0)
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.isConfirmedCaretOnly(
+                selectedTextRange: CFRange(location: 0, length: 3)
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.isConfirmedCaretOnly(selectedTextRange: nil)
+        )
+    }
+
+    func testDefinitiveEmptyBrowserSelectionStopsDialectRetries() {
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: "",
+                hadExecutionError: false
+            )
+        )
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: "  \n\t",
+                hadExecutionError: false
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: "hello",
+                hadExecutionError: false
+            )
+        )
+        // Script-form failures should keep trying other dialects.
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: nil,
+                hadExecutionError: true
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.isDefinitiveEmptyBrowserSelection(
+                output: "",
+                hadExecutionError: true
+            )
+        )
+    }
+
     func testRewriteAlwaysPresentsAnswerOverlay() {
         XCTAssertTrue(
             AppDelegate.shouldPresentRewriteAnswerOverlay(

--- a/VoxtTests/SessionTextIOTests.swift
+++ b/VoxtTests/SessionTextIOTests.swift
@@ -206,6 +206,49 @@ final class SessionTextIOTests: XCTestCase {
         )
     }
 
+    func testSelectionProbeDenialDetailMatchesCapabilityClasses() {
+        XCTAssertEqual(
+            SelectedTextSystemSelectionSupport.denialDetail(
+                allowCopy: true,
+                focusedElementAvailable: false,
+                selectedTextRange: nil,
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            ),
+            "copy-missed"
+        )
+        XCTAssertEqual(
+            SelectedTextSystemSelectionSupport.denialDetail(
+                allowCopy: false,
+                focusedElementAvailable: false,
+                selectedTextRange: nil,
+                isBrowser: false,
+                copiesLineOnEmptySelection: true
+            ),
+            "ax-focus-unavailable-line-copy-editor"
+        )
+        XCTAssertEqual(
+            SelectedTextSystemSelectionSupport.denialDetail(
+                allowCopy: false,
+                focusedElementAvailable: true,
+                selectedTextRange: CFRange(location: 3, length: 0),
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            ),
+            "confirmed-caret-only"
+        )
+        XCTAssertEqual(
+            SelectedTextSystemSelectionSupport.denialDetail(
+                allowCopy: false,
+                focusedElementAvailable: true,
+                selectedTextRange: nil,
+                isBrowser: false,
+                copiesLineOnEmptySelection: false
+            ),
+            "focused-without-range-non-browser"
+        )
+    }
+
     func testRewriteAlwaysPresentsAnswerOverlay() {
         XCTAssertTrue(
             AppDelegate.shouldPresentRewriteAnswerOverlay(

--- a/VoxtTests/SessionTextIOTests.swift
+++ b/VoxtTests/SessionTextIOTests.swift
@@ -99,6 +99,61 @@ final class SessionTextIOTests: XCTestCase {
         )
     }
 
+    func testAXBlackoutClipboardProbeOnlyWhenLineCopyEditorHasNoAXSurface() {
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.shouldAttemptAXBlackoutClipboardProbe(
+                focusedElementAvailable: false,
+                axWindowCandidatesAvailable: false,
+                copiesLineOnEmptySelection: true
+            )
+        )
+        // Still have window candidates: keep denying unfiltered Cmd+C.
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.shouldAttemptAXBlackoutClipboardProbe(
+                focusedElementAvailable: false,
+                axWindowCandidatesAvailable: true,
+                copiesLineOnEmptySelection: true
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.shouldAttemptAXBlackoutClipboardProbe(
+                focusedElementAvailable: false,
+                axWindowCandidatesAvailable: false,
+                copiesLineOnEmptySelection: false
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.shouldAttemptAXBlackoutClipboardProbe(
+                focusedElementAvailable: true,
+                axWindowCandidatesAvailable: false,
+                copiesLineOnEmptySelection: true
+            )
+        )
+    }
+
+    func testLooksLikeEmptySelectionLineCopyRecognizesClipboardCapabilityShape() {
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.looksLikeEmptySelectionLineCopy(
+                rawClipboardText: "    const foo = 1;\n"
+            )
+        )
+        XCTAssertTrue(
+            SelectedTextSystemSelectionSupport.looksLikeEmptySelectionLineCopy(
+                rawClipboardText: "single line\r\n"
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.looksLikeEmptySelectionLineCopy(
+                rawClipboardText: "selectedWord"
+            )
+        )
+        XCTAssertFalse(
+            SelectedTextSystemSelectionSupport.looksLikeEmptySelectionLineCopy(
+                rawClipboardText: "line one\nline two\n"
+            )
+        )
+    }
+
     func testCopiesCurrentLineWhenSelectionEmptyRecognizesEditorFamilies() {
         let lineCopyEditors = [
             "com.microsoft.VSCode",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -23,14 +23,19 @@ MacOS 语音输入与翻译工具，支持不同应用和网址文本增强。�
 
 - 边说边转文字，实时查看文本内容
 
-<video src="https://github.com/user-attachments/assets/75f08906-3e69-4ab5-9b29-f5c3745cebac">
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/75f08906-3e69-4ab5-9b29-f5c3745cebac" width="500px"></video>
+</p>
 
 **翻译，文本翻译**
 
 - AI 翻译，说完自动翻译
 - 选中翻译，选择文本，快捷键直接翻译
 
-<video src="https://github.com/user-attachments/assets/e69c2737-5d8c-4bd6-9f5b-1123947c7e39">
+
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/e69c2737-5d8c-4bd6-9f5b-1123947c7e39" width="500px"></video>
+</p>
 
 **转写，语音对话，结果增强**
 


### PR DESCRIPTION
## Summary
- 选区探测改为多层非破坏读取（AXSelectedText / StringForRange / TextMarker / 浏览器 AppleScript），仅在策略允许时才回退 Cmd+C。
- 按剪贴板语义分类「空选区会复制当前行」的编辑器（VS Code / Cursor / JetBrains 等）；焦点拿不到时禁止 Cmd+C，避免误触发加词/建笔记/翻译。
- 对微信等 AX 受限但不会行复制的应用保留 Cmd+C 兜底；同时把选区 AX 超时降到 0.2s，并在 caret-only / AppleScript 空选区时短路径返回，避免热键卡顿。

## Test plan
- [ ] Cursor / VS Code：仅光标、无选区时按转录/笔记热键，不应误触发加词或建笔记
- [ ] 微信：真选中文本后热键仍可识别选区
- [ ] Safari / Chrome：网页真选中可用；无选区不误触发
- [ ] TextEdit 等普通应用：有选区/无选区行为正常
- [ ] `xcodebuild test -project Voxt.xcodeproj -scheme Voxt -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:VoxtTests/SessionTextIOTests`


Made with [Cursor](https://cursor.com)