### PR TITLE
会议详情虚拟列表、历史条数清理与完成通知

### DIFF
--- a/Voxt.xcodeproj/project.pbxproj
+++ b/Voxt.xcodeproj/project.pbxproj
@@ -1047,7 +1047,7 @@
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm.git";
 			requirement = {
 				kind = revision;
-				revision = "d2424294a6c3bbd0de37a0761d80efc05e6813dd";
+				revision = d2424294a6c3bbd0de37a0761d80efc05e6813dd;
 			};
 		};
 		E2A1C3B4D5F60718293A4B70 /* XCRemoteSwiftPackageReference "PermissionFlow" */ = {

--- a/Voxt/App/VoxtApp.swift
+++ b/Voxt/App/VoxtApp.swift
@@ -358,6 +358,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             AppPreferenceKey.historyEnabled: true,
             AppPreferenceKey.historyCleanupEnabled: true,
             AppPreferenceKey.historyRetentionPeriod: HistoryRetentionPeriod.ninetyDays.rawValue,
+            AppPreferenceKey.historyRetentionCount: HistoryRetentionCount.unlimited.rawValue,
             AppPreferenceKey.historyAudioStorageEnabled: false,
             AppPreferenceKey.dictionaryRecognitionEnabled: true,
             AppPreferenceKey.dictionaryAutoLearningEnabled: true,
@@ -511,6 +512,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             VoxtLog.info("Voxt launch entering LLM smoke mode.")
             return
         }
+
+        SystemNotificationSupport.configure()
 
         SileroVADModelProvisioner.prefetchIfNeeded(for: LocalVADMode.stored())
         RemoteModelConfigurationStore.migrateLegacyStoredSecrets()

--- a/Voxt/Core/History/TranscriptionHistoryStore.swift
+++ b/Voxt/Core/History/TranscriptionHistoryStore.swift
@@ -1061,6 +1061,11 @@ final class TranscriptionHistoryStore: ObservableObject {
         return HistoryRetentionPeriod(rawValue: raw ?? "") ?? .ninetyDays
     }
 
+    private var historyRetentionCount: HistoryRetentionCount {
+        let raw = defaults.string(forKey: AppPreferenceKey.historyRetentionCount)
+        return HistoryRetentionCount(rawValue: raw ?? "") ?? .unlimited
+    }
+
     private func applyReloadedEntries(
         _ decodedEntries: [TranscriptionHistoryEntry],
         resetPagination: Bool
@@ -1105,21 +1110,38 @@ final class TranscriptionHistoryStore: ObservableObject {
 
     private func cleanupRetainedEntriesIfNeeded(referenceDate: Date = Date()) {
         guard historyCleanupEnabled else { return }
-        guard let days = historyRetentionPeriod.days else { return }
 
-        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: referenceDate) ?? referenceDate
-        let removedEntries = (
-            try? repository.deleteEntries(
-                olderThan: cutoff,
-                kinds: retentionCleanupKinds
-            )
-        ) ?? []
+        var removedEntries: [TranscriptionHistoryEntry] = []
+
+        if let days = historyRetentionPeriod.days {
+            let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: referenceDate) ?? referenceDate
+            let removedByAge = (
+                try? repository.deleteEntries(
+                    olderThan: cutoff,
+                    kinds: retentionCleanupKinds
+                )
+            ) ?? []
+            removedEntries.append(contentsOf: removedByAge)
+        }
+
+        if let keepCount = historyRetentionCount.count {
+            for kind in retentionCleanupKinds.sorted(by: { $0.rawValue < $1.rawValue }) {
+                let removedByCount = (
+                    try? repository.deleteEntries(
+                        keepingNewest: keepCount,
+                        kind: kind
+                    )
+                ) ?? []
+                removedEntries.append(contentsOf: removedByCount)
+            }
+        }
+
         guard !removedEntries.isEmpty else { return }
         let interruptedReload = invalidatePendingLoads()
         removedEntries.forEach(audioArchive.removeArchive(for:))
         let removedIDs = Set(removedEntries.map(\.id))
         allEntries.removeAll { removedIDs.contains($0.id) }
-        totalEntryCount = max(0, totalEntryCount - removedEntries.count)
+        totalEntryCount = max(0, totalEntryCount - removedIDs.count)
         loadedCount = min(loadedCount, allEntries.count)
         refreshEntryIndexes()
         publishVisibleEntries()

--- a/Voxt/Core/HistoryRepository.swift
+++ b/Voxt/Core/HistoryRepository.swift
@@ -26,6 +26,10 @@ protocol HistoryRepositoryProtocol: AnyObject, Sendable {
         olderThan cutoff: Date,
         kinds: Set<TranscriptionHistoryKind>
     ) throws -> [TranscriptionHistoryEntry]
+    func deleteEntries(
+        keepingNewest count: Int,
+        kind: TranscriptionHistoryKind
+    ) throws -> [TranscriptionHistoryEntry]
 }
 
 final class HistoryRepository: HistoryRepositoryProtocol, @unchecked Sendable {
@@ -393,6 +397,25 @@ final class HistoryRepository: HistoryRepositoryProtocol, @unchecked Sendable {
         return try deleteEntries(
             whereSQL: "createdAt < ? AND kind IN (\(placeholders))",
             arguments: arguments
+        )
+    }
+
+    @discardableResult
+    func deleteEntries(
+        keepingNewest count: Int,
+        kind: TranscriptionHistoryKind
+    ) throws -> [TranscriptionHistoryEntry] {
+        guard count >= 0 else { return [] }
+        return try deleteEntries(
+            whereSQL: """
+                id IN (
+                    SELECT id FROM history_entries
+                    WHERE kind = ?
+                    ORDER BY createdAt DESC, id DESC
+                    LIMIT -1 OFFSET ?
+                )
+                """,
+            arguments: [kind.rawValue, count]
         )
     }
 

--- a/Voxt/Core/Models/CustomLLMModelManager.swift
+++ b/Voxt/Core/Models/CustomLLMModelManager.swift
@@ -978,6 +978,7 @@ class CustomLLMModelManager: ObservableObject {
         let canonicalRepo = Self.canonicalModelRepo(repo)
         if downloadTasksByRepo[canonicalRepo] != nil { return }
 
+        SystemNotificationSupport.requestAuthorizationIfNeeded()
         let task = Task { [weak self] in
             guard let self else { return }
             defer {
@@ -1014,11 +1015,19 @@ class CustomLLMModelManager: ObservableObject {
                 let modelDir = try await performDownloadWithFallback(for: canonicalRepo)
                 guard CustomLLMModelStorageSupport.isModelDirectoryValid(modelDir) else {
                     setPausedStatusMessage(nil, for: canonicalRepo)
-                    setState(.error("Downloaded files are incomplete."), for: canonicalRepo)
+                    let message = "Downloaded files are incomplete."
+                    setState(.error(message), for: canonicalRepo)
+                    SystemNotificationSupport.postModelDownloadFailed(
+                        modelName: displayTitle(for: canonicalRepo),
+                        message: message
+                    )
                     VoxtLog.modelError("Custom LLM download produced incomplete files: \(canonicalRepo)")
                     return
                 }
                 markDownloadCompleted(for: canonicalRepo)
+                SystemNotificationSupport.postModelDownloadSucceeded(
+                    modelName: displayTitle(for: canonicalRepo)
+                )
                 VoxtLog.modelInfo("Custom LLM download completed: \(canonicalRepo)")
             } catch is CancellationError {
                 cancelDownloadProgressTask(for: canonicalRepo)
@@ -1040,7 +1049,12 @@ class CustomLLMModelManager: ObservableObject {
                 }
                 setPausedStatusMessage(nil, for: canonicalRepo)
                 clearHubCache(for: canonicalRepo)
-                setState(.error("Download failed: \(error.localizedDescription)"), for: canonicalRepo)
+                let message = "Download failed: \(error.localizedDescription)"
+                setState(.error(message), for: canonicalRepo)
+                SystemNotificationSupport.postModelDownloadFailed(
+                    modelName: displayTitle(for: canonicalRepo),
+                    message: message
+                )
                 VoxtLog.modelError("Custom LLM download failed: \(canonicalRepo), error=\(error.localizedDescription)")
             }
         }

--- a/Voxt/Core/Models/GGUFTranslationModelManager.swift
+++ b/Voxt/Core/Models/GGUFTranslationModelManager.swift
@@ -155,6 +155,7 @@ final class GGUFTranslationModelManager: ObservableObject {
             return
         }
 
+        SystemNotificationSupport.requestAuthorizationIfNeeded()
         activeDownloadModelID = id
         pausedStatusMessageByID[id] = nil
 
@@ -196,6 +197,9 @@ final class GGUFTranslationModelManager: ObservableObject {
                 try await performDownload(id: id)
                 pausedStatusMessageByID[id] = nil
                 stateByID[id] = .downloaded
+                SystemNotificationSupport.postModelDownloadSucceeded(
+                    modelName: displayTitle(for: id)
+                )
             } catch is CancellationError {
                 cancelDownloadProgressTask()
                 switch downloadStopAction {
@@ -223,7 +227,12 @@ final class GGUFTranslationModelManager: ObservableObject {
                     return
                 }
                 pausedStatusMessageByID[id] = nil
-                stateByID[id] = .error("Download failed: \(error.localizedDescription)")
+                let message = "Download failed: \(error.localizedDescription)"
+                stateByID[id] = .error(message)
+                SystemNotificationSupport.postModelDownloadFailed(
+                    modelName: displayTitle(for: id),
+                    message: message
+                )
             }
         }
     }

--- a/Voxt/Core/TranscriptAssembly.swift
+++ b/Voxt/Core/TranscriptAssembly.swift
@@ -69,7 +69,8 @@ enum TranscriptAssembler {
                 speakerDisplayName: segment.speakerDisplayName ?? existing.speakerDisplayName,
                 audioSource: segment.audioSource ?? existing.audioSource,
                 speakerConfidence: segment.speakerConfidence ?? existing.speakerConfidence,
-                startSeconds: existing.startSeconds,
+                // Partials keep the original bubble start; finals may adopt model timing.
+                startSeconds: isFinal ? segment.startSeconds : existing.startSeconds,
                 endSeconds: segment.endSeconds,
                 text: segment.text,
                 translatedText: preservesTranslatedText ? existing.translatedText : nil,

--- a/Voxt/Core/Utilities/SystemNotificationSupport.swift
+++ b/Voxt/Core/Utilities/SystemNotificationSupport.swift
@@ -1,0 +1,80 @@
+// SystemNotificationSupport.swift
+// Posts macOS User Notifications for long-running background work.
+
+import Foundation
+import UserNotifications
+
+enum SystemNotificationSupport {
+    private static let center = UNUserNotificationCenter.current()
+    private static let presentationDelegate = PresentationDelegate()
+
+    static func configure() {
+        center.delegate = presentationDelegate
+    }
+
+    /// Warm up the permission prompt before a long task so completion posts are likelier
+    /// to already be authorized. `post` still waits for authorization when needed.
+    static func requestAuthorizationIfNeeded() {
+        center.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .notDetermined else { return }
+            center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        }
+    }
+
+    static func post(title: String, body: String, identifier: String = UUID().uuidString) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: nil
+        )
+        deliver(request)
+    }
+
+    static func postModelDownloadSucceeded(modelName: String) {
+        post(
+            title: AppLocalization.localizedString("Model download succeeded"),
+            body: AppLocalization.format("%@ downloaded successfully.", modelName)
+        )
+    }
+
+    static func postModelDownloadFailed(modelName: String, message: String) {
+        let detail = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = detail.isEmpty ? modelName : "\(modelName): \(detail)"
+        post(
+            title: AppLocalization.localizedString("Model download failed"),
+            body: body
+        )
+    }
+
+    private static func deliver(_ request: UNNotificationRequest) {
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                center.add(request)
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                    guard granted else { return }
+                    center.add(request)
+                }
+            case .denied:
+                return
+            @unknown default:
+                return
+            }
+        }
+    }
+
+    private final class PresentationDelegate: NSObject, UNUserNotificationCenterDelegate {
+        func userNotificationCenter(
+            _ center: UNUserNotificationCenter,
+            willPresent notification: UNNotification
+        ) async -> UNNotificationPresentationOptions {
+            [.banner, .sound]
+        }
+    }
+}

