### PR TITLE
Add maximum recording duration safety guard

### DIFF
--- a/Voxt/App/Recording/RecordingCaptureFlow.swift
+++ b/Voxt/App/Recording/RecordingCaptureFlow.swift
@@ -397,6 +397,8 @@ extension AppDelegate {
             let monitorTask = self.silenceMonitorTask
             self.silenceMonitorTask?.cancel()
             self.silenceMonitorTask = nil
+            self.recordingMaximumDurationTask?.cancel()
+            self.recordingMaximumDurationTask = nil
             self.pauseLLMTask?.cancel()
             self.pauseLLMTask = nil
             await monitorTask?.value
@@ -452,6 +454,8 @@ extension AppDelegate {
     func cancelActiveRecordingTasks() {
         silenceMonitorTask?.cancel()
         silenceMonitorTask = nil
+        recordingMaximumDurationTask?.cancel()
+        recordingMaximumDurationTask = nil
         pauseLLMTask?.cancel()
         pauseLLMTask = nil
     }

--- a/Voxt/App/Recording/RecordingSessionFlow.swift
+++ b/Voxt/App/Recording/RecordingSessionFlow.swift
@@ -33,6 +33,8 @@ extension AppDelegate {
 
         silenceMonitorTask?.cancel()
         silenceMonitorTask = nil
+        recordingMaximumDurationTask?.cancel()
+        recordingMaximumDurationTask = nil
         pauseLLMTask?.cancel()
         pauseLLMTask = nil
         _ = cancelRecordingCaptureStartTask()
@@ -219,6 +221,7 @@ extension AppDelegate {
         }
 
         isSessionActive = true
+        startRecordingMaximumDurationGuard(sessionID: activeRecordingSessionID)
         let shouldEnableCommonStopKey = outputMode == .translation ||
             outputMode == .rewrite ||
             transcriptionHotkeyStartBehavior == .tap ||
@@ -320,6 +323,27 @@ extension AppDelegate {
             }
             VoxtLog.asr("Finish session executing now. displayMode=\(self.overlayState.displayMode)", verbose: true)
             self.executeSessionEndPipeline(for: finishingSessionID, trigger: "finish")
+        }
+    }
+
+    // Start a maximum-duration safety net that stops an active session automatically.
+    private func startRecordingMaximumDurationGuard(sessionID: UUID) {
+        recordingMaximumDurationTask?.cancel()
+        let maximumDuration = recordingMaximumDuration
+        recordingMaximumDurationTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: .seconds(maximumDuration))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            guard self.activeRecordingSessionID == sessionID else { return }
+            guard self.isSessionActive else { return }
+            VoxtLog.asrWarning(
+                "Recording reached the maximum duration (\(Int(maximumDuration))s) and was stopped automatically."
+            )
+            self.endRecording()
         }
     }
 }

--- a/Voxt/App/VoxtApp.swift
+++ b/Voxt/App/VoxtApp.swift
@@ -213,6 +213,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var isSessionActive = false
     var pendingSessionFinishTask: Task<Void, Never>?
     var silenceMonitorTask: Task<Void, Never>?
+    // Maximum-duration safety-net timer for recording sessions.
+    var recordingMaximumDurationTask: Task<Void, Never>?
     var pauseLLMTask: Task<Void, Never>?
     var pendingDictionaryHistoryScanTask: Task<Void, Never>?
     var pendingAutomaticDictionaryLearningTask: Task<Void, Never>?
@@ -245,6 +247,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var voiceEndCommandState = VoiceEndCommandState()
     let silenceAudioLevelThreshold: Float = 0.06
     let sessionFinishDelay: TimeInterval = 1.2
+    // Maximum duration of a single recording in seconds; the recording stops automatically when reached.
+    let recordingMaximumDuration: TimeInterval = 1800
     var recordingRequestedAt: Date?
     var recordingStartedAt: Date?
     var recordingStoppedAt: Date?
@@ -819,6 +823,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             inputDevicesRefreshTask,
             pendingSessionFinishTask,
             silenceMonitorTask,
+            recordingMaximumDurationTask,
             pauseLLMTask,
             pendingDictionaryHistoryScanTask,
             pendingAutomaticDictionaryLearningTask,
@@ -838,6 +843,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         inputDevicesRefreshTask = nil
         pendingSessionFinishTask = nil
         silenceMonitorTask = nil
+        recordingMaximumDurationTask = nil
         pauseLLMTask = nil
         pendingDictionaryHistoryScanTask = nil
         pendingAutomaticDictionaryLearningTask = nil


### PR DESCRIPTION
## Summary

Add a maximum-duration safety guard for active recording sessions so a recording cannot remain active indefinitely when the expected stop action is not triggered.

## Problem

When the dictation, translation, rewrite, or note recording control is used with the wrong interaction pattern, or when a stop event is not delivered, the session can remain active. In that state the app may continue holding the microphone and ASR-related resources, and system audio may remain muted until another cleanup path runs.

## Changes

- Start a 30-minute safety timer when a normal recording session becomes active.
- Automatically call `endRecording()` when the timer expires and the same session is still active.
- Use the session ID and active-session state to prevent a stale timer from stopping a later session.
- Cancel and clear the timer during normal stop, cancellation, residual-resource cleanup, failed-start cleanup, and application termination.

## Scope

This guard covers recording sessions routed through `beginRecording()`: dictation, translation, rewrite, and note sessions. It does not cover Meeting Notes, which uses the separate `MeetingSessionCoordinator` lifecycle, and it does not impose a timeout on post-recording transcription or LLM processing.

The existing normal stop and cancel behavior is unchanged; this is a safety fallback for sessions that do not reach those paths.

## Validation

- `git diff --check` passes.
- The change is limited to recording-session lifecycle state and timer cleanup.
- The timer is guarded by the active recording session ID to avoid cross-session effects.