### PR TITLE
wrap bare eval() with withError to avoid crash on MLX error

### DIFF
--- a/Voxt/Core/Models/MemoryEfficientModelContainerLoader.swift
+++ b/Voxt/Core/Models/MemoryEfficientModelContainerLoader.swift
@@ -288,7 +288,9 @@ nonisolated enum MemoryEfficientModelContainerLoader {
             parameters: ModuleParameters.unflattened(weights),
             verify: [.all]
         )
-        eval(model)
+        try withError {
+            eval(model)
+        }
     }
 
     private static func safetensorURLs(in modelDirectory: URL) throws -> [URL] {

--- a/Voxt/Meeting/Capture/MeetingVoiceActivity.swift
+++ b/Voxt/Meeting/Capture/MeetingVoiceActivity.swift
@@ -325,15 +325,16 @@ actor ASRSileroStreamingVoiceActivityDetector {
             let chunk = Array(pending[pendingOffset..<endOffset])
             pendingOffset = endOffset
             let state = states[streamID]
-            let (probabilityArray, nextState) = try model.feed(
-                chunk: MLXArray(chunk),
-                state: state,
-                sampleRate: sampleRate
-            )
-            try withError {
+            let (probability, nextState) = try withError {
+                let (probabilityArray, nextState) = try model.feed(
+                    chunk: MLXArray(chunk),
+                    state: state,
+                    sampleRate: sampleRate
+                )
                 eval(probabilityArray)
+                return (probabilityArray.asArray(Float.self).first, nextState)
             }
-            if let probability = probabilityArray.asArray(Float.self).first {
+            if let probability {
                 latestProbability = probability
             }
             states[streamID] = nextState
@@ -368,7 +369,7 @@ actor ASRSileroStreamingVoiceActivityDetector {
             return model
         }
         let directory = try await SileroVADModelProvisioner.shared.ensureModelDirectory()
-        let loaded = try SileroVAD.fromModelDirectory(directory)
+        let loaded = try SileroVADModelSupport.loadModel(from: directory)
         model = loaded
         return loaded
     }
@@ -393,14 +394,16 @@ actor ASRSileroOfflineVoiceActivityDetector: ASROfflineVoiceActivityBackend {
         guard !prepared.isEmpty else { return [] }
 
         let profile = MeetingSileroVADSensitivity.stored().configuration()
-        let timestamps = try model.getSpeechTimestamps(
-            MLXArray(prepared),
-            sampleRate: sampleRate,
-            threshold: profile.onsetProbabilityThreshold,
-            minSpeechDurationMs: Int((profile.minSpeechSeconds * 1_000).rounded(.up)),
-            minSilenceDurationMs: Int((profile.minSilenceSeconds * 1_000).rounded(.up)),
-            speechPadMs: Int((profile.speechPadSeconds * 1_000).rounded(.up))
-        )
+        let timestamps = try withError {
+            try model.getSpeechTimestamps(
+                MLXArray(prepared),
+                sampleRate: sampleRate,
+                threshold: profile.onsetProbabilityThreshold,
+                minSpeechDurationMs: Int((profile.minSpeechSeconds * 1_000).rounded(.up)),
+                minSilenceDurationMs: Int((profile.minSilenceSeconds * 1_000).rounded(.up)),
+                speechPadMs: Int((profile.speechPadSeconds * 1_000).rounded(.up))
+            )
+        }
         return timestamps.compactMap { timestamp in
             let start = Double(timestamp.start) / Double(sampleRate)
             let end = Double(timestamp.end) / Double(sampleRate)
@@ -414,7 +417,7 @@ actor ASRSileroOfflineVoiceActivityDetector: ASROfflineVoiceActivityBackend {
             return model
         }
         let directory = try await SileroVADModelProvisioner.shared.ensureModelDirectory()
-        let loaded = try SileroVAD.fromModelDirectory(directory)
+        let loaded = try SileroVADModelSupport.loadModel(from: directory)
         model = loaded
         return loaded
     }

--- a/Voxt/Meeting/Capture/MeetingVoiceActivity.swift
+++ b/Voxt/Meeting/Capture/MeetingVoiceActivity.swift
@@ -330,7 +330,9 @@ actor ASRSileroStreamingVoiceActivityDetector {
                 state: state,
                 sampleRate: sampleRate
             )
-            eval(probabilityArray)
+            try withError {
+                eval(probabilityArray)
+            }
             if let probability = probabilityArray.asArray(Float.self).first {
                 latestProbability = probability
             }

--- a/Voxt/Meeting/Capture/SileroVADModelProvisioner.swift
+++ b/Voxt/Meeting/Capture/SileroVADModelProvisioner.swift
@@ -2,7 +2,20 @@
 // Provisions the single supported Silero VAD checkpoint on demand.
 
 import Foundation
+import MLX
 import MLXAudioVAD
+
+extension SileroVADModelSupport {
+    /// Load Silero with MLX C-layer errors converted to Swift throws.
+    ///
+    /// `SileroVAD.fromModelDirectory` uses bare `eval()` internally; without a
+    /// scoped `withError` handler those failures call `fatalError`.
+    nonisolated static func loadModel(from directory: URL) throws -> SileroVAD {
+        try withError {
+            try SileroVAD.fromModelDirectory(directory)
+        }
+    }
+}
 
 @MainActor
 final class SileroVADModelProvisioner {
@@ -48,7 +61,7 @@ final class SileroVADModelProvisioner {
         let task = Task { @MainActor [modelManager] in
             let directory = try await modelManager.ensureModelDirectory(repo: repo)
             try Task.checkCancellation()
-            _ = try SileroVAD.fromModelDirectory(directory)
+            _ = try SileroVADModelSupport.loadModel(from: directory)
             return directory
         }
         inFlightTask = task

--- a/Voxt/Transcription/MLXTranscriber.swift
+++ b/Voxt/Transcription/MLXTranscriber.swift
@@ -3158,7 +3158,7 @@ class MLXTranscriber: ObservableObject, TranscriberProtocol {
 
         let modelDirectory = try await SileroVADModelProvisioner.shared.ensureModelDirectory()
         try Task.checkCancellation()
-        let loadedModel = try SileroVAD.fromModelDirectory(modelDirectory)
+        let loadedModel = try SileroVADModelSupport.loadModel(from: modelDirectory)
         senseVoiceVADModel = loadedModel
         return loadedModel
     }

--- a/Voxt/Transcription/Qwen3ASRMemoryEfficientLoader.swift
+++ b/Voxt/Transcription/Qwen3ASRMemoryEfficientLoader.swift
@@ -47,7 +47,9 @@ nonisolated enum Qwen3ASRMemoryEfficientLoader {
             parameters: ModuleParameters.unflattened(sanitizedWeights),
             verify: .all
         )
-        eval(model)
+        try withError {
+            eval(model)
+        }
         return model
     }
 


### PR DESCRIPTION
local crash when starting Transcription, SILeroVAD model load triggers fatalError.

crash stack:

```
Thread 6 Crashed:: Dispatch queue: com.apple.root.user-initiated-qos.cooperative
0   libswiftCore.dylib  _assertionFailure
1   Voxt                ErrorHandler.dispatch(_:)
2   Voxt                errorHandlerTrampoline
3   Voxt                _mlx_error
4   Voxt                mlx_eval
5   Voxt                eval(_:)
6   Voxt                SileroVAD.fromModelDirectory(_:)
7   Voxt                ASRSileroStreamingVoiceActivityDetector.loadModelIfAvailable()
```

root cause: `eval()` hits MLX error → `_mlx_error` → `ErrorHandler.dispatch` → no scoped handler → `fatalError`.

fix: wrap bare `eval()` with `withError { }` to throw instead of crash.

mlx-audio-swift (`SileroVAD.fromModelDirectory`) needs same fix — committed locally as `v0.1.3-voxt.13`.