--- a/Voxt/Meeting/MeetingLiveSessionSupport.swift
+++ b/Voxt/Meeting/MeetingLiveSessionSupport.swift
@@ -76,7 +76,8 @@ nonisolated enum MeetingNativeLiveStructuredFinalization {
         modelFamily: MLXModelFamily,
         timelineOffsetSeconds: TimeInterval,
         speaker: MeetingSpeaker,
-        audioSource: TranscriptAudioSource
+        audioSource: TranscriptAudioSource,
+        replacingSegmentID: UUID? = nil
     ) -> [MeetingTranscriptSegment] {
         let structured = MLXTranscriber.structuredSegmentsForLiveEnded(
             output: STTOutput(text: "", segments: rawSegments),
@@ -85,15 +86,23 @@ nonisolated enum MeetingNativeLiveStructuredFinalization {
         )
         guard !structured.isEmpty else { return [] }
 
-        return structured.enumerated().compactMap { _, segment in
+        var didAssignReplacementID = false
+        return structured.compactMap { segment in
             let text = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
             let start = timelineOffsetSeconds + max(0, segment.startSeconds)
             let end = timelineOffsetSeconds + max(segment.endSeconds, segment.startSeconds)
             let allowMossSpeaker = modelFamily == .mossTranscribeDiarize
             let speakerID = allowMossSpeaker ? segment.speakerID.map { "moss:\($0)" } : nil
+            let id: UUID
+            if !didAssignReplacementID, let replacingSegmentID {
+                id = replacingSegmentID
+                didAssignReplacementID = true
+            } else {
+                id = UUID()
+            }
             return MeetingTranscriptSegment(
-                id: UUID(),
+                id: id,
                 speaker: speaker,
                 speakerID: speakerID,
                 audioSource: audioSource,

--- a/Voxt/Meeting/MeetingMLXNativeLiveSession.swift
+++ b/Voxt/Meeting/MeetingMLXNativeLiveSession.swift
@@ -365,7 +365,10 @@ private final class MeetingMLXNativeLiveSession: MeetingLiveTranscribingSession 
             modelFamily: capability.family,
             timelineOffsetSeconds: timelineOffsetSeconds,
             speaker: speaker,
-            audioSource: speaker == .me ? .microphone : .systemAudio
+            audioSource: speaker == .me ? .microphone : .systemAudio,
+            // Reuse the in-flight partial ID so overlay upsert replaces it instead of
+            // appending a duplicate bubble with a fresh UUID.
+            replacingSegmentID: currentSegmentID
         )
         guard !structured.isEmpty else { return false }
 

--- a/Voxt/Meeting/Processing/MeetingImportedAudioFile.swift
+++ b/Voxt/Meeting/Processing/MeetingImportedAudioFile.swift
@@ -4,6 +4,61 @@
 import AVFoundation
 import CoreMedia
 import Foundation
+import UniformTypeIdentifiers
+
+enum MeetingFileImportSupport {
+    static let allowedContentTypes: [UTType] = [.audio, .movie]
+
+    static func isSupportedImportFile(at url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey, .contentTypeKey])
+        if values?.isDirectory == true {
+            return false
+        }
+        if let isRegularFile = values?.isRegularFile, !isRegularFile {
+            return false
+        }
+
+        if let contentType = values?.contentType {
+            return conformsToAllowedTypes(contentType)
+        }
+
+        let ext = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !ext.isEmpty, let inferred = UTType(filenameExtension: ext) else {
+            return false
+        }
+        return conformsToAllowedTypes(inferred)
+    }
+
+    /// Preserves the system-provided URL object. Do not standardize or rebuild from a
+    /// path string before `startAccessingSecurityScopedResource()` — that strips the
+    /// sandbox security scope carried by Finder / NSItemProvider drop URLs.
+    static func fileURL(fromDropItem item: Any?) -> URL? {
+        if let url = item as? URL {
+            return url
+        }
+        if let data = item as? Data {
+            return URL(dataRepresentation: data, relativeTo: nil)
+        }
+        if let path = item as? String {
+            return fileURL(fromPath: path)
+        }
+        if let path = item as? NSString {
+            return fileURL(fromPath: path as String)
+        }
+        return nil
+    }
+
+    private static func fileURL(fromPath path: String) -> URL? {
+        if path.hasPrefix("file:") {
+            return URL(string: path)
+        }
+        return URL(fileURLWithPath: path)
+    }
+
+    private static func conformsToAllowedTypes(_ type: UTType) -> Bool {
+        allowedContentTypes.contains { type.conforms(to: $0) }
+    }
+}
 
 enum MeetingFileAnalysisStage: Equatable, Sendable {
     case preparing

--- a/Voxt/Meeting/SpeakerAnalysis/MeetingDiarizationModelManager.swift
+++ b/Voxt/Meeting/SpeakerAnalysis/MeetingDiarizationModelManager.swift
@@ -65,6 +65,7 @@ final class MeetingDiarizationModelManager: ObservableObject {
         selectedMode = mode
         remoteSizeText = mode.fallbackRemoteSizeText
         state = .downloading(progress: 0, detail: nil)
+        SystemNotificationSupport.requestAuthorizationIfNeeded()
         downloadTask = Task { [weak self] in
             guard let self else { return }
             defer { self.downloadTask = nil }
@@ -77,11 +78,16 @@ final class MeetingDiarizationModelManager: ObservableObject {
                     _ = try await self.downloadSortformerWithFallback()
                 }
                 self.state = .downloaded
+                SystemNotificationSupport.postModelDownloadSucceeded(modelName: mode.title)
                 VoxtLog.meeting("Meeting diarization model ready. mode=\(mode.rawValue)")
             } catch is CancellationError {
                 self.state = .notDownloaded
             } catch {
                 self.state = .error(error.localizedDescription)
+                SystemNotificationSupport.postModelDownloadFailed(
+                    modelName: mode.title,
+                    message: error.localizedDescription
+                )
                 VoxtLog.meetingError("Meeting diarization model install failed. mode=\(mode.rawValue), error=\(error.localizedDescription)")
             }
         }

--- a/Voxt/Settings/Features/FeatureMeetingSections.swift
+++ b/Voxt/Settings/Features/FeatureMeetingSections.swift
@@ -76,7 +76,8 @@ extension FeatureSettingsView {
             MeetingFileUploadCard(
                 state: meetingFileUploadState,
                 onChooseFile: chooseMeetingFileForAnalysis,
-                onCancel: cancelMeetingFileAnalysis
+                onCancel: cancelMeetingFileAnalysis,
+                onImportDroppedFile: importDroppedMeetingFileForAnalysis
             )
         }
     }
@@ -87,13 +88,54 @@ extension FeatureSettingsView {
         panel.title = featureSettingsLocalized("Analyze Meeting File")
         panel.prompt = featureSettingsLocalized("Choose File")
         panel.message = featureSettingsLocalized("Choose an audio or video recording to transcribe and analyze.")
-        panel.allowedContentTypes = [.audio, .movie]
+        panel.allowedContentTypes = MeetingFileImportSupport.allowedContentTypes
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
 
         guard panel.runModal() == .OK, let fileURL = panel.url else { return }
         startMeetingFileAnalysis(fileURL)
+    }
+
+    func importDroppedMeetingFileForAnalysis(_ fileURL: URL?) {
+        guard let fileURL else {
+            showMeetingFileImportToast(
+                featureSettingsLocalized("Unsupported file type. Drop an audio or video recording instead.")
+            )
+            return
+        }
+
+        guard !meetingFileUploadState.isBusy else {
+            showMeetingFileImportToast(
+                featureSettingsLocalized("Meeting file analysis is already in progress.")
+            )
+            return
+        }
+
+        // Access the scoped drop URL before UTI/resource checks so sandboxed reads succeed.
+        let didAccessSecurityScopedResource = fileURL.startAccessingSecurityScopedResource()
+        defer {
+            if didAccessSecurityScopedResource {
+                fileURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        guard MeetingFileImportSupport.isSupportedImportFile(at: fileURL) else {
+            showMeetingFileImportToast(
+                featureSettingsLocalized("Unsupported file type. Drop an audio or video recording instead.")
+            )
+            return
+        }
+
+        startMeetingFileAnalysis(fileURL)
+    }
+
+    func showMeetingFileImportToast(_ message: String) {
+        NotificationCenter.default.post(
+            name: .voxtFeatureSettingsToastRequested,
+            object: nil,
+            userInfo: ["message": message]
+        )
     }
 
     func startMeetingFileAnalysis(_ fileURL: URL) {
@@ -103,13 +145,16 @@ extension FeatureSettingsView {
             fileName: fileName,
             progress: MeetingFileAnalysisProgress(stage: .preparing)
         )
+        SystemNotificationSupport.requestAuthorizationIfNeeded()
         meetingFileAnalysisTask = Task { @MainActor in
             defer { meetingFileAnalysisTask = nil }
             guard let appDelegate = AppDelegate.shared else {
+                let message = featureSettingsLocalized("Voxt is not ready to analyze this file yet.")
                 meetingFileUploadState = .failed(
                     fileName: fileName,
-                    message: featureSettingsLocalized("Voxt is not ready to analyze this file yet.")
+                    message: message
                 )
+                postMeetingFileConversionFailureNotification(fileName: fileName, message: message)
                 return
             }
 
@@ -129,6 +174,7 @@ extension FeatureSettingsView {
                     return
                 }
                 meetingFileUploadState = .completed(fileName: fileName)
+                postMeetingFileConversionSuccessNotification(fileName: fileName)
                 appDelegate.showMeetingDetailWindow(for: entry)
             } catch is CancellationError {
                 meetingFileUploadState = .idle
@@ -137,8 +183,28 @@ extension FeatureSettingsView {
                     fileName: fileName,
                     message: error.localizedDescription
                 )
+                postMeetingFileConversionFailureNotification(
+                    fileName: fileName,
+                    message: error.localizedDescription
+                )
             }
         }
+    }
+
+    func postMeetingFileConversionSuccessNotification(fileName: String) {
+        SystemNotificationSupport.post(
+            title: featureSettingsLocalized("File conversion succeeded"),
+            body: AppLocalization.format("%@ has been converted successfully.", fileName)
+        )
+    }
+
+    func postMeetingFileConversionFailureNotification(fileName: String, message: String) {
+        let detail = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = detail.isEmpty ? fileName : "\(fileName): \(detail)"
+        SystemNotificationSupport.post(
+            title: featureSettingsLocalized("File conversion failed"),
+            body: body
+        )
     }
 
     func cancelMeetingFileAnalysis() {
@@ -317,6 +383,9 @@ private struct MeetingFileUploadCard: View {
     let state: MeetingFileUploadState
     let onChooseFile: () -> Void
     let onCancel: () -> Void
+    let onImportDroppedFile: (URL?) -> Void
+
+    @State private var isDropTargeted = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -354,6 +423,9 @@ private struct MeetingFileUploadCard: View {
         }
         .padding(16)
         .settingsPanelSurface()
+        .onDrop(of: [UTType.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers)
+        }
     }
 
     @ViewBuilder
@@ -361,10 +433,16 @@ private struct MeetingFileUploadCard: View {
         VStack(spacing: 9) {
             switch state {
             case .idle:
-                Image(systemName: "arrow.up.doc")
+                Image(systemName: isDropTargeted ? "arrow.down.doc" : "arrow.up.doc")
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(Color.accentColor)
-                Text(featureSettingsLocalized("Click to choose a meeting recording"))
+                Text(
+                    featureSettingsLocalized(
+                        isDropTargeted
+                            ? "Drop to analyze this recording"
+                            : "Click to choose or drag in a meeting recording"
+                    )
+                )
                     .font(.subheadline.weight(.medium))
                 supportedFormats
             case let .analyzing(fileName, progress):
@@ -437,16 +515,23 @@ private struct MeetingFileUploadCard: View {
         .padding(.vertical, 12)
         .background(
             RoundedRectangle(cornerRadius: SettingsUIStyle.compactCornerRadius, style: .continuous)
-                .fill(SettingsUIStyle.groupedFillColor.opacity(0.55))
+                .fill(
+                    isDropTargeted
+                        ? Color.accentColor.opacity(0.08)
+                        : SettingsUIStyle.groupedFillColor.opacity(0.55)
+                )
         )
         .overlay(
             RoundedRectangle(cornerRadius: SettingsUIStyle.compactCornerRadius, style: .continuous)
                 .stroke(
-                    state.isAnalyzing ? Color.accentColor.opacity(0.42) : SettingsUIStyle.controlHoverBorderColor,
-                    style: StrokeStyle(lineWidth: 1, dash: [6, 5])
+                    (state.isAnalyzing || isDropTargeted)
+                        ? Color.accentColor.opacity(isDropTargeted ? 0.72 : 0.42)
+                        : SettingsUIStyle.controlHoverBorderColor,
+                    style: StrokeStyle(lineWidth: isDropTargeted ? 1.5 : 1, dash: [6, 5])
                 )
         )
         .contentShape(RoundedRectangle(cornerRadius: SettingsUIStyle.compactCornerRadius, style: .continuous))
+        .animation(.easeOut(duration: 0.12), value: isDropTargeted)
     }
 
     private var supportedFormats: some View {
@@ -455,6 +540,22 @@ private struct MeetingFileUploadCard: View {
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
             .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+        guard let provider = providers.first(where: {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }) else {
+            return false
+        }
+
+        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+            let fileURL = MeetingFileImportSupport.fileURL(fromDropItem: item)
+            Task { @MainActor in
+                onImportDroppedFile(fileURL)
+            }
+        }
+        return true
     }
 }
 

--- a/Voxt/Settings/History/HistoryAudioSettingsSheet.swift
+++ b/Voxt/Settings/History/HistoryAudioSettingsSheet.swift
@@ -10,6 +10,7 @@ private func localizedHistoryAudioSettings(_ key: String) -> String {
 struct HistoryAudioSettingsSheet: View {
     @Binding var historyCleanupEnabled: Bool
     @Binding var historyRetentionPeriodRaw: String
+    @Binding var historyRetentionCountRaw: String
     @Binding var historyAudioStorageEnabled: Bool
     @Binding var historyAudioStorageDisplayPath: String
     @Binding var historyAudioStorageSelectionError: String?
@@ -17,6 +18,7 @@ struct HistoryAudioSettingsSheet: View {
     @Binding var isPresented: Bool
 
     let historyRetentionPeriod: HistoryRetentionPeriod
+    let historyRetentionCount: HistoryRetentionCount
     let historyAudioStorageStatsSummary: String
     let onOpenHistoryAudioStorageInFinder: () -> Void
     let onChooseHistoryAudioStorageDirectory: () -> Void
@@ -44,6 +46,20 @@ struct HistoryAudioSettingsSheet: View {
                                 SettingsMenuOption(value: option.rawValue, title: option.title)
                             },
                             selectedTitle: historyRetentionPeriod.title,
+                            width: 160
+                        )
+                    }
+
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(localizedHistoryAudioSettings("Retention Count"))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        SettingsMenuPicker(
+                            selection: $historyRetentionCountRaw,
+                            options: HistoryRetentionCount.allCases.map { option in
+                                SettingsMenuOption(value: option.rawValue, title: option.title)
+                            },
+                            selectedTitle: historyRetentionCount.title,
                             width: 160
                         )
                     }

--- a/Voxt/Settings/History/HistorySettingsView.swift
+++ b/Voxt/Settings/History/HistorySettingsView.swift
@@ -40,6 +40,7 @@ struct HistorySettingsView: View {
     @Environment(\.locale) private var locale
     @AppStorage(AppPreferenceKey.historyCleanupEnabled) private var historyCleanupEnabled = true
     @AppStorage(AppPreferenceKey.historyRetentionPeriod) private var historyRetentionPeriodRaw = HistoryRetentionPeriod.ninetyDays.rawValue
+    @AppStorage(AppPreferenceKey.historyRetentionCount) private var historyRetentionCountRaw = HistoryRetentionCount.unlimited.rawValue
     @AppStorage(AppPreferenceKey.historyAudioStorageEnabled) private var historyAudioStorageEnabled = false
 
     @ObservedObject var historyStore: TranscriptionHistoryStore
@@ -83,6 +84,10 @@ struct HistorySettingsView: View {
 
     private var historyRetentionPeriod: HistoryRetentionPeriod {
         HistoryRetentionPeriod(rawValue: historyRetentionPeriodRaw) ?? .ninetyDays
+    }
+
+    private var historyRetentionCount: HistoryRetentionCount {
+        HistoryRetentionCount(rawValue: historyRetentionCountRaw) ?? .unlimited
     }
 
     private var allNotes: [VoxtNoteItem] {
@@ -292,12 +297,14 @@ struct HistorySettingsView: View {
             HistoryAudioSettingsSheet(
                 historyCleanupEnabled: $historyCleanupEnabled,
                 historyRetentionPeriodRaw: $historyRetentionPeriodRaw,
+                historyRetentionCountRaw: $historyRetentionCountRaw,
                 historyAudioStorageEnabled: $historyAudioStorageEnabled,
                 historyAudioStorageDisplayPath: $historyAudioStorageDisplayPath,
                 historyAudioStorageSelectionError: $historyAudioStorageSelectionError,
                 historyAudioExportResultMessage: $historyAudioExportResultMessage,
                 isPresented: $isHistoryAudioSettingsPresented,
                 historyRetentionPeriod: historyRetentionPeriod,
+                historyRetentionCount: historyRetentionCount,
                 historyAudioStorageStatsSummary: historyAudioStorageStatsSummary,
                 onOpenHistoryAudioStorageInFinder: openHistoryAudioStorageInFinder,
                 onChooseHistoryAudioStorageDirectory: chooseHistoryAudioStorageDirectory,
@@ -339,6 +346,9 @@ struct HistorySettingsView: View {
             if !HistoryRetentionPeriod.allCases.contains(where: { $0.rawValue == historyRetentionPeriodRaw }) {
                 historyRetentionPeriodRaw = HistoryRetentionPeriod.ninetyDays.rawValue
             }
+            if !HistoryRetentionCount.allCases.contains(where: { $0.rawValue == historyRetentionCountRaw }) {
+                historyRetentionCountRaw = HistoryRetentionCount.unlimited.rawValue
+            }
             refreshHistoryAudioStorageDisplayPath()
             refreshHistoryAudioStorageStats()
             reloadHistoryEntries(reset: true)
@@ -365,6 +375,12 @@ struct HistorySettingsView: View {
         .onChange(of: historyRetentionPeriodRaw) { _, newValue in
             if !HistoryRetentionPeriod.allCases.contains(where: { $0.rawValue == newValue }) {
                 historyRetentionPeriodRaw = HistoryRetentionPeriod.ninetyDays.rawValue
+            }
+            applyRetentionPolicyAndReload()
+        }
+        .onChange(of: historyRetentionCountRaw) { _, newValue in
+            if !HistoryRetentionCount.allCases.contains(where: { $0.rawValue == newValue }) {
+                historyRetentionCountRaw = HistoryRetentionCount.unlimited.rawValue
             }
             applyRetentionPolicyAndReload()
         }

--- a/Voxt/Settings/Shell/AppPreferenceKey.swift
+++ b/Voxt/Settings/Shell/AppPreferenceKey.swift
@@ -126,6 +126,7 @@ enum AppPreferenceKey {
     static let historyEnabled = "historyEnabled"
     static let historyCleanupEnabled = "historyCleanupEnabled"
     static let historyRetentionPeriod = "historyRetentionPeriod"
+    static let historyRetentionCount = "historyRetentionCount"
     static let historyAudioStorageEnabled = "historyAudioStorageEnabled"
     static let historyAudioStorageRootPath = "historyAudioStorageRootPath"
     static let historyAudioStorageRootBookmark = "historyAudioStorageRootBookmark"

--- a/Voxt/Settings/Shell/SettingsTypes.swift
+++ b/Voxt/Settings/Shell/SettingsTypes.swift
@@ -489,6 +489,62 @@ enum HistoryRetentionPeriod: String, Identifiable {
     }
 }
 
+enum HistoryRetentionCount: String, Identifiable {
+    case unlimited
+    case fifty
+    case oneHundred
+    case threeHundred
+    case fiveHundred
+    case oneThousand
+
+    static var allCases: [HistoryRetentionCount] {
+        [
+            .unlimited,
+            .fifty,
+            .oneHundred,
+            .threeHundred,
+            .fiveHundred,
+            .oneThousand
+        ]
+    }
+
+    var id: String { rawValue }
+
+    var count: Int? {
+        switch self {
+        case .unlimited:
+            return nil
+        case .fifty:
+            return 50
+        case .oneHundred:
+            return 100
+        case .threeHundred:
+            return 300
+        case .fiveHundred:
+            return 500
+        case .oneThousand:
+            return 1000
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .unlimited:
+            return AppLocalization.localizedString("Unlimited")
+        case .fifty:
+            return "50"
+        case .oneHundred:
+            return "100"
+        case .threeHundred:
+            return "300"
+        case .fiveHundred:
+            return "500"
+        case .oneThousand:
+            return "1000"
+        }
+    }
+}
+
 enum InteractionSoundPreset: String, CaseIterable, Identifiable, Codable, Sendable {
     case soft
     case glass

--- a/Voxt/Transcription/MLXModelManager.swift
+++ b/Voxt/Transcription/MLXModelManager.swift
@@ -698,6 +698,7 @@ class MLXModelManager: ObservableObject {
         if downloadTasksByRepo[canonicalRepo] != nil { return }
         if case .loading = state(for: canonicalRepo) { return }
 
+        SystemNotificationSupport.requestAuthorizationIfNeeded()
         resumableDownloadStateByRepo.removeValue(forKey: canonicalRepo)
         let task = Task { [weak self] in
             guard let self else { return }
@@ -740,6 +741,9 @@ class MLXModelManager: ObservableObject {
                     fileManager: .default
                 )
                 markDownloadCompleted(for: canonicalRepo)
+                SystemNotificationSupport.postModelDownloadSucceeded(
+                    modelName: displayTitle(for: canonicalRepo)
+                )
                 VoxtLog.modelInfo("Download complete. repo=\(canonicalRepo)")
             } catch is CancellationError {
                 switch downloadStopActionsByRepo[canonicalRepo] {
@@ -759,7 +763,12 @@ class MLXModelManager: ObservableObject {
                 }
                 setPausedStatusMessage(nil, for: canonicalRepo)
                 clearHubCache(for: canonicalRepo)
-                setState(.error(downloadErrorMessage(for: error, repo: canonicalRepo)), for: canonicalRepo)
+                let message = downloadErrorMessage(for: error, repo: canonicalRepo)
+                setState(.error(message), for: canonicalRepo)
+                SystemNotificationSupport.postModelDownloadFailed(
+                    modelName: displayTitle(for: canonicalRepo),
+                    message: message
+                )
                 VoxtLog.modelError("Download error. repo=\(canonicalRepo), error=\(error.localizedDescription)")
             }
         }

--- a/Voxt/Transcription/SherpaOnnxModelManager.swift
+++ b/Voxt/Transcription/SherpaOnnxModelManager.swift
@@ -160,6 +160,7 @@ final class SherpaOnnxModelManager: ObservableObject {
             return
         }
 
+        SystemNotificationSupport.requestAuthorizationIfNeeded()
         let option = option(for: id)
         setPausedStatusMessage(nil, for: id)
         setDownloadingState(
@@ -185,6 +186,9 @@ final class SherpaOnnxModelManager: ObservableObject {
                 try await performDownload(id: id)
                 cancelDownloadProgressTask(for: id)
                 markModelDownloaded(id: id)
+                SystemNotificationSupport.postModelDownloadSucceeded(
+                    modelName: displayTitle(for: id)
+                )
             } catch is CancellationError {
                 cancelDownloadProgressTask(for: id)
                 switch downloadStopActionsByID[id] {
@@ -200,7 +204,12 @@ final class SherpaOnnxModelManager: ObservableObject {
                 cleanupDownload(id: id)
                 downloadedStateByID[id] = false
                 setPausedStatusMessage(nil, for: id)
-                setState(.error("Download failed: \(error.localizedDescription)"), for: id)
+                let message = "Download failed: \(error.localizedDescription)"
+                setState(.error(message), for: id)
+                SystemNotificationSupport.postModelDownloadFailed(
+                    modelName: displayTitle(for: id),
+                    message: message
+                )
             }
         }
         downloadTasksByID[id] = task

--- a/Voxt/Windows/MeetingDetail/MeetingDetailSegmentRow.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingDetailSegmentRow.swift
@@ -1,0 +1,176 @@
+// MeetingDetailSegmentRow.swift
+// Segment and speaker-header rows for meeting detail transcript lists.
+
+import SwiftUI
+
+struct MeetingDetailSegmentRow: View, Equatable {
+    let segment: MeetingTranscriptSegment
+    let speakerTitle: String
+    let isActive: Bool
+    let showsTranslation: Bool
+    let isSearchMatch: Bool
+
+    @State private var isHovered = false
+    @State private var didCopy = false
+    @State private var copyFeedbackToken = UUID()
+
+    static func == (lhs: MeetingDetailSegmentRow, rhs: MeetingDetailSegmentRow) -> Bool {
+        lhs.segment == rhs.segment
+            && lhs.speakerTitle == rhs.speakerTitle
+            && lhs.isActive == rhs.isActive
+            && lhs.showsTranslation == rhs.showsTranslation
+            && lhs.isSearchMatch == rhs.isSearchMatch
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 8) {
+                Text(MeetingTranscriptFormatter.timestampString(for: segment.startSeconds))
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.secondary)
+
+                Text(speakerTitle)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(
+                        segment.speaker == .me
+                            ? Color(red: 0.16, green: 0.47, blue: 0.88)
+                            : Color(red: 0.12, green: 0.58, blue: 0.32)
+                    )
+
+                Spacer(minLength: 8)
+            }
+
+            Text(segment.text)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.primary.opacity(0.94))
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+
+            if showsTranslation,
+               let translatedText = segment.translatedText?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !translatedText.isEmpty {
+                Text(translatedText)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            } else if showsTranslation, segment.isTranslationPending {
+                Text(AppLocalization.localizedString("Translating…"))
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary.opacity(0.75))
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(backgroundColor)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(borderColor, lineWidth: 1)
+        )
+        .overlay(alignment: .topTrailing) {
+            if isHovered || didCopy {
+                Button(action: copySegmentText) {
+                    Group {
+                        if didCopy {
+                            CopySuccessIconView(color: Color.accentColor)
+                        } else {
+                            CopyIconView(color: .secondary)
+                        }
+                    }
+                    .frame(width: 13, height: 13)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        Circle()
+                            .fill(Color.primary.opacity(isHovered ? 0.08 : 0.05))
+                    )
+                    .overlay(
+                        Circle()
+                            .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .help(AppLocalization.localizedString("Copy"))
+                .accessibilityLabel(AppLocalization.localizedString("Copy"))
+                .padding(.top, 10)
+                .padding(.trailing, 10)
+                .transition(.opacity.combined(with: .scale(scale: 0.94, anchor: .topTrailing)))
+            }
+        }
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.12)) {
+                isHovered = hovering
+            }
+        }
+    }
+
+    private func copySegmentText() {
+        let trimmed = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        copyStringToPasteboard(trimmed)
+        copyFeedbackToken = UUID()
+        let token = copyFeedbackToken
+        didCopy = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            guard token == copyFeedbackToken else { return }
+            withAnimation(.easeOut(duration: 0.12)) {
+                didCopy = false
+            }
+        }
+    }
+
+    private var backgroundColor: Color {
+        if isActive {
+            return speakerAccentColor.opacity(0.16)
+        }
+        if isSearchMatch {
+            return Color.orange.opacity(0.12)
+        }
+        return speakerAccentColor.opacity(0.06)
+    }
+
+    private var borderColor: Color {
+        if isActive {
+            return speakerAccentColor.opacity(0.32)
+        }
+        if isSearchMatch {
+            return Color.orange.opacity(0.28)
+        }
+        return speakerAccentColor.opacity(0.16)
+    }
+
+    private var speakerAccentColor: Color {
+        segment.speaker == .me
+            ? Color(red: 0.16, green: 0.47, blue: 0.88)
+            : Color(red: 0.12, green: 0.58, blue: 0.32)
+    }
+}
+
+struct MeetingDetailSpeakerHeaderRow: View, Equatable {
+    let title: String
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+
+            Text(AppLocalization.format("%d", count))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(MeetingDetailUIStyle.mutedFillColor)
+                )
+
+            Spacer(minLength: 0)
+        }
+        .padding(.top, 4)
+    }
+}

--- a/Voxt/Windows/MeetingDetail/MeetingDetailSummaryViews.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingDetailSummaryViews.swift
@@ -87,25 +87,35 @@ struct MeetingDetailSummarySidebar: View {
                                     Text(summary.title)
                                         .font(.system(size: 16, weight: .semibold))
                                         .foregroundStyle(.primary)
+                                        .textSelection(.enabled)
 
                                     Text(summary.generatedAt.formatted(date: .abbreviated, time: .shortened))
                                         .font(.system(size: 11, weight: .medium))
                                         .foregroundStyle(.secondary)
+                                        .textSelection(.enabled)
                                 }
 
                                 if !summary.body.isEmpty {
                                     VStack(alignment: .leading, spacing: 10) {
-                                        Text(AppLocalization.localizedString("Summary"))
-                                            .font(.system(size: 12, weight: .semibold))
-                                            .foregroundStyle(.secondary)
+                                        HStack(spacing: 8) {
+                                            Text(AppLocalization.localizedString("Summary"))
+                                                .font(.system(size: 12, weight: .semibold))
+                                                .foregroundStyle(.secondary)
+
+                                            Spacer(minLength: 8)
+
+                                            MeetingDetailCopyButton(text: summary.body)
+                                        }
 
                                         ForEach(MeetingDetailFormatting.summaryParagraphs(summary.body), id: \.self) { paragraph in
                                             Text(paragraph)
                                                 .font(.system(size: 13, weight: .medium))
                                                 .foregroundStyle(.primary.opacity(0.92))
                                                 .frame(maxWidth: .infinity, alignment: .leading)
+                                                .textSelection(.enabled)
                                         }
                                     }
+                                    .textSelection(.enabled)
                                 }
 
                                 if !summary.todoItems.isEmpty {
@@ -129,9 +139,11 @@ struct MeetingDetailSummarySidebar: View {
                                                     .font(.system(size: 13, weight: .medium))
                                                     .foregroundStyle(.primary.opacity(0.92))
                                                     .frame(maxWidth: .infinity, alignment: .leading)
+                                                    .textSelection(.enabled)
                                             }
                                         }
                                     }
+                                    .textSelection(.enabled)
                                 }
 
                                 if !viewModel.summaryChatMessages.isEmpty || viewModel.isSummaryChatLoading || viewModel.summaryChatErrorMessage != nil {
@@ -179,6 +191,7 @@ struct MeetingDetailSummarySidebar: View {
                             .id(summaryBottomAnchorID)
                         }
                         .padding(16)
+                        .textSelection(.enabled)
                     }
                     .coordinateSpace(name: "MeetingSummaryScroll")
                     .onPreferenceChange(MeetingSummaryBottomVisibilityPreferenceKey.self) { isVisible in
@@ -611,6 +624,12 @@ private enum MeetingSummaryModelSelectorAdapter {
 struct SummaryChatMessageRow: View {
     let message: MeetingSummaryChatMessage
 
+    @State private var isHovered = false
+
+    private var isAssistantMessage: Bool {
+        message.role == .assistant
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(message.role == .user ? AppLocalization.localizedString("You") : AppLocalization.localizedString("Assistant"))
@@ -621,6 +640,7 @@ struct SummaryChatMessageRow: View {
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.primary.opacity(0.94))
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
         }
         .padding(12)
         .background(
@@ -634,5 +654,109 @@ struct SummaryChatMessageRow: View {
                     lineWidth: 1
                 )
         )
+        .overlay(alignment: .topTrailing) {
+            if isAssistantMessage && isHovered {
+                MeetingDetailHoverCopyCapsule(text: message.content)
+                    .padding(.top, 8)
+                    .padding(.trailing, 8)
+                    .transition(.opacity.combined(with: .scale(scale: 0.94, anchor: .topTrailing)))
+            }
+        }
+        .onHover { hovering in
+            guard isAssistantMessage else { return }
+            withAnimation(.easeOut(duration: 0.12)) {
+                isHovered = hovering
+            }
+        }
+    }
+}
+
+private struct MeetingDetailCopyButton: View {
+    let text: String
+
+    @State private var didCopy = false
+    @State private var copyFeedbackToken = UUID()
+
+    var body: some View {
+        Button(action: copyToPasteboard) {
+            Group {
+                if didCopy {
+                    CopySuccessIconView(color: Color.accentColor)
+                } else {
+                    CopyIconView(color: .secondary)
+                }
+            }
+            .frame(width: 13, height: 13)
+            .frame(width: 22, height: 22)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(AppLocalization.localizedString("Copy"))
+        .accessibilityLabel(AppLocalization.localizedString("Copy"))
+    }
+
+    private func copyToPasteboard() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        copyStringToPasteboard(trimmed)
+        copyFeedbackToken = UUID()
+        let token = copyFeedbackToken
+        didCopy = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            guard token == copyFeedbackToken else { return }
+            didCopy = false
+        }
+    }
+}
+
+private struct MeetingDetailHoverCopyCapsule: View {
+    let text: String
+
+    @State private var didCopy = false
+    @State private var copyFeedbackToken = UUID()
+
+    var body: some View {
+        Button(action: copyToPasteboard) {
+            HStack(spacing: 4) {
+                Group {
+                    if didCopy {
+                        CopySuccessIconView()
+                    } else {
+                        CopyIconView()
+                    }
+                }
+                .frame(width: 12, height: 12)
+
+                Text(didCopy ? AppLocalization.localizedString("Copied") : AppLocalization.localizedString("Copy"))
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .foregroundStyle(.white.opacity(0.96))
+            .padding(.horizontal, 8)
+            .frame(height: 22)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(.black.opacity(0.74))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help(AppLocalization.localizedString("Copy"))
+        .accessibilityLabel(AppLocalization.localizedString("Copy"))
+    }
+
+    private func copyToPasteboard() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        copyStringToPasteboard(trimmed)
+        copyFeedbackToken = UUID()
+        let token = copyFeedbackToken
+        didCopy = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            guard token == copyFeedbackToken else { return }
+            didCopy = false
+        }
     }
 }

--- a/Voxt/Windows/MeetingDetail/MeetingDetailViewModel.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingDetailViewModel.swift
@@ -39,6 +39,8 @@ final class MeetingDetailViewModel: ObservableObject {
     @Published private(set) var subtitle: String
     @Published private(set) var segments: [MeetingTranscriptSegment]
     @Published private(set) var segmentStructureRevision = 0
+    @Published private(set) var displayedSegments: [MeetingTranscriptSegment] = []
+    @Published private(set) var speakerGroups: [MeetingDetailSpeakerGroup] = []
     @Published private(set) var isPaused = false
     @Published private(set) var isFinalizing = false
     @Published var translationEnabled: Bool
@@ -58,8 +60,10 @@ final class MeetingDetailViewModel: ObservableObject {
     @Published var transcriptPresentationModeRaw = TranscriptPresentationMode.timeline.rawValue
     @Published var transcriptSpeakerDisplayModeRaw = TranscriptSpeakerDisplayMode.source.rawValue
     @Published var isSearchPresented = false
-    @Published var searchQuery = ""
+    @Published private(set) var searchQuery = ""
     @Published var isSummaryCollapsed = false
+
+    private var speakerOrdinalByIdentityKey: [String: Int] = [:]
 
     let mode: Mode
     let audioURL: URL?
@@ -147,6 +151,7 @@ final class MeetingDetailViewModel: ObservableObject {
             summaryState = .idle
         }
         bindInterfaceLanguageChanges()
+        refreshTranscriptListCaches()
     }
 
     init(
@@ -213,6 +218,7 @@ final class MeetingDetailViewModel: ObservableObject {
             .store(in: &cancellables)
 
         bindInterfaceLanguageChanges()
+        refreshTranscriptListCaches()
 
         liveState.$realtimeTranslateEnabled
             .receive(on: RunLoop.main)
@@ -410,13 +416,33 @@ final class MeetingDetailViewModel: ObservableObject {
     func setTranscriptSpeakerDisplayMode(_ mode: TranscriptSpeakerDisplayMode) {
         guard captureMode.capabilities.allowsSpeakerFeatures else { return }
         transcriptSpeakerDisplayModeRaw = mode.rawValue
+        refreshTranscriptListCaches()
+    }
+
+    func timelineSpeakerTitle(for segment: MeetingTranscriptSegment) -> String {
+        switch transcriptSpeakerDisplayMode {
+        case .source:
+            return segment.speaker.displayTitle
+        case .speaker:
+            return speakerTimelineTitle(for: segment)
+        }
+    }
+
+    func displayedNewestSegmentID() -> UUID? {
+        displayedSegments.last?.id
     }
 
     func toggleSearchPresentation() {
         isSearchPresented.toggle()
         if !isSearchPresented {
-            searchQuery = ""
+            setSearchQuery("")
         }
+    }
+
+    func setSearchQuery(_ query: String) {
+        guard searchQuery != query else { return }
+        searchQuery = query
+        refreshTranscriptListCaches()
     }
 
     func toggleSummaryCollapsed() {
@@ -438,6 +464,7 @@ final class MeetingDetailViewModel: ObservableObject {
         segments = updatedSegments
         segmentStructureRevision &+= 1
         cachedSummaryTranscript = nil
+        refreshTranscriptListCaches()
         _ = transcriptSegmentsPersistence?(historyEntryID, updatedSegments)
     }
 
@@ -625,6 +652,7 @@ final class MeetingDetailViewModel: ObservableObject {
         guard updatedSegments != segments else { return }
         segments = updatedSegments
         segmentStructureRevision &+= 1
+        refreshTranscriptListCaches()
         if translationEnabled {
             translateEligibleSegmentsIfNeeded(targetLanguage: targetLanguage)
         }
@@ -807,6 +835,7 @@ final class MeetingDetailViewModel: ObservableObject {
     private func markSegment(_ id: UUID, update: (MeetingTranscriptSegment) -> MeetingTranscriptSegment) {
         guard let index = segments.firstIndex(where: { $0.id == id }) else { return }
         segments[index] = update(segments[index])
+        refreshTranscriptListCaches()
     }
 
     private func cancelTranslationTasks() {
@@ -821,6 +850,58 @@ final class MeetingDetailViewModel: ObservableObject {
                 isTranslationPending: false
             )
         }
+        refreshTranscriptListCaches()
+    }
+
+    private func refreshTranscriptListCaches() {
+        speakerOrdinalByIdentityKey = MeetingTranscriptListSupport.speakerOrdinals(for: segments)
+        displayedSegments = MeetingTranscriptListSupport.displayedSegments(
+            from: segments,
+            searchQuery: searchQuery,
+            speakerTitle: { [weak self] segment in
+                self?.timelineSpeakerTitle(for: segment) ?? segment.speaker.displayTitle
+            }
+        )
+        speakerGroups = MeetingTranscriptListSupport.speakerGroups(
+            from: displayedSegments,
+            titleForSegment: { [weak self] segment in
+                self?.timelineSpeakerTitle(for: segment) ?? segment.speaker.displayTitle
+            }
+        )
+    }
+
+    private func speakerTimelineTitle(for segment: MeetingTranscriptSegment) -> String {
+        if let displayName = speakerDisplayNameIfUserFacing(for: segment) {
+            return displayName
+        }
+        let ordinal = speakerOrdinalByIdentityKey[segment.speakerIdentityKey] ?? 1
+        return AppLocalization.format("Speaker %d", ordinal)
+    }
+
+    private func speakerDisplayNameIfUserFacing(for segment: MeetingTranscriptSegment) -> String? {
+        guard let displayName = segment.speakerDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !displayName.isEmpty,
+              !isAudioSourceDisplayName(displayName)
+        else {
+            return nil
+        }
+        return displayName
+    }
+
+    private func isAudioSourceDisplayName(_ displayName: String) -> Bool {
+        let normalized = displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return false }
+        if normalized == TranscriptSpeaker.me.displayTitle.lowercased()
+            || normalized == TranscriptSpeaker.them.displayTitle.lowercased() {
+            return true
+        }
+        if normalized.range(of: #"^me\s+\d+$"#, options: .regularExpression) != nil {
+            return true
+        }
+        if normalized.range(of: #"^them\s+\d+$"#, options: .regularExpression) != nil {
+            return true
+        }
+        return false
     }
 
     private func resolvedStoredTranslationLanguage() -> TranslationTargetLanguage {

--- a/Voxt/Windows/MeetingDetail/MeetingDetailWindow.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingDetailWindow.swift
@@ -301,7 +301,9 @@ private struct MeetingDetailWindowView: View {
     @State private var speakerRenameGroupID: String?
     @State private var speakerRenameDraft = ""
     @State private var isScrubbing = false
-    @State private var speakerOrdinalByIdentityKey: [String: Int] = [:]
+    @State private var scrollRequest: MeetingTranscriptScrollRequest?
+    @State private var scrollGeneration: UInt64 = 0
+    @State private var displayedSegmentIDs: Set<UUID> = []
 
     init(viewModel: MeetingDetailViewModel) {
         self.viewModel = viewModel
@@ -330,7 +332,7 @@ private struct MeetingDetailWindowView: View {
             .ignoresSafeArea(.container, edges: .top)
             .onAppear {
                 viewModel.handleViewAppear()
-                refreshSpeakerOrdinalMap()
+                displayedSegmentIDs = Set(viewModel.displayedSegments.map(\.id))
                 updateActiveSegment(for: playbackController.currentTime)
             }
 
@@ -350,8 +352,23 @@ private struct MeetingDetailWindowView: View {
             MeetingDetailSummarySettingsDialog(viewModel: viewModel)
         }
         .onChange(of: viewModel.segmentStructureRevision) { _, _ in
-            refreshSpeakerOrdinalMap()
+            displayedSegmentIDs = Set(viewModel.displayedSegments.map(\.id))
             updateActiveSegment(for: playbackController.currentTime)
+            requestLiveScrollToNewestIfNeeded()
+        }
+        .onChange(of: viewModel.displayedSegments) { _, newValue in
+            displayedSegmentIDs = Set(newValue.map(\.id))
+        }
+        .onChange(of: playbackController.currentTime) { _, newValue in
+            guard viewModel.mode == .history else { return }
+            updateActiveSegment(for: newValue)
+        }
+        .onChange(of: activeSegmentID) { _, newValue in
+            requestHistoryScrollToActiveSegment(newValue)
+        }
+        .onChange(of: isScrubbing) { _, scrubbing in
+            guard !scrubbing else { return }
+            requestHistoryScrollToActiveSegment(activeSegmentID)
         }
     }
 
@@ -537,12 +554,18 @@ private struct MeetingDetailWindowView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
 
-            TextField(AppLocalization.localizedString("Search transcript"), text: $viewModel.searchQuery)
+            TextField(
+                AppLocalization.localizedString("Search transcript"),
+                text: Binding(
+                    get: { viewModel.searchQuery },
+                    set: { viewModel.setSearchQuery($0) }
+                )
+            )
                 .textFieldStyle(.plain)
 
             if !viewModel.searchQuery.isEmpty {
                 Button {
-                    viewModel.searchQuery = ""
+                    viewModel.setSearchQuery("")
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 12, weight: .semibold))
@@ -557,63 +580,48 @@ private struct MeetingDetailWindowView: View {
     }
 
     private var transcriptPane: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    transcriptCaption
+        VStack(alignment: .leading, spacing: 16) {
+            transcriptCaption
 
-                    if viewModel.isFinalizing {
-                        meetingFinalizationBanner
-                    }
+            if viewModel.isFinalizing {
+                meetingFinalizationBanner
+            }
 
-                    if displayedSegments.isEmpty {
-                        transcriptEmptyState
-                    } else if viewModel.transcriptPresentationMode == .timeline {
-                        LazyVStack(alignment: .leading, spacing: 12) {
-                            ForEach(displayedSegments) { segment in
-                                MeetingDetailSegmentRow(
-                                    segment: segment,
-                                    speakerTitle: timelineSpeakerTitle(for: segment),
-                                    isActive: activeSegmentID == segment.id,
-                                    showsTranslation: viewModel.translationEnabled,
-                                    isSearchMatch: segmentMatchesSearch(segment)
-                                )
-                                .id(segment.id)
-                            }
-                        }
-                    } else {
-                        speakerMarksPane
-                    }
-                }
-                .padding(16)
-            }
-            .meetingDetailPanelSurface(cornerRadius: 16)
-            .onChange(of: playbackController.currentTime) { _, newValue in
-                guard viewModel.mode == .history else { return }
-                updateActiveSegment(for: newValue)
-                guard !isScrubbing,
-                      viewModel.transcriptPresentationMode == .timeline,
-                      let activeSegmentID,
-                      displayedSegments.contains(where: { $0.id == activeSegmentID })
-                else {
-                    return
-                }
-                withAnimation(.easeOut(duration: 0.18)) {
-                    proxy.scrollTo(activeSegmentID, anchor: .center)
-                }
-            }
-            .onChange(of: viewModel.segmentStructureRevision) { _, _ in
-                guard viewModel.mode == .live,
-                      viewModel.transcriptPresentationMode == .timeline,
-                      let newest = displayedNewestSegmentID(in: viewModel.segments)
-                else {
-                    return
-                }
-                withAnimation(.easeOut(duration: 0.18)) {
-                    proxy.scrollTo(newest, anchor: .bottom)
-                }
+            if viewModel.displayedSegments.isEmpty {
+                transcriptEmptyState
+            } else if viewModel.transcriptPresentationMode == .timeline {
+                MeetingDetailTranscriptListPane(
+                    rows: timelineVirtualRows,
+                    showsTranslation: viewModel.translationEnabled,
+                    scrollRequest: scrollRequest
+                )
+                .equatable()
+            } else {
+                speakerMarksPane
             }
         }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .meetingDetailPanelSurface(cornerRadius: 16)
+    }
+
+    private var timelineVirtualRows: [MeetingTranscriptVirtualRow] {
+        MeetingTranscriptListSupport.timelineRows(
+            from: viewModel.displayedSegments,
+            activeSegmentID: activeSegmentID,
+            showsTranslation: viewModel.translationEnabled,
+            searchQuery: viewModel.searchQuery,
+            speakerTitle: viewModel.timelineSpeakerTitle(for:)
+        )
+    }
+
+    private var speakerMarkVirtualRows: [MeetingTranscriptVirtualRow] {
+        MeetingTranscriptListSupport.speakerMarkRows(
+            from: viewModel.speakerGroups,
+            activeSegmentID: activeSegmentID,
+            showsTranslation: viewModel.translationEnabled,
+            searchQuery: viewModel.searchQuery
+        )
     }
 
     private var transcriptCaption: some View {
@@ -715,84 +723,25 @@ private struct MeetingDetailWindowView: View {
     private var speakerMarksPane: some View {
         VStack(alignment: .leading, spacing: 16) {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 128), spacing: 10)], spacing: 10) {
-                ForEach(speakerGroups, id: \.id) { group in
+                ForEach(viewModel.speakerGroups) { group in
                     speakerOverviewCard(for: group)
                 }
             }
+            .fixedSize(horizontal: false, vertical: true)
 
-            ForEach(speakerGroups, id: \.id) { group in
-                let segments = group.segments
-                if !segments.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack(spacing: 8) {
-                            Text(group.title)
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(.primary)
-
-                            Text(AppLocalization.format("%d", segments.count))
-                                .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background(
-                                    Capsule(style: .continuous)
-                                        .fill(MeetingDetailUIStyle.mutedFillColor)
-                                )
-                        }
-
-                        VStack(alignment: .leading, spacing: 10) {
-                            ForEach(segments) { segment in
-                                MeetingDetailSegmentRow(
-                                    segment: segment,
-                                    speakerTitle: group.title,
-                                    isActive: activeSegmentID == segment.id,
-                                    showsTranslation: viewModel.translationEnabled,
-                                    isSearchMatch: segmentMatchesSearch(segment)
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private struct SpeakerGroup {
-        let id: String
-        let title: String
-        let speaker: MeetingSpeaker
-        let segments: [MeetingTranscriptSegment]
-    }
-
-    private var speakerGroups: [SpeakerGroup] {
-        let grouped = Dictionary(grouping: displayedSegments, by: stableSpeakerIdentityKey)
-        return grouped.map { key, segments in
-            let sortedSegments = segments.sorted { $0.startSeconds < $1.startSeconds }
-            let representative = sortedSegments.first
-            return SpeakerGroup(
-                id: key,
-                title: representative.map(speakerTimelineTitle) ?? "",
-                speaker: representative?.speaker ?? .them,
-                segments: sortedSegments
+            MeetingDetailTranscriptListPane(
+                rows: speakerMarkVirtualRows,
+                showsTranslation: viewModel.translationEnabled,
+                scrollRequest: scrollRequest
             )
+            .equatable()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .sorted { lhs, rhs in
-            guard let lhsStart = lhs.segments.first?.startSeconds,
-                  let rhsStart = rhs.segments.first?.startSeconds
-            else {
-                return lhs.title < rhs.title
-            }
-            return lhsStart < rhsStart
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private func speakerOverviewCard(for group: SpeakerGroup) -> some View {
-        let segments = group.segments
-        let totalWords = segments.reduce(0) { partialResult, segment in
-            partialResult + segment.text.split(whereSeparator: \.isWhitespace).count
-        }
-
-        return VStack(alignment: .leading, spacing: 6) {
+    private func speakerOverviewCard(for group: MeetingDetailSpeakerGroup) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Text(group.title)
                     .font(.system(size: 12, weight: .semibold))
@@ -816,11 +765,11 @@ private struct MeetingDetailWindowView: View {
                 }
             }
 
-            Text(AppLocalization.format("%d", segments.count))
+            Text(AppLocalization.format("%d", group.segments.count))
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundStyle(.primary)
 
-            Text(AppLocalization.format("%d words", totalWords))
+            Text(AppLocalization.format("%d words", group.wordCount))
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.secondary)
         }
@@ -1000,29 +949,6 @@ private struct MeetingDetailWindowView: View {
         "\(MeetingTranscriptFormatter.timestampString(for: playbackController.currentTime)) / \(MeetingTranscriptFormatter.timestampString(for: playbackController.duration))"
     }
 
-    private var displayedSegments: [MeetingTranscriptSegment] {
-        let query = viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return viewModel.segments }
-        return viewModel.segments.filter(segmentMatchesSearch)
-    }
-
-    private func displayedNewestSegmentID(in segments: [MeetingTranscriptSegment]) -> UUID? {
-        let query = viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        if query.isEmpty {
-            return segments.last?.id
-        }
-        return segments.last(where: segmentMatchesSearch)?.id
-    }
-
-    private func segmentMatchesSearch(_ segment: MeetingTranscriptSegment) -> Bool {
-        let query = viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return true }
-        return segment.text.localizedCaseInsensitiveContains(query)
-            || (segment.translatedText?.localizedCaseInsensitiveContains(query) ?? false)
-            || timelineSpeakerTitle(for: segment).localizedCaseInsensitiveContains(query)
-            || MeetingTranscriptFormatter.timestampString(for: segment.startSeconds).localizedCaseInsensitiveContains(query)
-    }
-
     private func updateActiveSegment(for currentTime: TimeInterval) {
         guard viewModel.mode == .history else {
             activeSegmentID = nil
@@ -1054,7 +980,32 @@ private struct MeetingDetailWindowView: View {
         return low > 0 ? segments[low - 1] : segments.first
     }
 
-    private func presentSpeakerRename(for group: SpeakerGroup) {
+    private func requestHistoryScrollToActiveSegment(_ segmentID: UUID?) {
+        guard viewModel.mode == .history else { return }
+        guard !isScrubbing else { return }
+        guard viewModel.transcriptPresentationMode == .timeline else { return }
+        guard let segmentID, displayedSegmentIDs.contains(segmentID) else { return }
+        scrollGeneration &+= 1
+        scrollRequest = MeetingTranscriptScrollRequest(
+            rowID: segmentID.uuidString,
+            anchor: .center,
+            generation: scrollGeneration
+        )
+    }
+
+    private func requestLiveScrollToNewestIfNeeded() {
+        guard viewModel.mode == .live else { return }
+        guard viewModel.transcriptPresentationMode == .timeline else { return }
+        guard let newest = viewModel.displayedNewestSegmentID() else { return }
+        scrollGeneration &+= 1
+        scrollRequest = MeetingTranscriptScrollRequest(
+            rowID: newest.uuidString,
+            anchor: .bottom,
+            generation: scrollGeneration
+        )
+    }
+
+    private func presentSpeakerRename(for group: MeetingDetailSpeakerGroup) {
         speakerRenameGroupID = group.id
         speakerRenameDraft = group.title
     }
@@ -1069,150 +1020,28 @@ private struct MeetingDetailWindowView: View {
         viewModel.renameSpeaker(identityKey: speakerRenameGroupID, displayName: speakerRenameDraft)
         cancelSpeakerRename()
     }
-
-    private func timelineSpeakerTitle(for segment: MeetingTranscriptSegment) -> String {
-        switch viewModel.transcriptSpeakerDisplayMode {
-        case .source:
-            return segment.speaker.displayTitle
-        case .speaker:
-            return speakerTimelineTitle(for: segment)
-        }
-    }
-
-    private func speakerTimelineTitle(for segment: MeetingTranscriptSegment) -> String {
-        if let displayName = speakerDisplayNameIfUserFacing(for: segment) {
-            return displayName
-        }
-        let ordinal = speakerOrdinalByIdentityKey[speakerTimelineIdentityKey(for: segment)] ?? 1
-        return AppLocalization.format("Speaker %d", ordinal)
-    }
-
-    private func refreshSpeakerOrdinalMap() {
-        var ordinals: [String: Int] = [:]
-        let sortedSegments = viewModel.segments.sorted { lhs, rhs in
-            if lhs.startSeconds == rhs.startSeconds {
-                return lhs.id.uuidString < rhs.id.uuidString
-            }
-            return lhs.startSeconds < rhs.startSeconds
-        }
-
-        for segment in sortedSegments {
-            let key = stableSpeakerIdentityKey(for: segment)
-            guard ordinals[key] == nil else { continue }
-            ordinals[key] = ordinals.count + 1
-        }
-        speakerOrdinalByIdentityKey = ordinals
-    }
-
-    private func speakerTimelineIdentityKey(for segment: MeetingTranscriptSegment) -> String {
-        stableSpeakerIdentityKey(for: segment)
-    }
-
-    private func stableSpeakerIdentityKey(for segment: MeetingTranscriptSegment) -> String {
-        segment.speakerIdentityKey
-    }
-
-    private func speakerDisplayNameIfUserFacing(for segment: MeetingTranscriptSegment) -> String? {
-        guard let displayName = segment.speakerDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !displayName.isEmpty,
-              !isAudioSourceDisplayName(displayName)
-        else {
-            return nil
-        }
-        return displayName
-    }
-
-    private func isAudioSourceDisplayName(_ displayName: String) -> Bool {
-        let normalized = displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalized.isEmpty else { return false }
-        if normalized == TranscriptSpeaker.me.displayTitle.lowercased()
-            || normalized == TranscriptSpeaker.them.displayTitle.lowercased() {
-            return true
-        }
-        if normalized.range(of: #"^me\s+\d+$"#, options: .regularExpression) != nil {
-            return true
-        }
-        if normalized.range(of: #"^them\s+\d+$"#, options: .regularExpression) != nil {
-            return true
-        }
-        return false
-    }
-
 }
 
-private struct MeetingDetailSegmentRow: View {
-    let segment: MeetingTranscriptSegment
-    let speakerTitle: String
-    let isActive: Bool
+private struct MeetingDetailTranscriptListPane: View, Equatable {
+    let rows: [MeetingTranscriptVirtualRow]
     let showsTranslation: Bool
-    let isSearchMatch: Bool
+    let scrollRequest: MeetingTranscriptScrollRequest?
+
+    static func == (
+        lhs: MeetingDetailTranscriptListPane,
+        rhs: MeetingDetailTranscriptListPane
+    ) -> Bool {
+        lhs.rows == rhs.rows
+            && lhs.showsTranslation == rhs.showsTranslation
+            && lhs.scrollRequest == rhs.scrollRequest
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 8) {
-                Text(MeetingTranscriptFormatter.timestampString(for: segment.startSeconds))
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(.secondary)
-
-                Text(speakerTitle)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(segment.speaker == .me ? Color(red: 0.16, green: 0.47, blue: 0.88) : Color(red: 0.12, green: 0.58, blue: 0.32))
-
-                Spacer(minLength: 8)
-            }
-
-            Text(segment.text)
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.primary.opacity(0.94))
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            if showsTranslation,
-               let translatedText = segment.translatedText?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !translatedText.isEmpty {
-                Text(translatedText)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            } else if showsTranslation, segment.isTranslationPending {
-                Text(AppLocalization.localizedString("Translating…"))
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary.opacity(0.75))
-            }
-        }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(backgroundColor)
+        MeetingTranscriptVirtualList(
+            rows: rows,
+            showsTranslation: showsTranslation,
+            scrollRequest: scrollRequest
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(borderColor, lineWidth: 1)
-        )
-    }
-
-    private var backgroundColor: Color {
-        if isActive {
-            return speakerAccentColor.opacity(0.16)
-        }
-        if isSearchMatch {
-            return Color.orange.opacity(0.12)
-        }
-        return speakerAccentColor.opacity(0.06)
-    }
-
-    private var borderColor: Color {
-        if isActive {
-            return speakerAccentColor.opacity(0.32)
-        }
-        if isSearchMatch {
-            return Color.orange.opacity(0.28)
-        }
-        return speakerAccentColor.opacity(0.16)
-    }
-
-    private var speakerAccentColor: Color {
-        segment.speaker == .me
-            ? Color(red: 0.16, green: 0.47, blue: 0.88)
-            : Color(red: 0.12, green: 0.58, blue: 0.32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Voxt/Windows/MeetingDetail/MeetingTranscriptRowHeightCache.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingTranscriptRowHeightCache.swift
@@ -1,0 +1,198 @@
+// MeetingTranscriptRowHeightCache.swift
+// Width-aware heights for meeting transcript virtual rows.
+// Initial heights use text boundingRect estimates; on-screen GeometryReader
+// reports can refine them (including shrinking overestimated rows).
+
+import AppKit
+import Foundation
+
+struct MeetingTranscriptRowHeightCache {
+    private var heights: [String: CGFloat] = [:]
+    private var reported: Set<String> = []
+
+    /// Widths below this are treated as provisional and are not cached.
+    static let minimumReliableWidth: CGFloat = 120
+
+    mutating func invalidateAll() {
+        heights.removeAll(keepingCapacity: true)
+        reported.removeAll(keepingCapacity: true)
+    }
+
+    mutating func invalidateWidth(_ width: CGFloat) {
+        let bucket = Self.widthBucket(width)
+        let prefix = "w\(bucket)|"
+        let removedKeys = heights.keys.filter { $0.hasPrefix(prefix) }
+        for key in removedKeys {
+            heights.removeValue(forKey: key)
+            reported.remove(key)
+        }
+    }
+
+    func height(
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> CGFloat {
+        let key = Self.cacheKey(for: row, width: width, showsTranslation: showsTranslation)
+        if let cached = heights[key] {
+            return cached
+        }
+        return Self.estimate(for: row, width: width, showsTranslation: showsTranslation)
+    }
+
+    mutating func cachedHeight(
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> CGFloat {
+        let key = Self.cacheKey(for: row, width: width, showsTranslation: showsTranslation)
+        if let cached = heights[key] {
+            return cached
+        }
+        let value = Self.estimate(for: row, width: width, showsTranslation: showsTranslation)
+        if width >= Self.minimumReliableWidth {
+            heights[key] = value
+        }
+        return value
+    }
+
+    func hasReportedHeight(
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> Bool {
+        let key = Self.cacheKey(for: row, width: width, showsTranslation: showsTranslation)
+        return reported.contains(key)
+    }
+
+    /// Stores an on-screen layout height. Unlike hosting-view fittingSize, this may
+    /// shrink below the initial estimate so inter-row gaps stay visually even.
+    @discardableResult
+    mutating func storeReportedHeight(
+        _ height: CGFloat,
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> Bool {
+        guard width >= Self.minimumReliableWidth else { return false }
+        let rounded = ceil(height)
+        guard rounded >= 24 else { return false }
+
+        let key = Self.cacheKey(for: row, width: width, showsTranslation: showsTranslation)
+        if let existing = heights[key], abs(existing - rounded) < 1 {
+            reported.insert(key)
+            return false
+        }
+        heights[key] = rounded
+        reported.insert(key)
+        return true
+    }
+
+    /// Legacy name kept for tests; reported heights are the authoritative measured values.
+    @discardableResult
+    mutating func storeMeasuredHeight(
+        _ height: CGFloat,
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> Bool {
+        storeReportedHeight(height, for: row, width: width, showsTranslation: showsTranslation)
+    }
+
+    func hasMeasuredHeight(
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> Bool {
+        hasReportedHeight(for: row, width: width, showsTranslation: showsTranslation)
+    }
+
+    static func estimate(
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> CGFloat {
+        switch row {
+        case .speakerHeader:
+            return 28
+        case .segment(let presentation):
+            return estimateSegmentHeight(
+                text: presentation.segment.text,
+                translatedText: presentation.segment.translatedText,
+                isTranslationPending: presentation.segment.isTranslationPending,
+                width: max(width, minimumReliableWidth),
+                showsTranslation: showsTranslation || presentation.showsTranslation
+            )
+        }
+    }
+
+    static func estimateSegmentHeight(
+        text: String,
+        translatedText: String?,
+        isTranslationPending: Bool,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> CGFloat {
+        // Match MeetingDetailSegmentRow: 14pt horizontal padding on each side.
+        let contentWidth = max(80, width - 28)
+        let headerHeight: CGFloat = 15
+        let spacing: CGFloat = 9
+        let verticalPadding: CGFloat = 28
+
+        let bodyHeight = textHeight(
+            text,
+            width: contentWidth,
+            font: .systemFont(ofSize: 14, weight: .medium)
+        )
+
+        var translationHeight: CGFloat = 0
+        if showsTranslation {
+            let trimmed = translatedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                translationHeight = spacing + textHeight(
+                    trimmed,
+                    width: contentWidth,
+                    font: .systemFont(ofSize: 13, weight: .medium)
+                )
+            } else if isTranslationPending {
+                translationHeight = spacing + 15
+            }
+        }
+
+        // Slightly generous first paint so text is never clipped before GeometryReader refines.
+        return max(60, verticalPadding + headerHeight + spacing + bodyHeight + translationHeight + 2)
+    }
+
+    static func widthBucket(_ width: CGFloat) -> Int {
+        max(1, Int((width / 8).rounded()) * 8)
+    }
+
+    static func cacheKey(
+        for row: MeetingTranscriptVirtualRow,
+        width: CGFloat,
+        showsTranslation: Bool
+    ) -> String {
+        let bucket = widthBucket(width)
+        switch row {
+        case .speakerHeader(let id, let title, let count):
+            return "w\(bucket)|h|\(id)|\(title)|\(count)"
+        case .segment(let presentation):
+            let translated = presentation.segment.translatedText ?? ""
+            let pending = presentation.segment.isTranslationPending ? "1" : "0"
+            let translationFlag = (showsTranslation || presentation.showsTranslation) ? "1" : "0"
+            return "w\(bucket)|s|\(presentation.id.uuidString)|\(translationFlag)|\(pending)|\(presentation.segment.text.hashValue)|\(translated.hashValue)"
+        }
+    }
+
+    private static func textHeight(_ text: String, width: CGFloat, font: NSFont) -> CGFloat {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return 17 }
+        let constraint = CGSize(width: width, height: .greatestFiniteMagnitude)
+        let bounds = (trimmed as NSString).boundingRect(
+            with: constraint,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        )
+        return max(17, ceil(bounds.height))
+    }
+}

--- a/Voxt/Windows/MeetingDetail/MeetingTranscriptVirtualList.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingTranscriptVirtualList.swift
@@ -1,0 +1,79 @@
+// MeetingTranscriptVirtualList.swift
+// Lazy SwiftUI transcript list with stable spacing and scroll requests.
+//
+// NSTableView + NSHostingView automatic/manual row heights repeatedly mis-measured
+// multi-line SwiftUI Text (extra blank space under wrapped cards). LazyVStack keeps
+// visually correct spacing while still deferring off-screen row bodies. Playback and
+// search CPU wins come from ViewModel caching + activeSegment-only scroll, not AppKit
+// cell reuse.
+
+import SwiftUI
+
+struct MeetingTranscriptVirtualList: View {
+    let rows: [MeetingTranscriptVirtualRow]
+    let showsTranslation: Bool
+    let rowSpacing: CGFloat
+    let scrollRequest: MeetingTranscriptScrollRequest?
+
+    init(
+        rows: [MeetingTranscriptVirtualRow],
+        showsTranslation: Bool,
+        rowSpacing: CGFloat = 12,
+        scrollRequest: MeetingTranscriptScrollRequest? = nil
+    ) {
+        self.rows = rows
+        self.showsTranslation = showsTranslation
+        self.rowSpacing = rowSpacing
+        self.scrollRequest = scrollRequest
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: rowSpacing) {
+                    ForEach(rows) { row in
+                        rowView(for: row)
+                            .id(row.id)
+                    }
+                }
+            }
+            .onChange(of: scrollRequest?.generation) { _, _ in
+                fulfillScrollRequest(using: proxy)
+            }
+            .onAppear {
+                fulfillScrollRequest(using: proxy)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowView(for row: MeetingTranscriptVirtualRow) -> some View {
+        switch row {
+        case .speakerHeader(_, let title, let count):
+            MeetingDetailSpeakerHeaderRow(title: title, count: count)
+        case .segment(let presentation):
+            MeetingDetailSegmentRow(
+                segment: presentation.segment,
+                speakerTitle: presentation.speakerTitle,
+                isActive: presentation.isActive,
+                showsTranslation: presentation.showsTranslation || showsTranslation,
+                isSearchMatch: presentation.isSearchMatch
+            )
+            .equatable()
+        }
+    }
+
+    private func fulfillScrollRequest(using proxy: ScrollViewProxy) {
+        guard let scrollRequest else { return }
+        let anchor: UnitPoint
+        switch scrollRequest.anchor {
+        case .top:
+            anchor = .top
+        case .center:
+            anchor = .center
+        case .bottom:
+            anchor = .bottom
+        }
+        proxy.scrollTo(scrollRequest.rowID, anchor: anchor)
+    }
+}

--- a/Voxt/Windows/MeetingDetail/MeetingTranscriptVirtualRows.swift
+++ b/Voxt/Windows/MeetingDetail/MeetingTranscriptVirtualRows.swift
@@ -1,0 +1,215 @@
+// MeetingTranscriptVirtualRows.swift
+// Flattened virtual-row models and pure list builders for meeting detail transcript.
+
+import Foundation
+
+struct MeetingTranscriptSegmentPresentation: Identifiable, Equatable {
+    let segment: MeetingTranscriptSegment
+    let speakerTitle: String
+    let isActive: Bool
+    let showsTranslation: Bool
+    let isSearchMatch: Bool
+
+    var id: UUID { segment.id }
+}
+
+enum MeetingTranscriptVirtualRow: Identifiable, Equatable {
+    case speakerHeader(id: String, title: String, count: Int)
+    case segment(MeetingTranscriptSegmentPresentation)
+
+    var id: String {
+        switch self {
+        case .speakerHeader(let id, _, _):
+            return "header:\(id)"
+        case .segment(let presentation):
+            return presentation.id.uuidString
+        }
+    }
+
+    var segmentID: UUID? {
+        switch self {
+        case .speakerHeader:
+            return nil
+        case .segment(let presentation):
+            return presentation.id
+        }
+    }
+}
+
+enum MeetingTranscriptScrollAnchor: Equatable {
+    case top
+    case center
+    case bottom
+}
+
+struct MeetingTranscriptScrollRequest: Equatable {
+    let rowID: String
+    let anchor: MeetingTranscriptScrollAnchor
+    let generation: UInt64
+}
+
+struct MeetingDetailSpeakerGroup: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let speaker: MeetingSpeaker
+    let segments: [MeetingTranscriptSegment]
+    let wordCount: Int
+}
+
+enum MeetingTranscriptListSupport {
+    static func normalizedSearchQuery(_ query: String) -> String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func segmentMatchesSearch(
+        _ segment: MeetingTranscriptSegment,
+        query: String,
+        speakerTitle: String
+    ) -> Bool {
+        let normalized = normalizedSearchQuery(query)
+        guard !normalized.isEmpty else { return true }
+        return segment.text.localizedCaseInsensitiveContains(normalized)
+            || (segment.translatedText?.localizedCaseInsensitiveContains(normalized) ?? false)
+            || speakerTitle.localizedCaseInsensitiveContains(normalized)
+            || MeetingTranscriptFormatter.timestampString(for: segment.startSeconds)
+                .localizedCaseInsensitiveContains(normalized)
+    }
+
+    static func displayedSegments(
+        from segments: [MeetingTranscriptSegment],
+        searchQuery: String,
+        speakerTitle: (MeetingTranscriptSegment) -> String
+    ) -> [MeetingTranscriptSegment] {
+        let normalized = normalizedSearchQuery(searchQuery)
+        guard !normalized.isEmpty else { return segments }
+        return segments.filter { segment in
+            segmentMatchesSearch(segment, query: normalized, speakerTitle: speakerTitle(segment))
+        }
+    }
+
+    static func speakerOrdinals(for segments: [MeetingTranscriptSegment]) -> [String: Int] {
+        var ordinals: [String: Int] = [:]
+        let sortedSegments = segments.sorted { lhs, rhs in
+            if lhs.startSeconds == rhs.startSeconds {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.startSeconds < rhs.startSeconds
+        }
+        for segment in sortedSegments {
+            let key = segment.speakerIdentityKey
+            guard ordinals[key] == nil else { continue }
+            ordinals[key] = ordinals.count + 1
+        }
+        return ordinals
+    }
+
+    static func speakerGroups(
+        from segments: [MeetingTranscriptSegment],
+        titleForSegment: (MeetingTranscriptSegment) -> String
+    ) -> [MeetingDetailSpeakerGroup] {
+        let grouped = Dictionary(grouping: segments, by: \.speakerIdentityKey)
+        return grouped.map { key, groupSegments in
+            let sortedSegments = groupSegments.sorted { $0.startSeconds < $1.startSeconds }
+            let representative = sortedSegments.first
+            let wordCount = sortedSegments.reduce(0) { partial, segment in
+                partial + segment.text.split(whereSeparator: \.isWhitespace).count
+            }
+            return MeetingDetailSpeakerGroup(
+                id: key,
+                title: representative.map(titleForSegment) ?? "",
+                speaker: representative?.speaker ?? .them,
+                segments: sortedSegments,
+                wordCount: wordCount
+            )
+        }
+        .sorted { lhs, rhs in
+            guard let lhsStart = lhs.segments.first?.startSeconds,
+                  let rhsStart = rhs.segments.first?.startSeconds
+            else {
+                return lhs.title < rhs.title
+            }
+            return lhsStart < rhsStart
+        }
+    }
+
+    static func timelineRows(
+        from segments: [MeetingTranscriptSegment],
+        activeSegmentID: UUID?,
+        showsTranslation: Bool,
+        searchQuery: String,
+        speakerTitle: (MeetingTranscriptSegment) -> String
+    ) -> [MeetingTranscriptVirtualRow] {
+        let normalized = normalizedSearchQuery(searchQuery)
+        return segments.map { segment in
+            .segment(
+                MeetingTranscriptSegmentPresentation(
+                    segment: segment,
+                    speakerTitle: speakerTitle(segment),
+                    isActive: activeSegmentID == segment.id,
+                    showsTranslation: showsTranslation,
+                    isSearchMatch: !normalized.isEmpty
+                        && segmentMatchesSearch(segment, query: normalized, speakerTitle: speakerTitle(segment))
+                )
+            )
+        }
+    }
+
+    static func speakerMarkRows(
+        from groups: [MeetingDetailSpeakerGroup],
+        activeSegmentID: UUID?,
+        showsTranslation: Bool,
+        searchQuery: String
+    ) -> [MeetingTranscriptVirtualRow] {
+        let normalized = normalizedSearchQuery(searchQuery)
+        var rows: [MeetingTranscriptVirtualRow] = []
+        rows.reserveCapacity(groups.reduce(0) { $0 + $1.segments.count + 1 })
+        for group in groups where !group.segments.isEmpty {
+            rows.append(.speakerHeader(id: group.id, title: group.title, count: group.segments.count))
+            for segment in group.segments {
+                rows.append(
+                    .segment(
+                        MeetingTranscriptSegmentPresentation(
+                            segment: segment,
+                            speakerTitle: group.title,
+                            isActive: activeSegmentID == segment.id,
+                            showsTranslation: showsTranslation,
+                            isSearchMatch: !normalized.isEmpty
+                                && segmentMatchesSearch(segment, query: normalized, speakerTitle: group.title)
+                        )
+                    )
+                )
+            }
+        }
+        return rows
+    }
+
+    /// Returns indexes that need content reload when identity sequence is unchanged.
+    /// Returns `nil` when the identity structure changed and a structural update is required.
+    static func contentChangedIndexes(
+        from oldRows: [MeetingTranscriptVirtualRow],
+        to newRows: [MeetingTranscriptVirtualRow]
+    ) -> IndexSet? {
+        guard oldRows.count == newRows.count else { return nil }
+        var changed = IndexSet()
+        for index in oldRows.indices {
+            let oldRow = oldRows[index]
+            let newRow = newRows[index]
+            guard oldRow.id == newRow.id else { return nil }
+            if oldRow != newRow {
+                changed.insert(index)
+            }
+        }
+        return changed
+    }
+
+    static func isSuffixAppend(
+        from oldRows: [MeetingTranscriptVirtualRow],
+        to newRows: [MeetingTranscriptVirtualRow]
+    ) -> Bool {
+        guard newRows.count > oldRows.count else { return false }
+        for index in oldRows.indices {
+            guard oldRows[index].id == newRows[index].id else { return false }
+        }
+        return true
+    }
+}

--- a/Voxt/Windows/TranscriptionConversationViews.swift
+++ b/Voxt/Windows/TranscriptionConversationViews.swift
@@ -334,11 +334,18 @@ private struct TranscriptionDetailMessageBubble: View {
                 .strokeBorder(borderColor, lineWidth: 1)
         )
         .overlay(alignment: .topTrailing) {
-            if isHovered {
+            if !isUserMessage && isHovered {
                 Button(action: copyToPasteboard) {
                     HStack(spacing: 4) {
-                        Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 9, weight: .semibold))
+                        Group {
+                            if didCopy {
+                                CopySuccessIconView()
+                            } else {
+                                CopyIconView()
+                            }
+                        }
+                        .frame(width: 12, height: 12)
+
                         Text(didCopy ? AppLocalization.localizedString("Copied") : AppLocalization.localizedString("Copy"))
                             .font(.system(size: 10, weight: .semibold))
                     }
@@ -361,6 +368,7 @@ private struct TranscriptionDetailMessageBubble: View {
             }
         }
         .onHover { hovering in
+            guard !isUserMessage else { return }
             withAnimation(.easeOut(duration: 0.12)) {
                 isHovered = hovering
             }

--- a/Voxt/Windows/WaveformAnswerCardComponents.swift
+++ b/Voxt/Windows/WaveformAnswerCardComponents.swift
@@ -802,8 +802,15 @@ struct RewriteConversationBubble: View {
             if !isUser && isHovered {
                 Button(action: copyToPasteboard) {
                     HStack(spacing: 4) {
-                        Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 9, weight: .semibold))
+                        Group {
+                            if didCopy {
+                                CopySuccessIconView()
+                            } else {
+                                CopyIconView()
+                            }
+                        }
+                        .frame(width: 12, height: 12)
+
                         Text(didCopy ? AppLocalization.localizedString("Copied") : AppLocalization.localizedString("Copy"))
                             .font(.system(size: 10, weight: .semibold))
                     }

--- a/Voxt/Windows/WaveformIconViews.swift
+++ b/Voxt/Windows/WaveformIconViews.swift
@@ -298,31 +298,35 @@ struct ModelInitializingIconView: View {
 }
 
 struct CopyIconView: View {
+    var color: Color = .white
+
     var body: some View {
         ZStack {
             SVGPathShape(pathData: WaveformIconPathData.copyFront)
-                .fill(.white.opacity(0.4))
+                .fill(color.opacity(0.4))
 
             SVGPathShape(pathData: WaveformIconPathData.copyBack)
-                .fill(.white)
+                .fill(color)
 
             SVGPathShape(pathData: WaveformIconPathData.copyFold)
-                .fill(.white)
+                .fill(color)
         }
     }
 }
 
 struct CopySuccessIconView: View {
+    var color: Color = .white
+
     var body: some View {
         ZStack {
             SVGPathShape(pathData: WaveformIconPathData.copyFront)
-                .fill(.white)
+                .fill(color)
 
             SVGPathShape(pathData: WaveformIconPathData.copySuccessBack)
-                .fill(.white)
+                .fill(color)
 
             SVGPathShape(pathData: WaveformIconPathData.copySuccessFold)
-                .fill(.white)
+                .fill(color)
         }
     }
 }

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -542,6 +542,8 @@
 "Browser URL read test failed." = "Browser URL read test failed.";
 "History Cleanup" = "History Cleanup";
 "Retention" = "Retention";
+"Retention Count" = "Retention Count";
+"Unlimited" = "Unlimited";
 "1 Week" = "1 Week";
 "1 Year" = "1 Year";
 "3 Months" = "3 Months";
@@ -2241,6 +2243,9 @@
 "This model is unavailable because the sherpa-onnx runtime is not included in this build." = "This model is unavailable because the sherpa-onnx runtime is not included in this build.";
 "Uninstalled %@." = "Uninstalled %@.";
 "Uninstall failed: %@" = "Uninstall failed: %@";
+"Model download succeeded" = "Model download succeeded";
+"Model download failed" = "Model download failed";
+"%@ downloaded successfully." = "%@ downloaded successfully.";
 "Endpoint must be a valid HTTP or HTTPS URL." = "Endpoint must be a valid HTTP or HTTPS URL.";
 "Endpoint must be a valid HTTP, HTTPS, WS, or WSS URL." = "Endpoint must be a valid HTTP, HTTPS, WS, or WSS URL.";
 "Endpoint must not contain a username or password." = "Endpoint must not contain a username or password.";
@@ -2258,9 +2263,16 @@
 "Upload File" = "Upload File";
 "Upload a meeting audio or video file" = "Upload a meeting audio or video file";
 "Click to choose a meeting recording" = "Click to choose a meeting recording";
+"Click to choose or drag in a meeting recording" = "Click to choose or drag in a meeting recording";
+"Drop to analyze this recording" = "Drop to analyze this recording";
+"Unsupported file type. Drop an audio or video recording instead." = "Unsupported file type. Drop an audio or video recording instead.";
+"Meeting file analysis is already in progress." = "Meeting file analysis is already in progress.";
 "Supports MP3, MP4, M4A, WAV, AAC, MOV, and other common audio or video formats." = "Supports MP3, MP4, M4A, WAV, AAC, MOV, and other common audio or video formats.";
 "Analysis complete. Opening Meeting Details…" = "Analysis complete. Opening Meeting Details…";
 "File analysis failed" = "File analysis failed";
+"File conversion succeeded" = "File conversion succeeded";
+"File conversion failed" = "File conversion failed";
+"%@ has been converted successfully." = "%@ has been converted successfully.";
 "Preparing audio…" = "Preparing audio…";
 "Transcribing meeting…" = "Transcribing meeting…";
 "Identifying speakers…" = "Identifying speakers…";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Browser URL read test failed." = "ブラウザ URL 読み取りテストに失敗しました。";
 "History Cleanup" = "履歴の自動削除";
 "Retention" = "保持期間";
+"Retention Count" = "保持件数";
+"Unlimited" = "無制限";
 "1 Week" = "1週間";
 "1 Year" = "1年";
 "3 Months" = "3か月";
@@ -2236,6 +2238,9 @@
 "This model is unavailable because the sherpa-onnx runtime is not included in this build." = "このビルドには sherpa-onnx ランタイムが含まれていないため、このモデルは利用できません。";
 "Uninstalled %@." = "%@ をアンインストールしました。";
 "Uninstall failed: %@" = "アンインストールに失敗しました: %@";
+"Model download succeeded" = "モデルのダウンロードが完了しました";
+"Model download failed" = "モデルのダウンロードに失敗しました";
+"%@ downloaded successfully." = "%@ のダウンロードが完了しました。";
 "Endpoint must be a valid HTTP or HTTPS URL." = "エンドポイントには有効な HTTP または HTTPS URL を指定してください。";
 "Endpoint must be a valid HTTP, HTTPS, WS, or WSS URL." = "エンドポイントには有効な HTTP、HTTPS、WS、または WSS URL を指定してください。";
 "Endpoint must not contain a username or password." = "エンドポイントにユーザー名やパスワードを含めることはできません。";
@@ -2253,9 +2258,16 @@
 "Upload File" = "ファイルをアップロード";
 "Upload a meeting audio or video file" = "会議の音声または動画ファイルをアップロード";
 "Click to choose a meeting recording" = "クリックして会議録画を選択";
+"Click to choose or drag in a meeting recording" = "クリックして選択するか、会議録画をドラッグして追加";
+"Drop to analyze this recording" = "ドロップしてこの録画を分析";
+"Unsupported file type. Drop an audio or video recording instead." = "このファイル形式はサポートされていません。音声または動画の録画をドロップしてください。";
+"Meeting file analysis is already in progress." = "会議ファイルの分析はすでに進行中です。";
 "Supports MP3, MP4, M4A, WAV, AAC, MOV, and other common audio or video formats." = "MP3、MP4、M4A、WAV、AAC、MOV など、一般的な音声・動画形式に対応しています。";
 "Analysis complete. Opening Meeting Details…" = "分析が完了しました。会議の詳細を開いています…";
 "File analysis failed" = "ファイルの分析に失敗しました";
+"File conversion succeeded" = "ファイル変換が完了しました";
+"File conversion failed" = "ファイル変換に失敗しました";
+"%@ has been converted successfully." = "%@ の変換が完了しました。";
 "Preparing audio…" = "音声を準備しています…";
 "Transcribing meeting…" = "会議を文字起こししています…";
 "Identifying speakers…" = "話者を識別しています…";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -542,6 +542,8 @@
 "Browser URL read test failed." = "浏览器 URL 读取测试失败。";
 "History Cleanup" = "历史记录清理";
 "Retention" = "保留时长";
+"Retention Count" = "保留条数";
+"Unlimited" = "不限制";
 "1 Week" = "一周";
 "1 Year" = "一年";
 "3 Months" = "三个月";
@@ -2241,6 +2243,9 @@
 "This model is unavailable because the sherpa-onnx runtime is not included in this build." = "此版本未包含 sherpa-onnx 运行时，因此该模型不可用。";
 "Uninstalled %@." = "已卸载 %@。";
 "Uninstall failed: %@" = "卸载失败：%@";
+"Model download succeeded" = "模型下载成功";
+"Model download failed" = "模型下载失败";
+"%@ downloaded successfully." = "%@ 下载成功。";
 "Endpoint must be a valid HTTP or HTTPS URL." = "端点必须是有效的 HTTP 或 HTTPS URL。";
 "Endpoint must be a valid HTTP, HTTPS, WS, or WSS URL." = "端点必须是有效的 HTTP、HTTPS、WS 或 WSS URL。";
 "Endpoint must not contain a username or password." = "端点中不能包含用户名或密码。";
@@ -2258,9 +2263,16 @@
 "Upload File" = "上传文件";
 "Upload a meeting audio or video file" = "上传会议音频或视频文件";
 "Click to choose a meeting recording" = "点击选择会议录制";
+"Click to choose or drag in a meeting recording" = "点击选择或拖入会议录制";
+"Drop to analyze this recording" = "松开以分析此录制";
+"Unsupported file type. Drop an audio or video recording instead." = "不支持该文件类型，请拖入音频或视频录制文件。";
+"Meeting file analysis is already in progress." = "会议文件分析正在进行中。";
 "Supports MP3, MP4, M4A, WAV, AAC, MOV, and other common audio or video formats." = "支持 MP3、MP4、M4A、WAV、AAC、MOV 及其他常见音视频格式。";
 "Analysis complete. Opening Meeting Details…" = "分析完成，正在打开会议详情…";
 "File analysis failed" = "文件分析失败";
+"File conversion succeeded" = "文件转换成功";
+"File conversion failed" = "文件转换失败";
+"%@ has been converted successfully." = "%@ 已转换成功。";
 "Preparing audio…" = "正在准备音频…";
 "Transcribing meeting…" = "正在转写会议…";
 "Identifying speakers…" = "正在识别说话人…";

--- a/VoxtTests/LocalizationResourcesTests.swift
+++ b/VoxtTests/LocalizationResourcesTests.swift
@@ -267,9 +267,27 @@ final class LocalizationResourcesTests: XCTestCase {
 
     func testHistorySettingsToggleLabelsAreLocalized() {
         XCTAssertEqual(AppLocalization.localizedString("History Cleanup", localeIdentifier: "zh-Hans"), "历史记录清理")
+        XCTAssertEqual(AppLocalization.localizedString("Retention Count", localeIdentifier: "zh-Hans"), "保留条数")
+        XCTAssertEqual(AppLocalization.localizedString("Unlimited", localeIdentifier: "zh-Hans"), "不限制")
         XCTAssertEqual(AppLocalization.localizedString("Save history audio", localeIdentifier: "zh-Hans"), "保存历史音频")
         XCTAssertEqual(AppLocalization.localizedString("History Cleanup", localeIdentifier: "ja"), "履歴の自動削除")
+        XCTAssertEqual(AppLocalization.localizedString("Retention Count", localeIdentifier: "ja"), "保持件数")
+        XCTAssertEqual(AppLocalization.localizedString("Unlimited", localeIdentifier: "ja"), "無制限")
         XCTAssertEqual(AppLocalization.localizedString("Save history audio", localeIdentifier: "ja"), "履歴音声を保存")
+    }
+
+    func testMeetingFileConversionNotificationLabelsAreLocalized() {
+        XCTAssertEqual(AppLocalization.localizedString("File conversion succeeded", localeIdentifier: "zh-Hans"), "文件转换成功")
+        XCTAssertEqual(AppLocalization.localizedString("File conversion failed", localeIdentifier: "zh-Hans"), "文件转换失败")
+        XCTAssertEqual(AppLocalization.localizedString("File conversion succeeded", localeIdentifier: "ja"), "ファイル変換が完了しました")
+        XCTAssertEqual(AppLocalization.localizedString("File conversion failed", localeIdentifier: "ja"), "ファイル変換に失敗しました")
+    }
+
+    func testModelDownloadNotificationLabelsAreLocalized() {
+        XCTAssertEqual(AppLocalization.localizedString("Model download succeeded", localeIdentifier: "zh-Hans"), "模型下载成功")
+        XCTAssertEqual(AppLocalization.localizedString("Model download failed", localeIdentifier: "zh-Hans"), "模型下载失败")
+        XCTAssertEqual(AppLocalization.localizedString("Model download succeeded", localeIdentifier: "ja"), "モデルのダウンロードが完了しました")
+        XCTAssertEqual(AppLocalization.localizedString("Model download failed", localeIdentifier: "ja"), "モデルのダウンロードに失敗しました")
     }
 
     func testCodexConfigurationTextIsLocalizedInSupportedLanguages() {

--- a/VoxtTests/MeetingHistoryDurabilityTests.swift
+++ b/VoxtTests/MeetingHistoryDurabilityTests.swift
@@ -118,6 +118,13 @@ private final class FailingMeetingHistoryRepository: HistoryRepositoryProtocol, 
     ) throws -> [TranscriptionHistoryEntry] {
         try base.deleteEntries(olderThan: cutoff, kinds: kinds)
     }
+
+    func deleteEntries(
+        keepingNewest count: Int,
+        kind: TranscriptionHistoryKind
+    ) throws -> [TranscriptionHistoryEntry] {
+        try base.deleteEntries(keepingNewest: count, kind: kind)
+    }
 }
 
 private enum MeetingHistoryDurabilityTestError: Error {

--- a/VoxtTests/MeetingImportedAudioFileTests.swift
+++ b/VoxtTests/MeetingImportedAudioFileTests.swift
@@ -6,6 +6,30 @@ import XCTest
 
 @MainActor
 final class MeetingImportedAudioFileTests: XCTestCase {
+    func testImportSupportAcceptsCommonAudioAndVideoExtensions() {
+        XCTAssertTrue(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/demo.mp3")))
+        XCTAssertTrue(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/demo.m4a")))
+        XCTAssertTrue(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/demo.wav")))
+        XCTAssertTrue(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/demo.mp4")))
+        XCTAssertTrue(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/demo.mov")))
+        XCTAssertFalse(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/notes.txt")))
+        XCTAssertFalse(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/slides.pdf")))
+        XCTAssertFalse(MeetingFileImportSupport.isSupportedImportFile(at: URL(fileURLWithPath: "/tmp/archive.zip")))
+    }
+
+    func testImportSupportParsesDroppedFileURLItems() {
+        let fileURL = URL(fileURLWithPath: "/tmp/meeting-demo.m4a")
+        // Keep the provider URL object intact (no standardizedFileURL) so sandbox
+        // security scope from Finder drops is not stripped.
+        let fromURL = MeetingFileImportSupport.fileURL(fromDropItem: fileURL as NSURL)
+        XCTAssertEqual(fromURL, fileURL)
+        XCTAssertEqual(fromURL?.path, fileURL.path)
+
+        let fromData = MeetingFileImportSupport.fileURL(fromDropItem: fileURL.dataRepresentation)
+        XCTAssertEqual(fromData?.path, fileURL.path)
+        XCTAssertNil(MeetingFileImportSupport.fileURL(fromDropItem: nil))
+    }
+
     func testAnalysisProgressMapsStageProgressToMonotonicOverallProgress() {
         let samples = [
             MeetingFileAnalysisProgress(stage: .preparing, stageFraction: 0),

--- a/VoxtTests/MeetingLiveSessionSupportTests.swift
+++ b/VoxtTests/MeetingLiveSessionSupportTests.swift
@@ -228,6 +228,29 @@ final class MeetingLiveSessionSupportTests: XCTestCase {
         XCTAssertEqual(mapped[0].endSeconds ?? -1, 1.5, accuracy: 0.0001)
     }
 
+    func testStructuredLiveFinalizationReusesInFlightSegmentIDForFirstItem() {
+        let inFlightID = UUID()
+        let mapped = MeetingNativeLiveStructuredFinalization.meetingSegments(
+            from: [
+                STTTranscriptSegment(text: "", startTime: 0.0, endTime: 0.1),
+                STTTranscriptSegment(text: "first", startTime: 12.0, endTime: 13.0),
+                STTTranscriptSegment(text: "second", startTime: 13.2, endTime: 14.0),
+            ],
+            timingGranularity: .sentence,
+            modelFamily: .nemotronASR,
+            timelineOffsetSeconds: 0,
+            speaker: .me,
+            audioSource: .microphone,
+            replacingSegmentID: inFlightID
+        )
+
+        XCTAssertEqual(mapped.count, 2)
+        XCTAssertEqual(mapped[0].id, inFlightID)
+        XCTAssertEqual(mapped[0].text, "first")
+        XCTAssertNotEqual(mapped[1].id, inFlightID)
+        XCTAssertEqual(mapped[1].text, "second")
+    }
+
     func testTranscriptStateSubtractsAllPriorFrozenText() {
         var state = MeetingLiveTranscriptState()
 

--- a/VoxtTests/MeetingTranscriptAssemblyTests.swift
+++ b/VoxtTests/MeetingTranscriptAssemblyTests.swift
@@ -32,6 +32,82 @@ final class MeetingTranscriptAssemblyTests: XCTestCase {
         XCTAssertEqual(finalResult.finalizedSegmentID, id)
     }
 
+    func testStructuredEndedFinalsReplaceInFlightPartialWithoutDuplicatingText() {
+        let inFlightID = UUID()
+        let partial = MeetingTranscriptSegment(
+            id: inFlightID,
+            speaker: .me,
+            audioSource: .microphone,
+            startSeconds: 12.0,
+            endSeconds: 13.5,
+            text: "呃，现在看起来。",
+            preventsAdjacentMerge: true
+        )
+        // Mimic MeetingNativeLiveStructuredFinalization: first final reuses the
+        // in-flight partial ID; additional structured items get fresh IDs.
+        let structured = [
+            MeetingTranscriptSegment(
+                id: inFlightID,
+                speaker: .me,
+                audioSource: .microphone,
+                startSeconds: 12.1,
+                endSeconds: 13.4,
+                text: "呃，现在看起来。",
+                preventsAdjacentMerge: true
+            ),
+            MeetingTranscriptSegment(
+                id: UUID(),
+                speaker: .me,
+                audioSource: .microphone,
+                startSeconds: 15.0,
+                endSeconds: 16.2,
+                text: "会出现重复的问题",
+                preventsAdjacentMerge: true
+            ),
+        ]
+
+        var segments = MeetingTranscriptAssembler.apply(.partial(partial), to: []).segments
+        for item in structured {
+            segments = MeetingTranscriptAssembler.apply(.final(item), to: segments).segments
+        }
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].id, inFlightID)
+        XCTAssertEqual(segments[0].text, "呃，现在看起来。")
+        XCTAssertEqual(segments[0].startSeconds, 12.1, accuracy: 0.0001)
+        XCTAssertEqual(segments[1].text, "会出现重复的问题")
+        XCTAssertEqual(
+            segments.filter { $0.text == "呃，现在看起来。" }.count,
+            1,
+            "In-flight partial must be replaced, not left beside structured finals"
+        )
+    }
+
+    func testFinalUpsertAdoptsIncomingStartSeconds() {
+        let id = UUID()
+        let partial = MeetingTranscriptSegment(
+            id: id,
+            speaker: .me,
+            startSeconds: 10.0,
+            endSeconds: 11.0,
+            text: "hello"
+        )
+        let final = MeetingTranscriptSegment(
+            id: id,
+            speaker: .me,
+            startSeconds: 10.4,
+            endSeconds: 11.2,
+            text: "hello world"
+        )
+
+        let afterPartial = MeetingTranscriptAssembler.apply(.partial(partial), to: [])
+        let afterFinal = MeetingTranscriptAssembler.apply(.final(final), to: afterPartial.segments)
+
+        XCTAssertEqual(afterFinal.segments.count, 1)
+        XCTAssertEqual(afterFinal.segments[0].startSeconds, 10.4, accuracy: 0.0001)
+        XCTAssertEqual(afterFinal.segments[0].endSeconds ?? -1, 11.2, accuracy: 0.0001)
+    }
+
     func testFinalSegmentsMergeWithinTwoSecondsForSameSpeaker() {
         let first = MeetingTranscriptSegment(
             id: UUID(),

--- a/VoxtTests/MeetingTranscriptVirtualListTests.swift
+++ b/VoxtTests/MeetingTranscriptVirtualListTests.swift
@@ -1,0 +1,380 @@
+// MeetingTranscriptVirtualListTests.swift
+// Tests for meeting detail virtual transcript rows and height cache.
+
+import XCTest
+@testable import Voxt
+
+final class MeetingTranscriptVirtualListTests: XCTestCase {
+    func testDisplayedSegmentsFiltersByTextAndTranslation() {
+        let segments = [
+            MeetingTranscriptSegment(
+                speaker: .me,
+                startSeconds: 0,
+                endSeconds: 2,
+                text: "hello world"
+            ),
+            MeetingTranscriptSegment(
+                id: UUID(),
+                speaker: .them,
+                startSeconds: 2,
+                endSeconds: 4,
+                text: "unrelated",
+                translatedText: "bonjour"
+            ),
+        ]
+
+        let filtered = MeetingTranscriptListSupport.displayedSegments(
+            from: segments,
+            searchQuery: "bonjour",
+            speakerTitle: { $0.speaker.displayTitle }
+        )
+
+        XCTAssertEqual(filtered.count, 1)
+        XCTAssertEqual(filtered.first?.translatedText, "bonjour")
+    }
+
+    func testSpeakerMarkRowsFlattenHeadersAndSegments() {
+        let first = MeetingTranscriptSegment(
+            speaker: .me,
+            startSeconds: 0,
+            endSeconds: 1,
+            text: "one"
+        )
+        let second = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 2,
+            endSeconds: 3,
+            text: "two"
+        )
+        let groups = MeetingTranscriptListSupport.speakerGroups(
+            from: [first, second],
+            titleForSegment: { $0.speaker.displayTitle }
+        )
+        let rows = MeetingTranscriptListSupport.speakerMarkRows(
+            from: groups,
+            activeSegmentID: second.id,
+            showsTranslation: false,
+            searchQuery: ""
+        )
+
+        XCTAssertEqual(rows.count, 4)
+        guard case .speakerHeader = rows[0] else {
+            return XCTFail("Expected speaker header at 0")
+        }
+        guard case .segment(let firstPresentation) = rows[1] else {
+            return XCTFail("Expected segment at 1")
+        }
+        XCTAssertEqual(firstPresentation.segment.id, groups[0].segments[0].id)
+        guard case .speakerHeader = rows[2] else {
+            return XCTFail("Expected speaker header at 2")
+        }
+        guard case .segment(let secondPresentation) = rows[3] else {
+            return XCTFail("Expected segment at 3")
+        }
+        XCTAssertTrue(secondPresentation.isActive)
+        XCTAssertEqual(secondPresentation.segment.id, second.id)
+    }
+
+    func testTimelineRowsMarkActiveAndSearchMatch() {
+        let segment = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 5,
+            endSeconds: 8,
+            text: "release checklist"
+        )
+        let rows = MeetingTranscriptListSupport.timelineRows(
+            from: [segment],
+            activeSegmentID: segment.id,
+            showsTranslation: true,
+            searchQuery: "checklist",
+            speakerTitle: { _ in "Them" }
+        )
+
+        XCTAssertEqual(rows.count, 1)
+        guard case .segment(let presentation) = rows[0] else {
+            return XCTFail("Expected segment row")
+        }
+        XCTAssertTrue(presentation.isActive)
+        XCTAssertTrue(presentation.isSearchMatch)
+        XCTAssertTrue(presentation.showsTranslation)
+    }
+
+    func testContentChangedIndexesDetectsActiveToggleOnly() {
+        let segment = MeetingTranscriptSegment(
+            speaker: .me,
+            startSeconds: 0,
+            endSeconds: 1,
+            text: "alpha"
+        )
+        let inactive = MeetingTranscriptListSupport.timelineRows(
+            from: [segment],
+            activeSegmentID: nil,
+            showsTranslation: false,
+            searchQuery: "",
+            speakerTitle: { _ in "Me" }
+        )
+        let active = MeetingTranscriptListSupport.timelineRows(
+            from: [segment],
+            activeSegmentID: segment.id,
+            showsTranslation: false,
+            searchQuery: "",
+            speakerTitle: { _ in "Me" }
+        )
+
+        let changed = MeetingTranscriptListSupport.contentChangedIndexes(from: inactive, to: active)
+        XCTAssertEqual(changed, IndexSet(integer: 0))
+    }
+
+    func testContentChangedIndexesReturnsNilOnIdentityChange() {
+        let first = MeetingTranscriptSegment(
+            speaker: .me,
+            startSeconds: 0,
+            endSeconds: 1,
+            text: "a"
+        )
+        let second = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 1,
+            endSeconds: 2,
+            text: "b"
+        )
+        let oldRows = MeetingTranscriptListSupport.timelineRows(
+            from: [first],
+            activeSegmentID: nil,
+            showsTranslation: false,
+            searchQuery: "",
+            speakerTitle: { $0.speaker.displayTitle }
+        )
+        let newRows = MeetingTranscriptListSupport.timelineRows(
+            from: [second],
+            activeSegmentID: nil,
+            showsTranslation: false,
+            searchQuery: "",
+            speakerTitle: { $0.speaker.displayTitle }
+        )
+
+        XCTAssertNil(MeetingTranscriptListSupport.contentChangedIndexes(from: oldRows, to: newRows))
+        XCTAssertFalse(MeetingTranscriptListSupport.isSuffixAppend(from: oldRows, to: newRows))
+    }
+
+    func testSuffixAppendDetection() {
+        let first = MeetingTranscriptSegment(
+            speaker: .me,
+            startSeconds: 0,
+            endSeconds: 1,
+            text: "a"
+        )
+        let second = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 1,
+            endSeconds: 2,
+            text: "b"
+        )
+        let oldRows = MeetingTranscriptListSupport.timelineRows(
+            from: [first],
+            activeSegmentID: nil,
+            showsTranslation: false,
+            searchQuery: "",
+            speakerTitle: { $0.speaker.displayTitle }
+        )
+        let newRows = MeetingTranscriptListSupport.timelineRows(
+            from: [first, second],
+            activeSegmentID: nil,
+            showsTranslation: false,
+            searchQuery: "",
+            speakerTitle: { $0.speaker.displayTitle }
+        )
+
+        XCTAssertTrue(MeetingTranscriptListSupport.isSuffixAppend(from: oldRows, to: newRows))
+        XCTAssertTrue(MeetingTranscriptListSupport.isSuffixAppend(from: [], to: newRows))
+    }
+
+    func testHeightCacheStableForSameContentAndInvalidateOnTranslation() {
+        var cache = MeetingTranscriptRowHeightCache()
+        let segment = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 0,
+            endSeconds: 3,
+            text: String(repeating: "hello ", count: 40),
+            translatedText: String(repeating: "bonjour ", count: 40)
+        )
+        let row = MeetingTranscriptVirtualRow.segment(
+            MeetingTranscriptSegmentPresentation(
+                segment: segment,
+                speakerTitle: "Them",
+                isActive: false,
+                showsTranslation: false,
+                isSearchMatch: false
+            )
+        )
+
+        let withoutTranslation = cache.cachedHeight(for: row, width: 420, showsTranslation: false)
+        let again = cache.cachedHeight(for: row, width: 420, showsTranslation: false)
+        XCTAssertEqual(withoutTranslation, again)
+
+        let withTranslation = MeetingTranscriptRowHeightCache.estimate(
+            for: row,
+            width: 420,
+            showsTranslation: true
+        )
+        XCTAssertGreaterThan(withTranslation, withoutTranslation)
+
+        let taller = ceil(withoutTranslation + 12)
+        XCTAssertTrue(
+            cache.storeMeasuredHeight(taller, for: row, width: 420, showsTranslation: false)
+        )
+        XCTAssertEqual(cache.height(for: row, width: 420, showsTranslation: false), taller)
+
+        // On-screen GeometryReader reports may shrink overestimated rows.
+        let refined = ceil(withoutTranslation - 8)
+        XCTAssertTrue(
+            cache.storeReportedHeight(refined, for: row, width: 420, showsTranslation: false)
+        )
+        XCTAssertEqual(cache.height(for: row, width: 420, showsTranslation: false), refined)
+        XCTAssertTrue(cache.hasReportedHeight(for: row, width: 420, showsTranslation: false))
+
+        // Unreliable widths must not poison the cache.
+        XCTAssertFalse(
+            cache.storeMeasuredHeight(999, for: row, width: 40, showsTranslation: false)
+        )
+
+        cache.invalidateWidth(420)
+        XCTAssertFalse(cache.hasMeasuredHeight(for: row, width: 420, showsTranslation: false))
+        XCTAssertEqual(
+            cache.height(for: row, width: 420, showsTranslation: false),
+            MeetingTranscriptRowHeightCache.estimate(for: row, width: 420, showsTranslation: false)
+        )
+    }
+
+    func testMultiLineSegmentEstimateExceedsSingleLine() {
+        let short = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 0,
+            endSeconds: 1,
+            text: "Short"
+        )
+        let long = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 1,
+            endSeconds: 2,
+            text: String(repeating: "This is a longer transcript line that should wrap. ", count: 6)
+        )
+        let shortHeight = MeetingTranscriptRowHeightCache.estimateSegmentHeight(
+            text: short.text,
+            translatedText: nil,
+            isTranslationPending: false,
+            width: 360,
+            showsTranslation: false
+        )
+        let longHeight = MeetingTranscriptRowHeightCache.estimateSegmentHeight(
+            text: long.text,
+            translatedText: nil,
+            isTranslationPending: false,
+            width: 360,
+            showsTranslation: false
+        )
+        XCTAssertGreaterThan(longHeight, shortHeight + 20)
+    }
+
+    func testNarrowWidthEstimateIsTallerThanWideWidth() {
+        let segment = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 0,
+            endSeconds: 3,
+            text: String(repeating: "hello world ", count: 24)
+        )
+        let row = MeetingTranscriptVirtualRow.segment(
+            MeetingTranscriptSegmentPresentation(
+                segment: segment,
+                speakerTitle: "Them",
+                isActive: false,
+                showsTranslation: false,
+                isSearchMatch: false
+            )
+        )
+
+        let narrow = MeetingTranscriptRowHeightCache.estimate(
+            for: row,
+            width: 180,
+            showsTranslation: false
+        )
+        let wide = MeetingTranscriptRowHeightCache.estimate(
+            for: row,
+            width: 520,
+            showsTranslation: false
+        )
+        XCTAssertGreaterThan(narrow, wide)
+    }
+
+    func testSpeakerHeaderHeightIsCompact() {
+        let row = MeetingTranscriptVirtualRow.speakerHeader(id: "me", title: "Me", count: 3)
+        let height = MeetingTranscriptRowHeightCache.estimate(
+            for: row,
+            width: 400,
+            showsTranslation: false
+        )
+        XCTAssertEqual(height, 28)
+    }
+}
+
+@MainActor
+final class MeetingDetailTranscriptListCacheTests: XCTestCase {
+    func testViewModelCachesDisplayedSegmentsAndSpeakerGroups() {
+        let them = MeetingTranscriptSegment(
+            speaker: .them,
+            startSeconds: 1,
+            endSeconds: 2,
+            text: "agenda"
+        )
+        let me = MeetingTranscriptSegment(
+            speaker: .me,
+            startSeconds: 0,
+            endSeconds: 1,
+            text: "intro"
+        )
+        let viewModel = MeetingDetailViewModel(
+            title: "Meeting Details",
+            subtitle: "Today",
+            historyEntryID: UUID(),
+            initialSummary: nil,
+            initialSummaryChatMessages: [],
+            initialSummarySettings: MeetingSummarySettingsSnapshot(
+                autoGenerate: false,
+                promptTemplate: "prompt",
+                modelSelectionID: nil
+            ),
+            summaryModelOptions: [],
+            summarySettingsProvider: {
+                MeetingSummarySettingsSnapshot(
+                    autoGenerate: false,
+                    promptTemplate: "prompt",
+                    modelSelectionID: nil
+                )
+            },
+            summaryModelOptionsProvider: { [] },
+            segments: [me, them],
+            audioURL: nil,
+            translationHandler: { text, _ in
+                MeetingTranslationOperation(executionScope: .externalRequest) { text }
+            },
+            summaryStatusProvider: { _ in
+                MeetingSummaryProviderStatus(isAvailable: false, message: "Unavailable")
+            },
+            summaryGenerator: { _, _ in
+                throw NSError(domain: "test", code: 1)
+            },
+            summaryPersistence: { _, _ in nil },
+            summaryChatAnswerer: { _, _, _, _, _ in "" },
+            summaryChatPersistence: { _, _ in nil },
+            transcriptSegmentsPersistence: { _, _ in nil }
+        )
+
+        XCTAssertEqual(viewModel.displayedSegments.count, 2)
+        XCTAssertEqual(viewModel.speakerGroups.count, 2)
+
+        viewModel.setSearchQuery("agenda")
+        XCTAssertEqual(viewModel.displayedSegments.map(\.text), ["agenda"])
+        XCTAssertEqual(viewModel.speakerGroups.count, 1)
+        XCTAssertEqual(viewModel.displayedNewestSegmentID(), them.id)
+    }
+}

--- a/VoxtTests/SQLiteStorageRepositoryTests.swift
+++ b/VoxtTests/SQLiteStorageRepositoryTests.swift
@@ -360,6 +360,35 @@ final class SQLiteStorageRepositoryTests: XCTestCase {
         XCTAssertNotNil(try repository.entry(id: newTranscription.id))
     }
 
+    func testHistoryCountCleanupKeepsNewestPerKindAndPreservesMeetings() throws {
+        let database = try makeDatabase()
+        let repository = retain(HistoryRepository(database: database, legacyJSONURL: nil, migrateLegacyJSON: false))
+        let newest = makeHistoryEntry(text: "normal-2", createdAt: Date(timeIntervalSince1970: 3), kind: .normal)
+        let middle = makeHistoryEntry(text: "normal-1", createdAt: Date(timeIntervalSince1970: 2), kind: .normal)
+        let oldest = makeHistoryEntry(text: "normal-0", createdAt: Date(timeIntervalSince1970: 1), kind: .normal)
+        let translationNewest = makeHistoryEntry(text: "translation-1", createdAt: Date(timeIntervalSince1970: 5), kind: .translation)
+        let translationOldest = makeHistoryEntry(text: "translation-0", createdAt: Date(timeIntervalSince1970: 4), kind: .translation)
+        let meeting = makeHistoryEntry(text: "meeting", createdAt: Date(timeIntervalSince1970: 0), kind: .transcript)
+        try repository.replaceAll([
+            newest,
+            middle,
+            oldest,
+            translationNewest,
+            translationOldest,
+            meeting
+        ])
+
+        let removedNormal = try repository.deleteEntries(keepingNewest: 2, kind: .normal)
+        let removedTranslation = try repository.deleteEntries(keepingNewest: 1, kind: .translation)
+
+        XCTAssertEqual(Set(removedNormal.map(\.id)), Set([oldest.id]))
+        XCTAssertEqual(Set(removedTranslation.map(\.id)), Set([translationOldest.id]))
+        XCTAssertNotNil(try repository.entry(id: newest.id))
+        XCTAssertNotNil(try repository.entry(id: middle.id))
+        XCTAssertNotNil(try repository.entry(id: translationNewest.id))
+        XCTAssertNotNil(try repository.entry(id: meeting.id))
+    }
+
     func testHistoryReportMetricsUseDatabaseAggregates() throws {
         let database = try makeDatabase()
         let repository = retain(HistoryRepository(database: database, legacyJSONURL: nil, migrateLegacyJSON: false))

--- a/VoxtTests/TranscriptionHistoryStoreAsyncTests.swift
+++ b/VoxtTests/TranscriptionHistoryStoreAsyncTests.swift
@@ -43,8 +43,10 @@ final class TranscriptionHistoryStoreAsyncTests: XCTestCase {
         let defaults = UserDefaults.standard
         let cleanupEnabledKey = AppPreferenceKey.historyCleanupEnabled
         let retentionPeriodKey = AppPreferenceKey.historyRetentionPeriod
+        let retentionCountKey = AppPreferenceKey.historyRetentionCount
         let previousCleanupEnabled = defaults.object(forKey: cleanupEnabledKey)
         let previousRetentionPeriod = defaults.object(forKey: retentionPeriodKey)
+        let previousRetentionCount = defaults.object(forKey: retentionCountKey)
         defer {
             if let previousCleanupEnabled {
                 defaults.set(previousCleanupEnabled, forKey: cleanupEnabledKey)
@@ -56,10 +58,16 @@ final class TranscriptionHistoryStoreAsyncTests: XCTestCase {
             } else {
                 defaults.removeObject(forKey: retentionPeriodKey)
             }
+            if let previousRetentionCount {
+                defaults.set(previousRetentionCount, forKey: retentionCountKey)
+            } else {
+                defaults.removeObject(forKey: retentionCountKey)
+            }
         }
 
         defaults.set(true, forKey: cleanupEnabledKey)
         defaults.set(HistoryRetentionPeriod.oneDay.rawValue, forKey: retentionPeriodKey)
+        defaults.set(HistoryRetentionCount.unlimited.rawValue, forKey: retentionCountKey)
         let oldDate = Date().addingTimeInterval(-2 * 24 * 60 * 60)
         let transcription = makeEntry(index: 0, kind: .normal, createdAt: oldDate)
         let translation = makeEntry(index: 1, kind: .translation, createdAt: oldDate)
@@ -72,6 +80,77 @@ final class TranscriptionHistoryStoreAsyncTests: XCTestCase {
         XCTAssertNil(store.entry(id: translation.id))
         XCTAssertNil(store.entry(id: rewrite.id))
         XCTAssertNotNil(store.entry(id: meeting.id))
+        await drainMainQueue()
+    }
+
+    func testRetentionCountCleanupKeepsNewestPerKindAndPreservesMeetings() async throws {
+        let defaults = UserDefaults.standard
+        let cleanupEnabledKey = AppPreferenceKey.historyCleanupEnabled
+        let retentionPeriodKey = AppPreferenceKey.historyRetentionPeriod
+        let retentionCountKey = AppPreferenceKey.historyRetentionCount
+        let previousCleanupEnabled = defaults.object(forKey: cleanupEnabledKey)
+        let previousRetentionPeriod = defaults.object(forKey: retentionPeriodKey)
+        let previousRetentionCount = defaults.object(forKey: retentionCountKey)
+        defer {
+            if let previousCleanupEnabled {
+                defaults.set(previousCleanupEnabled, forKey: cleanupEnabledKey)
+            } else {
+                defaults.removeObject(forKey: cleanupEnabledKey)
+            }
+            if let previousRetentionPeriod {
+                defaults.set(previousRetentionPeriod, forKey: retentionPeriodKey)
+            } else {
+                defaults.removeObject(forKey: retentionPeriodKey)
+            }
+            if let previousRetentionCount {
+                defaults.set(previousRetentionCount, forKey: retentionCountKey)
+            } else {
+                defaults.removeObject(forKey: retentionCountKey)
+            }
+        }
+
+        defaults.set(true, forKey: cleanupEnabledKey)
+        defaults.set(HistoryRetentionPeriod.forever.rawValue, forKey: retentionPeriodKey)
+        defaults.set(HistoryRetentionCount.fifty.rawValue, forKey: retentionCountKey)
+
+        let now = Date()
+        var entries: [TranscriptionHistoryEntry] = []
+        var newestNormalIDs: [UUID] = []
+        var newestTranslationIDs: [UUID] = []
+        var newestRewriteIDs: [UUID] = []
+
+        for index in 0..<55 {
+            let createdAt = now.addingTimeInterval(TimeInterval(-index))
+            let normal = makeEntry(index: index, kind: .normal, createdAt: createdAt)
+            let translation = makeEntry(index: 1000 + index, kind: .translation, createdAt: createdAt)
+            let rewrite = makeEntry(index: 2000 + index, kind: .rewrite, createdAt: createdAt)
+            entries.append(contentsOf: [normal, translation, rewrite])
+            if index < 50 {
+                newestNormalIDs.append(normal.id)
+                newestTranslationIDs.append(translation.id)
+                newestRewriteIDs.append(rewrite.id)
+            }
+        }
+
+        let meeting = makeEntry(index: 9999, kind: .transcript, createdAt: now.addingTimeInterval(-10_000))
+        entries.append(meeting)
+
+        let repository = try makeFixture(entries: entries)
+        let store = TranscriptionHistoryStore(repository: repository)
+
+        for id in newestNormalIDs {
+            XCTAssertNotNil(store.entry(id: id))
+        }
+        for id in newestTranslationIDs {
+            XCTAssertNotNil(store.entry(id: id))
+        }
+        for id in newestRewriteIDs {
+            XCTAssertNotNil(store.entry(id: id))
+        }
+        XCTAssertEqual(try repository.entryCount(kind: .normal, query: ""), 50)
+        XCTAssertEqual(try repository.entryCount(kind: .translation, query: ""), 50)
+        XCTAssertEqual(try repository.entryCount(kind: .rewrite, query: ""), 50)
+        XCTAssertNotNil(try repository.entry(id: meeting.id))
         await drainMainQueue()
     }
 
@@ -302,6 +381,13 @@ private final class BlockingHistoryRepository: HistoryRepositoryProtocol, @unche
         kinds: Set<TranscriptionHistoryKind>
     ) throws -> [TranscriptionHistoryEntry] {
         try base.deleteEntries(olderThan: cutoff, kinds: kinds)
+    }
+
+    func deleteEntries(
+        keepingNewest count: Int,
+        kind: TranscriptionHistoryKind
+    ) throws -> [TranscriptionHistoryEntry] {
+        try base.deleteEntries(keepingNewest: count, kind: kind)
     }
 }
 

--- a/docs/MeetingDetailVirtualList.zh-CN.md
+++ b/docs/MeetingDetailVirtualList.zh-CN.md
@@ -1,0 +1,46 @@
+# 会议详情左侧转录列表优化
+
+日期：2026-08-02  
+对齐：[MeetingLocalPerformanceSafetyOptimizationPlan.zh-CN.md](MeetingLocalPerformanceSafetyOptimizationPlan.zh-CN.md) §8.3
+
+## 目标
+
+- 降低长会议详情页滚动 / 播放跟播时的主线程压力。
+- 时间轴与发言标记列表保持**稳定、均匀**的卡片间距与正确多行高度。
+
+## 最终实现
+
+### 保留的性能手段
+
+- 进度条继续订阅 `currentTime`；列表只在 `activeSegmentID` 变化时无动画滚动。
+- `displayedSegments` / `speakerGroups` 缓存在 `MeetingDetailViewModel`。
+- 列表包在 `Equatable` 子视图中，降低纯进度刷新带来的无效更新。
+- 行模型扁平化为 `MeetingTranscriptVirtualRow`（Timeline / Speaker Marks 共用）。
+
+### 列表承载
+
+使用 SwiftUI `ScrollView` + `LazyVStack`（见 `MeetingTranscriptVirtualList`）。
+
+曾尝试 `NSTableView` + `NSHostingView`（手动行高 / GeometryReader 回写 / `usesAutomaticRowHeights`）。在换行 `Text` 场景下，AppKit 测得的行高经常大于真实卡片高度，表现为：
+
+- 多行卡片下方空白偏大
+- 间距忽大忽小
+- 卡片内部上下 padding 视觉不对称
+
+因此放弃 AppKit 动态行高路径，改回 SwiftUI 懒加载列表以保证视觉正确。长列表的主要 CPU 放大器（播放 0.15s 整表跟滚、body 内反复 group/filter）已在上层消掉。
+
+## 关键文件
+
+| 路径 | 角色 |
+|------|------|
+| `Voxt/Windows/MeetingDetail/MeetingTranscriptVirtualList.swift` | LazyVStack 列表 + scrollRequest |
+| `Voxt/Windows/MeetingDetail/MeetingTranscriptVirtualRows.swift` | 行模型 / flatten / diff 辅助 |
+| `Voxt/Windows/MeetingDetail/MeetingTranscriptRowHeightCache.swift` | 文本高度估算（测试与后续备用） |
+| `Voxt/Windows/MeetingDetail/MeetingDetailSegmentRow.swift` | 段行 / speaker header |
+| `Voxt/Windows/MeetingDetail/MeetingDetailViewModel.swift` | 列表缓存 |
+| `Voxt/Windows/MeetingDetail/MeetingDetailWindow.swift` | 接入与跟播 |
+
+## 验收
+
+- 单元：`VoxtTests/MeetingTranscriptVirtualListTests.swift`
+- 手动：时间轴 / 发言标记下多行与单行卡片间距一致；播放跟播不带动画抖动；开关翻译、搜索、侧栏折叠正常。


### PR DESCRIPTION
## Summary
- 会议详情转录改为 `ScrollView` + `LazyVStack` 虚拟列表，缓存筛选/发言分组，降低长会议播放跟播时的主线程压力，并支持段落复制与摘要文本选择。
- 历史设置新增按条数保留策略；会议文件支持拖放导入（保留沙盒 security scope）；模型下载与文件转换完成/失败通过系统通知提醒。
- 修复 MLX native live structured final 复用 in-flight partial ID，避免重复气泡；Final 可采用模型时间戳。

## Test plan
- [ ] 打开长会议详情：时间轴/发言标记滚动流畅，多行卡片间距稳定；播放跟播无动画抖动
- [ ] 搜索、翻译开关、侧栏折叠后列表显示正确；段落与摘要可复制
- [ ] 历史清理开启后设置保留条数，确认各类型（转写/翻译/改写）只保留最新 N 条，会议记录不受影响
- [ ] 设置页拖入桌面/下载目录的音视频可成功分析；不支持类型有 toast 提示
- [ ] 首次下载模型或转换文件时授权通知，完成后前台也能看到横幅
- [ ] 运行相关单测：`MeetingTranscriptVirtualListTests`、`MeetingImportedAudioFileTests`、`TranscriptionHistoryStoreAsyncTests`、`MeetingTranscriptAssemblyTests`


Made with [Cursor](https://cursor.com)