### PR TITLE
Add Google Gemini live transcribe remote ASR

### DIFF
--- a/Voxt/Core/ASRHintSettings.swift
+++ b/Voxt/Core/ASRHintSettings.swift
@@ -13,6 +13,7 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
     case aliyunBailianASR
     case stepFunASR
     case xiaomiMiMoASR
+    case googleGeminiASR
 
     var id: String { rawValue }
 
@@ -36,6 +37,8 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
             return AppLocalization.localizedString("StepFun")
         case .xiaomiMiMoASR:
             return AppLocalization.localizedString("Xiaomi MiMo")
+        case .googleGeminiASR:
+            return AppLocalization.localizedString("Google Gemini")
         }
     }
 
@@ -43,7 +46,8 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .openAIWhisper, .glmASR:
             return true
-        case .dictation, .mlxAudio, .sherpaOnnx, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR:
+        case .dictation, .mlxAudio, .sherpaOnnx, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR,
+             .googleGeminiASR:
             return false
         }
     }
@@ -60,7 +64,8 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
             return AppPromptDefaults.text(for: .openAIASRHint)
         case .glmASR:
             return AppPromptDefaults.text(for: .glmASRHint)
-        case .mlxAudio, .sherpaOnnx, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR:
+        case .mlxAudio, .sherpaOnnx, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR,
+             .googleGeminiASR:
             return ""
         }
     }
@@ -85,6 +90,8 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
             return AppLocalization.localizedString("StepFun ASR uses language hints derived from your selected user languages.")
         case .xiaomiMiMoASR:
             return AppLocalization.localizedString("Xiaomi MiMo ASR uses auto, Chinese, or English language hints derived from your selected user language.")
+        case .googleGeminiASR:
+            return AppLocalization.localizedString("Gemini live transcribe auto-detects language and mid-sentence code-mixing. Contextual phrases and dictionary terms are sent as custom vocabulary.")
         }
     }
 
@@ -92,7 +99,8 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .dictation:
             return AppLocalization.localizedString("Dictation Settings")
-        case .mlxAudio, .sherpaOnnx, .openAIWhisper, .glmASR, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR:
+        case .mlxAudio, .sherpaOnnx, .openAIWhisper, .glmASR, .doubaoASR, .aliyunBailianASR, .stepFunASR,
+             .xiaomiMiMoASR, .googleGeminiASR:
             return AppLocalization.localizedString("Engine Hint Settings")
         }
     }
@@ -119,6 +127,8 @@ enum ASRHintTarget: String, CaseIterable, Codable, Identifiable {
                 return .stepFunASR
             case .xiaomiMiMoASR:
                 return .xiaomiMiMoASR
+            case .googleGeminiASR:
+                return .googleGeminiASR
             }
         }
     }
@@ -270,7 +280,8 @@ enum ASRHintSettingsStore {
             return .openAIASRHint
         case .glmASR:
             return .glmASRHint
-        case .dictation, .mlxAudio, .sherpaOnnx, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR:
+        case .dictation, .mlxAudio, .sherpaOnnx, .doubaoASR, .aliyunBailianASR, .stepFunASR, .xiaomiMiMoASR,
+             .googleGeminiASR:
             return .openAIASRHint
         }
     }

--- a/Voxt/Core/Models/RemoteModelConfiguration.swift
+++ b/Voxt/Core/Models/RemoteModelConfiguration.swift
@@ -238,6 +238,7 @@ enum RemoteASRProvider: String, CaseIterable, Identifiable {
     case aliyunBailianASR
     case stepFunASR
     case xiaomiMiMoASR
+    case googleGeminiASR
 
     nonisolated var id: String { rawValue }
 
@@ -255,6 +256,8 @@ enum RemoteASRProvider: String, CaseIterable, Identifiable {
             return AppLocalization.localizedString("StepFun")
         case .xiaomiMiMoASR:
             return AppLocalization.localizedString("Xiaomi MiMo")
+        case .googleGeminiASR:
+            return AppLocalization.localizedString("Google Gemini")
         }
     }
 
@@ -272,6 +275,8 @@ enum RemoteASRProvider: String, CaseIterable, Identifiable {
             return "stepaudio-2.5-asr"
         case .xiaomiMiMoASR:
             return "mimo-v2.5-asr"
+        case .googleGeminiASR:
+            return GeminiLivePayloadSupport.defaultModel
         }
     }
 
@@ -323,6 +328,13 @@ enum RemoteASRProvider: String, CaseIterable, Identifiable {
         case .xiaomiMiMoASR:
             return [
                 RemoteModelOption(id: "mimo-v2.5-asr", title: "MiMo V2.5 ASR")
+            ]
+        case .googleGeminiASR:
+            return [
+                RemoteModelOption(
+                    id: GeminiLivePayloadSupport.defaultModel,
+                    title: "Gemini 3.5 Transcribe Live"
+                )
             ]
         }
     }

--- a/Voxt/Core/RemoteProviders/RemoteConfigurationPolicy.swift
+++ b/Voxt/Core/RemoteProviders/RemoteConfigurationPolicy.swift
@@ -216,6 +216,8 @@ enum RemoteProviderConfigurationPolicy {
                 return "https://api.stepfun.com/v1/audio/asr/sse"
             case .xiaomiMiMoASR:
                 return "https://api.xiaomimimo.com/v1/chat/completions"
+            case .googleGeminiASR:
+                return RemoteASREndpointSupport.geminiLiveDefaultEndpoint
             }
         case .llm(let provider):
             return RemoteLLMRuntimeClient().resolvedLLMEndpoint(

--- a/Voxt/Core/RemoteProviders/RemoteConnectivityEndpoints.swift
+++ b/Voxt/Core/RemoteProviders/RemoteConnectivityEndpoints.swift
@@ -133,6 +133,10 @@ enum RemoteProviderConnectivityTestEndpoints {
         RemoteASREndpointSupport.resolvedXiaomiMiMoASREndpoint(endpoint)
     }
 
+    static func resolvedGeminiLiveASREndpoint(_ endpoint: String) -> String {
+        RemoteASREndpointSupport.resolvedGeminiLiveEndpoint(endpoint)
+    }
+
     private static func replacingPathSuffix(in value: String, oldSuffix: String, newSuffix: String) -> String {
         guard value.lowercased().hasSuffix(oldSuffix) else { return value }
         return String(value.dropLast(oldSuffix.count)) + newSuffix

--- a/Voxt/Core/RemoteProviders/RemoteConnectivityTester.swift
+++ b/Voxt/Core/RemoteProviders/RemoteConnectivityTester.swift
@@ -149,6 +149,19 @@ struct RemoteProviderConnectivityTester {
                 apiKey: configuration.apiKey,
                 model: configuration.model.isEmpty ? RemoteASRProvider.xiaomiMiMoASR.suggestedModel : configuration.model
             )
+        case .googleGeminiASR:
+            guard !configuration.apiKey.isEmpty else {
+                throw NSError(
+                    domain: "Voxt.Settings",
+                    code: -9,
+                    userInfo: [NSLocalizedDescriptionKey: AppLocalization.localizedString("Google Gemini API Key is required for testing.")]
+                )
+            }
+            return try await testGeminiLiveReachability(
+                endpoint: configuration.endpoint,
+                apiKey: configuration.apiKey,
+                model: configuration.model.isEmpty ? RemoteASRProvider.googleGeminiASR.suggestedModel : configuration.model
+            )
         }
     }
 
@@ -452,6 +465,93 @@ struct RemoteProviderConnectivityTester {
             "Accept": "text/event-stream",
             "Authorization": "Bearer \(token)"
         ]
+    }
+
+    private func testGeminiLiveReachability(
+        endpoint: String,
+        apiKey: String,
+        model: String
+    ) async throws -> String {
+        guard let url = RemoteASREndpointSupport.geminiLiveURL(endpoint: endpoint, apiKey: apiKey) else {
+            throw NSError(domain: "Voxt.Settings", code: -58, userInfo: [NSLocalizedDescriptionKey: AppLocalization.localizedString("Invalid WebSocket endpoint URL.")])
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        // The key rides in the query string, so only the sanitized endpoint is logged.
+        RemoteProviderConnectivityTestLogging.logHTTPRequest(
+            context: "Gemini live transcribe WebSocket test",
+            request: URLRequest(url: URL(string: RemoteASREndpointSupport.resolvedGeminiLiveEndpoint(endpoint)) ?? url),
+            bodyPreview: "setup"
+        )
+
+        let managedSocket = VoxtNetworkSession.makeWebSocketTask(with: request)
+        let ws = managedSocket.task
+        ws.resume()
+        defer {
+            ws.cancel(with: .goingAway, reason: nil)
+        }
+
+        let setupPayload = GeminiLivePayloadSupport.setupPayload(
+            model: model,
+            hintPayload: ResolvedASRHintPayload(language: nil)
+        )
+        let setupData = try JSONSerialization.data(withJSONObject: setupPayload)
+        guard let setupText = String(data: setupData, encoding: .utf8) else {
+            throw NSError(domain: "Voxt.Settings", code: -59, userInfo: [NSLocalizedDescriptionKey: AppLocalization.localizedString("Failed to encode Gemini live payload.")])
+        }
+
+        do {
+            try await ws.send(.string(setupText))
+        } catch {
+            throw NSError(
+                domain: "Voxt.Settings",
+                code: -60,
+                userInfo: [NSLocalizedDescriptionKey: AppLocalization.format("Network connection failed before realtime handshake. %@ (Check proxy/VPN and endpoint reachability.)", error.localizedDescription)]
+            )
+        }
+
+        do {
+            for _ in 0..<6 {
+                let message = try await receiveWebSocketMessage(task: ws, timeoutSeconds: 3)
+                let text: String?
+                switch message {
+                case .string(let value):
+                    text = value
+                case .data(let data):
+                    text = String(data: data, encoding: .utf8)
+                @unknown default:
+                    text = nil
+                }
+                guard let text,
+                      let data = text.data(using: .utf8),
+                      let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else { continue }
+
+                if let detail = GeminiLivePayloadSupport.errorMessage(from: object) {
+                    throw NSError(
+                        domain: "Voxt.Settings",
+                        code: 403,
+                        userInfo: [NSLocalizedDescriptionKey: AppLocalization.format("Connection failed (HTTP %d). %@", 403, detail)]
+                    )
+                }
+                if GeminiLivePayloadSupport.isSetupComplete(object) {
+                    return AppLocalization.localizedString("Connection test succeeded (Gemini live transcribe reachable).")
+                }
+            }
+        } catch {
+            throw NSError(
+                domain: "Voxt.Settings",
+                code: -61,
+                userInfo: [NSLocalizedDescriptionKey: AppLocalization.format("Realtime WebSocket receive failed. %@ (Check proxy/VPN or region endpoint.)", error.localizedDescription)]
+            )
+        }
+
+        throw NSError(
+            domain: "Voxt.Settings",
+            code: -62,
+            userInfo: [NSLocalizedDescriptionKey: AppLocalization.localizedString("Connection failed (HTTP %d). %@").replacingOccurrences(of: "%d", with: "0").replacingOccurrences(of: "%@", with: "No valid ASR response packet.")]
+        )
     }
 
     private func testXiaomiMiMoASRReachability(

--- a/Voxt/Core/Transcription/ASRHintResolver.swift
+++ b/Voxt/Core/Transcription/ASRHintResolver.swift
@@ -127,6 +127,21 @@ enum ASRHintResolver {
                 prompt: nil,
                 otherLanguages: otherLanguages
             )
+        case .googleGeminiASR:
+            let hints = settings.followsUserMainLanguage
+                ? resolvedGeminiLanguageHints(options: selectedOptions)
+                : []
+            let terms = resolvedGeminiTerms(
+                contextualPhrases: contextualPhrases,
+                dictionaryTerms: dictionaryTerms
+            )
+            return ResolvedASRHintPayload(
+                language: hints.first,
+                languageHints: hints,
+                prompt: nil,
+                otherLanguages: otherLanguages,
+                contextualPhrases: terms
+            )
         }
     }
 
@@ -375,6 +390,26 @@ enum ASRHintResolver {
 
     private static func resolvedStepFunLanguage(_ language: UserMainLanguageOption) -> String {
         language.baseLanguageCode
+    }
+
+    /// Gemini takes BCP-47 tags; an empty list is what enables auto-detection
+    /// and mid-sentence code-mixing.
+    private static func resolvedGeminiLanguageHints(options: [UserMainLanguageOption]) -> [String] {
+        var seen = Set<String>()
+        return options.compactMap { option in
+            let code = option.baseLanguageCode
+            guard !code.isEmpty, seen.insert(code).inserted else { return nil }
+            return code
+        }
+    }
+
+    private static func resolvedGeminiTerms(
+        contextualPhrases: [String],
+        dictionaryTerms: String
+    ) -> [String] {
+        mergedTermLines(
+            contextualPhrases + dictionaryTerms.components(separatedBy: .newlines)
+        )
     }
 
     private static func resolvedXiaomiMiMoLanguage(_ language: UserMainLanguageOption) -> String {

--- a/Voxt/Meeting/MeetingLiveSessionSupport.swift
+++ b/Voxt/Meeting/MeetingLiveSessionSupport.swift
@@ -150,7 +150,7 @@ struct MeetingLiveSessionPolicy: Equatable, Sendable {
                 prebufferDuration: 1.0,
                 segmentSilenceSplitThreshold: isRealtimeModel ? 1.2 : 0
             )
-        case .openAIWhisper, .glmASR, .stepFunASR, .xiaomiMiMoASR:
+        case .openAIWhisper, .glmASR, .stepFunASR, .xiaomiMiMoASR, .googleGeminiASR:
             return MeetingLiveSessionPolicy(
                 idleKeepaliveEnabled: false,
                 idleKeepaliveInterval: 0,

--- a/Voxt/Meeting/MeetingRemoteProviderLiveSession.swift
+++ b/Voxt/Meeting/MeetingRemoteProviderLiveSession.swift
@@ -44,7 +44,7 @@ struct MeetingRemoteLiveSessionFactory: MeetingLiveSessionFactory {
                 timelineOffsetSeconds: timelineOffsetSeconds,
                 policy: policy
             )
-        case .openAIWhisper, .glmASR, .stepFunASR, .xiaomiMiMoASR:
+        case .openAIWhisper, .glmASR, .stepFunASR, .xiaomiMiMoASR, .googleGeminiASR:
             throw NSError(
                 domain: "Voxt.Meeting",
                 code: -1,

--- a/Voxt/Meeting/Processing/MeetingASRSupport.swift
+++ b/Voxt/Meeting/Processing/MeetingASRSupport.swift
@@ -151,7 +151,7 @@ enum MeetingASRSupport {
             return .chunk(profile: .quality)
         case .openAIWhisper:
             return .chunk(profile: configuration.openAIChunkPseudoRealtimeEnabled ? .realtime : .quality)
-        case .glmASR, .stepFunASR, .xiaomiMiMoASR:
+        case .glmASR, .stepFunASR, .xiaomiMiMoASR, .googleGeminiASR:
             return .chunk(profile: .quality)
         }
     }
@@ -183,6 +183,8 @@ extension RemoteASRRealtimeSupport {
         case .stepFunASR:
             return false
         case .xiaomiMiMoASR:
+            return false
+        case .googleGeminiASR:
             return false
         }
     }

--- a/Voxt/Settings/Features/FeatureModelCatalogBuilder.swift
+++ b/Voxt/Settings/Features/FeatureModelCatalogBuilder.swift
@@ -690,6 +690,8 @@ struct FeatureModelCatalogBuilder {
             tags.append(contentsOf: [localized("Accurate"), localized("Multilingual")])
         case .xiaomiMiMoASR:
             tags.append(contentsOf: [localized("Accurate"), localized("Multilingual")])
+        case .googleGeminiASR:
+            tags.append(contentsOf: [localized("Realtime"), localized("Accurate"), localized("Multilingual")])
         }
         return deduplicatedFeatureTags(tags)
     }

--- a/Voxt/Settings/Models/ModelLogoView.swift
+++ b/Voxt/Settings/Models/ModelLogoView.swift
@@ -260,6 +260,7 @@ enum ModelLogoKey: String {
             return .gemma
         }
         if value == "google"
+            || value.hasPrefix("google gemini")
             || value == "google remote llm"
             || value.hasPrefix("google remote llm ")
             || value == "google 远程 llm"

--- a/Voxt/Settings/Models/ModelSettingsActions.swift
+++ b/Voxt/Settings/Models/ModelSettingsActions.swift
@@ -670,6 +670,8 @@ extension ModelSettingsView {
             return AppLocalization.localizedString("Aliyun ASR in Voxt uses realtime WebSocket only: Qwen models use /api-ws/v1/realtime, Fun/Paraformer models use /api-ws/v1/inference.")
         case .xiaomiMiMoASR:
             return AppLocalization.localizedString("Xiaomi MiMo ASR uses a MiMo API Key and the OpenAI-compatible chat completions audio endpoint.")
+        case .googleGeminiASR:
+            return AppLocalization.localizedString("Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported.")
         case .openAIWhisper, .glmASR, .stepFunASR:
             return nil
         }

--- a/Voxt/Settings/Models/ModelSettingsCatalogBuilder.swift
+++ b/Voxt/Settings/Models/ModelSettingsCatalogBuilder.swift
@@ -387,6 +387,12 @@ struct ModelCatalogBuilder {
             tags.append(contentsOf: [localizedModelCatalog("Accurate"), localizedModelCatalog("Multilingual")])
         case .xiaomiMiMoASR:
             tags.append(contentsOf: [localizedModelCatalog("Accurate"), localizedModelCatalog("Multilingual")])
+        case .googleGeminiASR:
+            tags.append(contentsOf: [
+                localizedModelCatalog("Realtime"),
+                localizedModelCatalog("Accurate"),
+                localizedModelCatalog("Multilingual")
+            ])
         }
         return deduplicatedTags(tags)
     }

--- a/Voxt/Settings/Onboarding/OnboardingGuideView.swift
+++ b/Voxt/Settings/Onboarding/OnboardingGuideView.swift
@@ -3121,6 +3121,8 @@ private extension OnboardingGuideView {
             return guideLocalized("Aliyun ASR in Voxt uses realtime WebSocket only: Qwen models use /api-ws/v1/realtime, Fun/Paraformer models use /api-ws/v1/inference.")
         case .xiaomiMiMoASR:
             return guideLocalized("Xiaomi MiMo ASR uses a MiMo API Key and the OpenAI-compatible chat completions audio endpoint.")
+        case .googleGeminiASR:
+            return guideLocalized("Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported.")
         case .openAIWhisper, .glmASR, .stepFunASR:
             return nil
         }

--- a/Voxt/Settings/Onboarding/OnboardingSettingsData.swift
+++ b/Voxt/Settings/Onboarding/OnboardingSettingsData.swift
@@ -468,6 +468,8 @@ extension OnboardingSettingsView {
             return AppLocalization.localizedString("Aliyun ASR in Voxt uses realtime WebSocket only: Qwen models use /api-ws/v1/realtime, Fun/Paraformer models use /api-ws/v1/inference.")
         case .xiaomiMiMoASR:
             return AppLocalization.localizedString("Xiaomi MiMo ASR uses a MiMo API Key and the OpenAI-compatible chat completions audio endpoint.")
+        case .googleGeminiASR:
+            return AppLocalization.localizedString("Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported.")
         case .openAIWhisper, .glmASR, .stepFunASR:
             return nil
         }

--- a/Voxt/Transcription/RemoteASR/GeminiLiveStreamingSupport.swift
+++ b/Voxt/Transcription/RemoteASR/GeminiLiveStreamingSupport.swift
@@ -1,0 +1,344 @@
+// GeminiLiveStreamingSupport.swift
+// Provides Gemini live transcribe streaming for remote ASR adapters.
+
+import AVFoundation
+import Foundation
+
+@MainActor
+extension RemoteASRTranscriber {
+    func startGeminiLiveStreaming(
+        configuration: RemoteProviderConfiguration,
+        hintPayload: ResolvedASRHintPayload
+    ) throws {
+        let apiKey = configuration.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else {
+            throw NSError(
+                domain: "Voxt.RemoteASR",
+                code: -60,
+                userInfo: [NSLocalizedDescriptionKey: "Google Gemini API key is empty."]
+            )
+        }
+
+        let configuredModel = configuration.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = configuredModel.isEmpty ? GeminiLivePayloadSupport.defaultModel : configuredModel
+        let loggedEndpoint = RemoteASREndpointSupport.resolvedGeminiLiveEndpoint(configuration.endpoint)
+        guard let wsURL = RemoteASREndpointSupport.geminiLiveURL(
+            endpoint: configuration.endpoint,
+            apiKey: apiKey
+        ) else {
+            throw NSError(
+                domain: "Voxt.RemoteASR",
+                code: -61,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid Gemini live transcribe WebSocket endpoint URL."]
+            )
+        }
+
+        var request = URLRequest(url: wsURL)
+        request.timeoutInterval = 45
+        VoxtLog.model("Gemini live transcribe connect. endpoint=\(loggedEndpoint), model=\(model)")
+
+        let managedSocket = VoxtNetworkSession.makeWebSocketTask(with: request)
+        let ws = managedSocket.task
+        ws.resume()
+
+        let context = GeminiLiveStreamingContext(
+            session: managedSocket.session,
+            ws: ws,
+            responseState: GeminiLiveResponseState { [weak self] error in
+                Task { @MainActor [weak self] in
+                    self?.notifyRuntimeFailure(error)
+                }
+            },
+            generationID: recordingGenerationID
+        )
+        geminiLiveStreamingContext = context
+        receiveGeminiLiveMessages(context)
+        try startGeminiLiveAudioCapture(context: context)
+        context.didStartAudioStream = true
+
+        let payload = GeminiLivePayloadSupport.setupPayload(model: model, hintPayload: hintPayload)
+        VoxtLog.model(
+            "Gemini live setup sent. languageCodes=\(GeminiLivePayloadSupport.languageCodes(from: hintPayload).joined(separator: ",")), vocabulary=\(GeminiLivePayloadSupport.customVocabulary(from: hintPayload).count)"
+        )
+        sendGeminiLiveJSON(payload, through: ws) { error in
+            if let error {
+                Task { [responseState = context.responseState] in
+                    await responseState.markCompletedWithError(error)
+                }
+            }
+        }
+    }
+
+    func stopGeminiLiveStreaming(_ context: GeminiLiveStreamingContext) {
+        VoxtLog.model("Gemini live stop requested. stopRequested=\(stopRequested)")
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard self.isCurrentGeneration(context.generationID),
+                  self.geminiLiveStreamingContext === context,
+                  !context.isClosed
+            else { return }
+
+            try? await Task.sleep(for: self.aliyunRealtimeStopDrainDelay)
+
+            guard self.isCurrentGeneration(context.generationID),
+                  self.geminiLiveStreamingContext === context,
+                  !context.isClosed
+            else { return }
+
+            self.isRecording = false
+            self.stopGeminiLiveAudioCapture()
+            if context.isSetupComplete {
+                self.flushPendingGeminiLiveAudio(context)
+                self.sendGeminiLiveAudioStreamEnd(context)
+            } else {
+                context.shouldEndAudioStreamAfterSetup = true
+                VoxtLog.model(
+                    "Gemini live stop deferred until setupComplete. bufferedBytes=\(context.pendingAudioByteCount)"
+                )
+            }
+        }
+    }
+
+    private func receiveGeminiLiveMessages(_ context: GeminiLiveStreamingContext) {
+        context.ws.receive { [weak self, weak context] result in
+            Task { @MainActor [weak self, weak context] in
+                guard let self, let context else { return }
+                guard self.geminiLiveStreamingContext === context, !context.isClosed else { return }
+
+                switch result {
+                case .failure(let error):
+                    await self.handleGeminiLiveSocketFailure(error, context: context)
+                    return
+                case .success(let message):
+                    let text: String?
+                    switch message {
+                    case .string(let value):
+                        text = value
+                    case .data(let data):
+                        text = String(data: data, encoding: .utf8)
+                    @unknown default:
+                        text = nil
+                    }
+                    if let text {
+                        await self.handleGeminiLiveMessage(text, context: context)
+                    }
+                    if !context.isClosed {
+                        self.receiveGeminiLiveMessages(context)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Google closes the socket once the stream ends, so a post-stop failure with
+    /// text already in hand is a normal shutdown, not a runtime error.
+    private func handleGeminiLiveSocketFailure(
+        _ error: Error,
+        context: GeminiLiveStreamingContext
+    ) async {
+        guard !context.isClosed else { return }
+        if stopRequested {
+            let current = await context.responseState.currentText()
+            if !current.isEmpty {
+                context.isClosed = true
+                VoxtLog.model("Gemini live socket closed after stop. chars=\(current.count)")
+                await context.responseState.markSessionFinished()
+                return
+            }
+        }
+        await context.responseState.markCompletedWithError(error)
+    }
+
+    private func handleGeminiLiveMessage(_ text: String, context: GeminiLiveStreamingContext) async {
+        guard let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+
+        if let message = GeminiLivePayloadSupport.errorMessage(from: object) {
+            VoxtLog.asr("Gemini live error packet received. detail=\(message)", verbose: true)
+            await context.responseState.markCompletedWithError(
+                NSError(
+                    domain: "Voxt.RemoteASR",
+                    code: -62,
+                    userInfo: [NSLocalizedDescriptionKey: "Gemini live transcribe error: \(message)"]
+                )
+            )
+            return
+        }
+
+        if GeminiLivePayloadSupport.isSetupComplete(object) {
+            guard !context.isSetupComplete else { return }
+            context.isSetupComplete = true
+            flushPendingGeminiLiveAudio(context)
+            VoxtLog.model(
+                "Gemini live setupComplete acknowledged. pendingEnd=\(context.shouldEndAudioStreamAfterSetup)"
+            )
+            if context.shouldEndAudioStreamAfterSetup {
+                context.shouldEndAudioStreamAfterSetup = false
+                sendGeminiLiveAudioStreamEnd(context)
+            }
+            return
+        }
+
+        let update = GeminiLivePayloadSupport.transcriptUpdate(from: object)
+        if let final = update.final {
+            let merged = await context.responseState.commit(final)
+            publishIntermediateTranscription(merged)
+        } else if let interim = update.interim {
+            let merged = await context.responseState.setInterim(interim)
+            publishIntermediateTranscription(merged)
+        }
+
+        // A turn ends on every pause, so only a terminal event after our own
+        // audioStreamEnd means the session is really done.
+        if context.didSendAudioStreamEnd, GeminiLivePayloadSupport.isSessionTerminal(object) {
+            context.isClosed = true
+            VoxtLog.model("Gemini live session terminal event received.")
+            await context.responseState.markSessionFinished()
+        }
+    }
+
+    func startGeminiLiveAudioCapture(context: GeminiLiveStreamingContext) throws {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.reset()
+
+        let inputNode = audioEngine.inputNode
+        let didApplyPreferredInputDevice = preferredInputDeviceID != nil
+            ? applyPreferredInputDeviceIfNeeded(inputNode: inputNode)
+            : false
+        let activeInputDeviceID = didApplyPreferredInputDevice
+            ? preferredInputDeviceID
+            : AudioInputDeviceManager.defaultInputDeviceID()
+        let inputFormat = inputCaptureTapFormat(
+            inputNode: inputNode,
+            activeInputDeviceID: activeInputDeviceID,
+            logContext: "Gemini live transcriber"
+        )
+        streamingInputSampleRate = inputFormat.sampleRate
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            guard let pcmData = Self.makeDoubaoPCM16MonoData(from: buffer) else { return }
+            if let samples = AudioLevelMeter.monoSamples(from: buffer), !samples.isEmpty {
+                self.sampleStore.append(samples)
+            }
+            Task { @MainActor in
+                guard self.isRecording,
+                      let context = self.geminiLiveStreamingContext,
+                      !context.isClosed
+                else { return }
+                self.audioLevel = self.audioLevelFromPCM16(pcmData)
+                self.sendGeminiLiveAudio(pcmData, context: context)
+            }
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+        isRecording = true
+        VoxtLog.asr(
+            "Gemini live audio capture started. sampleRate=\(Int(inputFormat.sampleRate)), channels=\(inputFormat.channelCount)",
+            verbose: true
+        )
+    }
+
+    func stopGeminiLiveAudioCapture() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioLevel = 0
+    }
+
+    private func sendGeminiLiveAudio(_ pcmData: Data, context: GeminiLiveStreamingContext) {
+        guard !pcmData.isEmpty, !context.isClosed else { return }
+        guard context.isSetupComplete else {
+            queuePendingGeminiLiveAudio(pcmData, context: context)
+            return
+        }
+        sendGeminiLiveAudioChunk(pcmData, context: context)
+    }
+
+    /// Speech starts before the setup handshake completes, so the first syllables
+    /// are buffered instead of dropped.
+    private func queuePendingGeminiLiveAudio(_ pcmData: Data, context: GeminiLiveStreamingContext) {
+        context.pendingAudioChunks.append(pcmData)
+        context.pendingAudioByteCount += pcmData.count
+
+        var droppedBytes = 0
+        var droppedChunks = 0
+        while context.pendingAudioByteCount > realtimePendingAudioByteLimit,
+              !context.pendingAudioChunks.isEmpty {
+            let dropped = context.pendingAudioChunks.removeFirst()
+            context.pendingAudioByteCount -= dropped.count
+            droppedBytes += dropped.count
+            droppedChunks += 1
+        }
+
+        if droppedChunks > 0 {
+            VoxtLog.asrWarning(
+                "Gemini live startup audio buffer exceeded limit; dropped oldest chunks. droppedChunks=\(droppedChunks), droppedBytes=\(droppedBytes)"
+            )
+        }
+    }
+
+    private func flushPendingGeminiLiveAudio(_ context: GeminiLiveStreamingContext) {
+        guard context.isSetupComplete, !context.isClosed else { return }
+        let chunks = context.pendingAudioChunks
+        let byteCount = context.pendingAudioByteCount
+        context.pendingAudioChunks.removeAll(keepingCapacity: false)
+        context.pendingAudioByteCount = 0
+
+        guard !chunks.isEmpty else { return }
+        VoxtLog.model(
+            "Gemini live flushing buffered startup audio. chunks=\(chunks.count), bytes=\(byteCount)"
+        )
+        for chunk in chunks {
+            sendGeminiLiveAudioChunk(chunk, context: context)
+        }
+    }
+
+    private func sendGeminiLiveAudioChunk(_ pcmData: Data, context: GeminiLiveStreamingContext) {
+        sendGeminiLiveJSON(GeminiLivePayloadSupport.audioPayload(pcmData), through: context.ws) { error in
+            if let error {
+                Task { [responseState = context.responseState] in
+                    await responseState.markCompletedWithError(error)
+                }
+            }
+        }
+    }
+
+    private func sendGeminiLiveAudioStreamEnd(_ context: GeminiLiveStreamingContext) {
+        context.didSendAudioStreamEnd = true
+        sendGeminiLiveJSON(GeminiLivePayloadSupport.audioStreamEndPayload, through: context.ws) { error in
+            Task { [responseState = context.responseState] in
+                if let error {
+                    await responseState.markCompletedWithError(error)
+                } else {
+                    await responseState.markFinishRequested()
+                }
+            }
+        }
+    }
+
+    private func sendGeminiLiveJSON(
+        _ payload: [String: Any],
+        through ws: URLSessionWebSocketTask,
+        onError: @escaping (Error?) -> Void
+    ) {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw NSError(
+                    domain: "Voxt.RemoteASR",
+                    code: -63,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to encode Gemini live payload."]
+                )
+            }
+            ws.send(.string(text)) { error in
+                onError(error)
+            }
+        } catch {
+            onError(error)
+        }
+    }
+}

--- a/Voxt/Transcription/RemoteASR/RemoteASRAudioUploadPreprocessing.swift
+++ b/Voxt/Transcription/RemoteASR/RemoteASRAudioUploadPreprocessing.swift
@@ -64,6 +64,8 @@ enum RemoteASRAudioUploadVADPolicyResolver {
             return .disabled(reason: "unsupported-aliyun-route")
         case .doubaoASR:
             return .realtimeUnchanged(reason: "doubao-streaming")
+        case .googleGeminiASR:
+            return .realtimeServerVAD
         }
     }
 }

--- a/Voxt/Transcription/RemoteASR/RemoteASRStreamingContexts.swift
+++ b/Voxt/Transcription/RemoteASR/RemoteASRStreamingContexts.swift
@@ -345,3 +345,111 @@ func remoteASRUInt32(fromBigEndian data: Data) -> UInt32 {
 func remoteASRInt32(fromBigEndian data: Data) -> Int32 {
     Int32(bitPattern: remoteASRUInt32(fromBigEndian: data))
 }
+
+@MainActor
+final class GeminiLiveStreamingContext {
+    let session: URLSession
+    let ws: URLSessionWebSocketTask
+    let responseState: GeminiLiveResponseState
+    let generationID: UUID
+    var isClosed = false
+    var isSetupComplete = false
+    var didStartAudioStream = false
+    var shouldEndAudioStreamAfterSetup = false
+    var didSendAudioStreamEnd = false
+    var pendingAudioChunks: [Data] = []
+    var pendingAudioByteCount = 0
+
+    init(
+        session: URLSession,
+        ws: URLSessionWebSocketTask,
+        responseState: GeminiLiveResponseState,
+        generationID: UUID
+    ) {
+        self.session = session
+        self.ws = ws
+        self.responseState = responseState
+        self.generationID = generationID
+    }
+}
+
+actor GeminiLiveResponseState {
+    private var committed: [String] = []
+    private var interim = ""
+    private var finishRequested = false
+    private var finishRequestedAt: Date?
+    private var sessionFinished = false
+    private var completionError: Error?
+    private let onError: @Sendable (Error) -> Void
+
+    init(onError: @escaping @Sendable (Error) -> Void = { _ in }) {
+        self.onError = onError
+    }
+
+    func markFinishRequested() {
+        finishRequested = true
+        finishRequestedAt = Date()
+    }
+
+    func markSessionFinished() {
+        sessionFinished = true
+    }
+
+    func markCompletedWithError(_ error: Error) {
+        if sessionFinished {
+            return
+        }
+        if completionError == nil {
+            completionError = error
+            onError(error)
+        }
+    }
+
+    func setInterim(_ value: String) -> String {
+        interim = value
+        return mergedText()
+    }
+
+    func commit(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty, committed.last != trimmed {
+            committed.append(trimmed)
+        }
+        interim = ""
+        return mergedText()
+    }
+
+    func waitForFinalResult(timeoutSeconds: TimeInterval) async throws -> String {
+        let deadline = Date().addingTimeInterval(max(timeoutSeconds, 0))
+        while !sessionFinished, completionError == nil, Date() < deadline {
+            // The live transcribe API documents no session-end event, so a short
+            // grace window after audioStreamEnd is what actually ends the wait.
+            if let finishRequestedAt, Date().timeIntervalSince(finishRequestedAt) >= 2.5 {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(120))
+        }
+        if let completionError {
+            throw completionError
+        }
+        if finishRequested, !interim.isEmpty {
+            if committed.last != interim {
+                committed.append(interim)
+            }
+            interim = ""
+        }
+        return mergedText()
+    }
+
+    func currentText() -> String {
+        mergedText()
+    }
+
+    private func mergedText() -> String {
+        var values = committed
+        if !interim.isEmpty {
+            values.append(interim)
+        }
+        return GeminiLiveTranscriptJoining.join(values)
+    }
+}

--- a/Voxt/Transcription/RemoteASR/RemoteASRSupport.swift
+++ b/Voxt/Transcription/RemoteASR/RemoteASRSupport.swift
@@ -880,3 +880,205 @@ enum StepFunSupport {
         return wavData.subdata(in: 44..<wavData.count)
     }
 }
+
+extension RemoteASREndpointSupport {
+    static let geminiLiveDefaultEndpoint =
+        "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+
+    static func resolvedGeminiLiveEndpoint(_ endpoint: String) -> String {
+        let trimmed = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return geminiLiveDefaultEndpoint
+        }
+        guard var components = URLComponents(string: trimmed) else {
+            return trimmed
+        }
+        switch components.scheme?.lowercased() {
+        case "https":
+            components.scheme = "wss"
+        case "http":
+            components.scheme = "ws"
+        default:
+            break
+        }
+        if components.path.isEmpty || components.path == "/" {
+            components.path = "/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+        }
+        // The API key is attached only at connect time, never stored in settings.
+        components.queryItems = components.queryItems?.filter { $0.name != "key" }
+        if components.queryItems?.isEmpty == true {
+            components.queryItems = nil
+        }
+        return components.string ?? trimmed
+    }
+
+    static func geminiLiveURL(endpoint: String, apiKey: String) -> URL? {
+        let resolved = resolvedGeminiLiveEndpoint(endpoint)
+        guard var components = URLComponents(string: resolved) else { return nil }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == "key" }
+        items.append(URLQueryItem(name: "key", value: apiKey))
+        components.queryItems = items
+        return components.url
+    }
+}
+
+enum GeminiLiveTranscriptJoining {
+    /// Gemini emits Chinese segments that must not be space-joined, and English
+    /// turns that must be. Decide per boundary instead of per session.
+    static func join(_ segments: [String]) -> String {
+        var result = ""
+        for segment in segments {
+            let piece = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !piece.isEmpty else { continue }
+            if result.isEmpty {
+                result = piece
+                continue
+            }
+            if needsSeparator(previous: result, next: piece) {
+                result += " "
+            }
+            result += piece
+        }
+        return result
+    }
+
+    private static func needsSeparator(previous: String, next: String) -> Bool {
+        guard let left = previous.unicodeScalars.last,
+              let right = next.unicodeScalars.first
+        else { return false }
+        return !isCJK(left) && !isCJK(right)
+    }
+
+    private static func isCJK(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x3000...0x303F, 0x3400...0x4DBF, 0x4E00...0x9FFF,
+             0xF900...0xFAFF, 0xFF00...0xFFEF,
+             0x3040...0x30FF, 0xAC00...0xD7AF:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+enum GeminiLivePayloadSupport {
+    static let defaultModel = "gemini-3.5-transcribe-live"
+    static let audioMimeType = "audio/pcm;rate=16000"
+
+    static func setupPayload(
+        model: String,
+        hintPayload: ResolvedASRHintPayload
+    ) -> [String: Any] {
+        let resolvedModel = model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? defaultModel
+            : model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let qualifiedModel = resolvedModel.hasPrefix("models/") ? resolvedModel : "models/\(resolvedModel)"
+
+        var transcription: [String: Any] = [
+            "languageCodes": languageCodes(from: hintPayload),
+            "mode": "SMART"
+        ]
+        let vocabulary = customVocabulary(from: hintPayload)
+        if !vocabulary.isEmpty {
+            transcription["customVocabulary"] = vocabulary
+        }
+
+        return [
+            "setup": [
+                "model": qualifiedModel,
+                "generationConfig": ["responseModalities": ["TEXT"]],
+                "inputAudioTranscription": transcription
+            ]
+        ]
+    }
+
+    static func audioPayload(_ audio: Data) -> [String: Any] {
+        [
+            "realtimeInput": [
+                "audio": [
+                    "data": audio.base64EncodedString(),
+                    "mimeType": audioMimeType
+                ]
+            ]
+        ]
+    }
+
+    static let audioStreamEndPayload: [String: Any] = [
+        "realtimeInput": ["audioStreamEnd": true]
+    ]
+
+    /// An empty array asks Gemini to auto-detect, which is also what keeps
+    /// mid-sentence code-mixing working.
+    static func languageCodes(from hintPayload: ResolvedASRHintPayload) -> [String] {
+        var seen = Set<String>()
+        return hintPayload.languageHints.compactMap { hint in
+            let normalized = hint.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty, seen.insert(normalized.lowercased()).inserted else { return nil }
+            return normalized
+        }
+    }
+
+    static func customVocabulary(from hintPayload: ResolvedASRHintPayload) -> [String] {
+        var seen = Set<String>()
+        let terms = hintPayload.contextualPhrases.compactMap { phrase -> String? in
+            let normalized = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { return nil }
+            return normalized
+        }
+        return Array(terms.prefix(1000))
+    }
+
+    struct TranscriptUpdate {
+        var interim: String?
+        var final: String?
+    }
+
+    static func transcriptUpdate(from object: [String: Any]) -> TranscriptUpdate {
+        guard let serverContent = value(in: object, "serverContent", "server_content") as? [String: Any] else {
+            return TranscriptUpdate()
+        }
+        return TranscriptUpdate(
+            interim: text(in: serverContent, "interimInputTranscription", "interim_input_transcription"),
+            final: text(in: serverContent, "inputTranscription", "input_transcription")
+        )
+    }
+
+    static func isSetupComplete(_ object: [String: Any]) -> Bool {
+        value(in: object, "setupComplete", "setup_complete") != nil
+    }
+
+    static func isSessionTerminal(_ object: [String: Any]) -> Bool {
+        if value(in: object, "goAway", "go_away") != nil {
+            return true
+        }
+        guard let serverContent = value(in: object, "serverContent", "server_content") as? [String: Any] else {
+            return false
+        }
+        return (value(in: serverContent, "turnComplete", "turn_complete") as? Bool) == true
+    }
+
+    static func errorMessage(from object: [String: Any]) -> String? {
+        guard let error = value(in: object, "error", "error") as? [String: Any] else { return nil }
+        if let message = error["message"] as? String, !message.isEmpty {
+            return message
+        }
+        if let status = error["status"] as? String, !status.isEmpty {
+            return status
+        }
+        return "Gemini live transcribe session failed."
+    }
+
+    private static func text(in object: [String: Any], _ camel: String, _ snake: String) -> String? {
+        guard let container = value(in: object, camel, snake) as? [String: Any],
+              let text = container["text"] as? String
+        else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The socket speaks proto JSON, which may arrive in either casing.
+    private static func value(in object: [String: Any], _ camel: String, _ snake: String) -> Any? {
+        object[camel] ?? object[snake]
+    }
+}

--- a/Voxt/Transcription/RemoteASR/RemoteASRTranscriber.swift
+++ b/Voxt/Transcription/RemoteASR/RemoteASRTranscriber.swift
@@ -53,6 +53,7 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
     private var aliyunStreamingContext: AliyunFunStreamingContext?
     private var aliyunQwenStreamingContext: AliyunQwenStreamingContext?
     var stepFunStreamingContext: StepFunStreamingContext?
+    var geminiLiveStreamingContext: GeminiLiveStreamingContext?
     private var meterTimer: Timer?
     private var openAIPreviewTask: Task<Void, Never>?
     private var openAIPreviewInFlight = false
@@ -76,7 +77,7 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
     private var doubaoCaptureUsesPreferredInputDevice = false
     private let doubaoCaptureStartupWatchdogDelay: Duration = .seconds(1.2)
     let aliyunRealtimeStopDrainDelay: Duration = .milliseconds(180)
-    let stepFunPendingAudioByteLimit = 1_024_000
+    let realtimePendingAudioByteLimit = 1_024_000
 
     func setPreferredInputDevice(_ deviceID: AudioDeviceID?) {
         preferredInputDeviceID = deviceID
@@ -94,6 +95,9 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         }
         if stepFunStreamingContext != nil {
             return "stepfun{active=true}"
+        }
+        if geminiLiveStreamingContext != nil {
+            return "gemini-live{active=true}"
         }
         return nil
     }
@@ -120,6 +124,7 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         cleanupDoubaoStreamingState()
         cleanupAliyunStreamingState()
         cleanupStepFunStreamingState()
+        cleanupGeminiLiveStreamingState()
         sampleStore.clear()
         streamingInputSampleRate = HistoryAudioArchiveSupport.targetSampleRate
         transcribedText = ""
@@ -167,6 +172,8 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         } else if provider == .stepFunASR,
                   RemoteASRRealtimeSupport.isStepFunRealtimeModel(resolvedModel) {
             routeSummary = "stepfun-realtime"
+        } else if provider == .googleGeminiASR {
+            routeSummary = "gemini-live"
         } else {
             routeSummary = provider.rawValue
         }
@@ -225,6 +232,20 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
             return
         }
 
+        if provider == .googleGeminiASR {
+            do {
+                try startGeminiLiveStreaming(configuration: configuration, hintPayload: hintPayload)
+            } catch {
+                VoxtLog.asrError("Gemini live streaming setup failed: \(error.localizedDescription)")
+                cleanupRecorderState()
+                cleanupGeminiLiveStreamingState()
+                activeProvider = nil
+                activeConfiguration = nil
+                notifyStartFailure(error)
+            }
+            return
+        }
+
         do {
             try startFileRecordingMode()
             if provider == .openAIWhisper,
@@ -246,7 +267,8 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
             doubaoStreamingContext != nil ||
             aliyunStreamingContext != nil ||
             aliyunQwenStreamingContext != nil ||
-            stepFunStreamingContext != nil
+            stepFunStreamingContext != nil ||
+            geminiLiveStreamingContext != nil
         guard isRecording || hasPendingRealtimeSession || recorder != nil else { return }
         stopRequested = true
         let generationID = recordingGenerationID
@@ -304,6 +326,21 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
             scheduleStreamingCompletion(generationID: generationID) {
                 await self.resolveStreamingResult(
                     warningMessage: "StepFun realtime final result wait failed"
+                ) {
+                    try await context.responseState.waitForFinalResult(timeoutSeconds: self.streamingFinalWaitTimeout)
+                } fallback: {
+                    await context.responseState.currentText()
+                }
+            }
+            return
+        }
+
+        if activeProvider == .googleGeminiASR, let context = geminiLiveStreamingContext {
+            isRequesting = true
+            stopGeminiLiveStreaming(context)
+            scheduleStreamingCompletion(generationID: generationID) {
+                await self.resolveStreamingResult(
+                    warningMessage: "Gemini live final result wait failed"
                 ) {
                     try await context.responseState.waitForFinalResult(timeoutSeconds: self.streamingFinalWaitTimeout)
                 } fallback: {
@@ -447,6 +484,13 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
             guard context.didStartAudioStream else { return }
             stopStepFunAudioCapture()
             try startStepFunAudioCapture(context: context)
+            return
+        }
+
+        if let context = geminiLiveStreamingContext {
+            guard context.didStartAudioStream else { return }
+            stopGeminiLiveAudioCapture()
+            try startGeminiLiveAudioCapture(context: context)
             return
         }
 
@@ -652,6 +696,12 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
             return try await transcribeStepFun(fileURL: fileURL, configuration: configuration, hintPayload: hintPayload)
         case .xiaomiMiMoASR:
             return try await transcribeXiaomiMiMo(fileURL: fileURL, configuration: configuration, hintPayload: hintPayload)
+        case .googleGeminiASR:
+            throw NSError(
+                domain: "Voxt.RemoteASR",
+                code: -64,
+                userInfo: [NSLocalizedDescriptionKey: AppLocalization.localizedString("Gemini live transcribe supports voice input only. File transcription and meeting mode are not available for this provider.")]
+            )
         }
     }
 
@@ -3174,6 +3224,16 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         stopStepFunAudioCapture()
     }
 
+    private func cleanupGeminiLiveStreamingState() {
+        if let context = geminiLiveStreamingContext {
+            context.isClosed = true
+            context.ws.cancel(with: .normalClosure, reason: nil)
+            context.session.invalidateAndCancel()
+        }
+        geminiLiveStreamingContext = nil
+        stopGeminiLiveAudioCapture()
+    }
+
     private func cleanupActiveUploadTask() {
         transcribeTask?.cancel()
         transcribeTask = nil
@@ -3189,6 +3249,7 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         cleanupDoubaoStreamingState()
         cleanupAliyunStreamingState()
         cleanupStepFunStreamingState()
+        cleanupGeminiLiveStreamingState()
         activeProvider = nil
         activeConfiguration = nil
         stopRequested = false
@@ -3387,6 +3448,7 @@ class RemoteASRTranscriber: NSObject, ObservableObject, TranscriberProtocol {
         cleanupDoubaoStreamingState()
         cleanupAliyunStreamingState()
         cleanupStepFunStreamingState()
+        cleanupGeminiLiveStreamingState()
         activeProvider = nil
         activeConfiguration = nil
         lastPresentedRuntimeErrorMessage = ""

--- a/Voxt/Transcription/RemoteASR/StepFunStreamingSupport.swift
+++ b/Voxt/Transcription/RemoteASR/StepFunStreamingSupport.swift
@@ -242,7 +242,7 @@ extension RemoteASRTranscriber {
 
         var droppedBytes = 0
         var droppedChunks = 0
-        while context.pendingAudioByteCount > stepFunPendingAudioByteLimit,
+        while context.pendingAudioByteCount > realtimePendingAudioByteLimit,
               !context.pendingAudioChunks.isEmpty {
             let dropped = context.pendingAudioChunks.removeFirst()
             context.pendingAudioByteCount -= dropped.count

--- a/Voxt/en.lproj/Localizable.strings
+++ b/Voxt/en.lproj/Localizable.strings
@@ -2362,3 +2362,10 @@
 "Punctuation Prediction" = "Punctuation Prediction";
 "Inverse Text Normalization" = "Inverse Text Normalization";
 "Remove Disfluencies" = "Remove Disfluencies";
+"Google Gemini" = "Google Gemini";
+"Gemini live transcribe auto-detects language and mid-sentence code-mixing. Contextual phrases and dictionary terms are sent as custom vocabulary." = "Gemini live transcribe auto-detects language and mid-sentence code-mixing. Contextual phrases and dictionary terms are sent as custom vocabulary.";
+"Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported." = "Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported.";
+"Gemini live transcribe supports voice input only. File transcription and meeting mode are not available for this provider." = "Gemini live transcribe supports voice input only. File transcription and meeting mode are not available for this provider.";
+"Google Gemini API Key is required for testing." = "Google Gemini API Key is required for testing.";
+"Connection test succeeded (Gemini live transcribe reachable)." = "Connection test succeeded (Gemini live transcribe reachable).";
+"Failed to encode Gemini live payload." = "Failed to encode Gemini live payload.";

--- a/Voxt/ja.lproj/Localizable.strings
+++ b/Voxt/ja.lproj/Localizable.strings
@@ -2357,3 +2357,10 @@
 "Punctuation Prediction" = "句読点予測";
 "Inverse Text Normalization" = "逆テキスト正規化";
 "Remove Disfluencies" = "フィラーを除去";
+"Google Gemini" = "Google Gemini";
+"Gemini live transcribe auto-detects language and mid-sentence code-mixing. Contextual phrases and dictionary terms are sent as custom vocabulary." = "Gemini ライブ文字起こしは言語を自動検出し、文中の言語切り替えにも対応します。コンテキストフレーズと辞書の用語はカスタム語彙として送信されます。";
+"Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported." = "Gemini ライブ文字起こしは Google AI Studio の API キーを使用し、Live WebSocket API 経由で動作します。音声入力のみ対応で、ファイル文字起こしと会議モードには対応していません。";
+"Gemini live transcribe supports voice input only. File transcription and meeting mode are not available for this provider." = "Gemini ライブ文字起こしは音声入力のみ対応です。このプロバイダーではファイル文字起こしと会議モードを利用できません。";
+"Google Gemini API Key is required for testing." = "テストには Google Gemini API Key が必要です。";
+"Connection test succeeded (Gemini live transcribe reachable)." = "接続テストに成功しました（Gemini ライブ文字起こしに到達できます）。";
+"Failed to encode Gemini live payload." = "Gemini ライブのペイロードのエンコードに失敗しました。";

--- a/Voxt/zh-Hans.lproj/Localizable.strings
+++ b/Voxt/zh-Hans.lproj/Localizable.strings
@@ -2362,3 +2362,10 @@
 "Punctuation Prediction" = "标点预测";
 "Inverse Text Normalization" = "逆文本规范化";
 "Remove Disfluencies" = "去除语气词";
+"Google Gemini" = "Google Gemini";
+"Gemini live transcribe auto-detects language and mid-sentence code-mixing. Contextual phrases and dictionary terms are sent as custom vocabulary." = "Gemini 实时转写会自动检测语言，也支持句中中英混说。上下文短语和词典条目会作为自定义词表发送。";
+"Gemini live transcribe uses a Google AI Studio API key over the Live WebSocket API. Voice input only: file transcription and meeting mode are not supported." = "Gemini 实时转写使用 Google AI Studio 的 API Key，通过 Live WebSocket 接口调用。仅支持语音输入，不支持文件转写和会议模式。";
+"Gemini live transcribe supports voice input only. File transcription and meeting mode are not available for this provider." = "Gemini 实时转写仅支持语音输入，该服务商不支持文件转写和会议模式。";
+"Google Gemini API Key is required for testing." = "测试需要填写 Google Gemini API Key。";
+"Connection test succeeded (Gemini live transcribe reachable)." = "连接测试成功（Gemini 实时转写可访问）。";
+"Failed to encode Gemini live payload." = "Gemini 实时转写请求编码失败。";

--- a/VoxtTests/ModelLogoKeyTests.swift
+++ b/VoxtTests/ModelLogoKeyTests.swift
@@ -72,4 +72,15 @@ final class ModelLogoKeyTests: XCTestCase {
         XCTAssertEqual(FeatureModelCatalogBuilder.compactModelBadgeTitle(from: "SenseVoice"), "SenseVoice")
         XCTAssertEqual(FeatureModelCatalogBuilder.compactModelBadgeTitle(from: "GLM Nano (4bit)"), "GLM")
     }
+
+    func testGoogleGeminiASRUsesGoogleLogo() {
+        XCTAssertEqual(
+            ModelLogoKey.resolve(title: RemoteASRProvider.googleGeminiASR.title, engine: "Remote ASR"),
+            .google
+        )
+        XCTAssertEqual(
+            ModelLogoKey.resolve(title: "Google", engine: "Remote LLM"),
+            .google
+        )
+    }
 }

--- a/VoxtTests/RemoteASRSupportTests.swift
+++ b/VoxtTests/RemoteASRSupportTests.swift
@@ -374,4 +374,115 @@ final class RemoteASRSupportTests: XCTestCase {
             "https://api.xiaomimimo.com/v1/chat/completions"
         )
     }
+
+    func testGeminiLiveEndpointResolutionNormalizesSchemeAndStripsKey() {
+        XCTAssertEqual(
+            RemoteASREndpointSupport.resolvedGeminiLiveEndpoint(""),
+            RemoteASREndpointSupport.geminiLiveDefaultEndpoint
+        )
+        XCTAssertEqual(
+            RemoteASREndpointSupport.resolvedGeminiLiveEndpoint("https://generativelanguage.googleapis.com"),
+            RemoteASREndpointSupport.geminiLiveDefaultEndpoint
+        )
+        XCTAssertEqual(
+            RemoteASREndpointSupport.resolvedGeminiLiveEndpoint("https://relay.example.com/ws/bidi?key=secret"),
+            "wss://relay.example.com/ws/bidi"
+        )
+    }
+
+    func testGeminiLiveURLAppendsAPIKeyExactlyOnce() throws {
+        let url = try XCTUnwrap(
+            RemoteASREndpointSupport.geminiLiveURL(
+                endpoint: "wss://relay.example.com/ws/bidi?key=stale",
+                apiKey: "fresh-key"
+            )
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let keys = (components.queryItems ?? []).filter { $0.name == "key" }
+        XCTAssertEqual(keys.count, 1)
+        XCTAssertEqual(keys.first?.value, "fresh-key")
+    }
+
+    func testGeminiLiveSetupPayloadQualifiesModelAndCarriesHints() throws {
+        let payload = GeminiLivePayloadSupport.setupPayload(
+            model: "",
+            hintPayload: ResolvedASRHintPayload(
+                language: "zh",
+                languageHints: ["zh", "zh", "en"],
+                contextualPhrases: ["Voxt", "Voxt", "mihomo"]
+            )
+        )
+
+        let setup = try XCTUnwrap(payload["setup"] as? [String: Any])
+        XCTAssertEqual(setup["model"] as? String, "models/\(GeminiLivePayloadSupport.defaultModel)")
+
+        let generation = try XCTUnwrap(setup["generationConfig"] as? [String: Any])
+        XCTAssertEqual(generation["responseModalities"] as? [String], ["TEXT"])
+
+        let transcription = try XCTUnwrap(setup["inputAudioTranscription"] as? [String: Any])
+        XCTAssertEqual(transcription["mode"] as? String, "SMART")
+        XCTAssertEqual(transcription["languageCodes"] as? [String], ["zh", "en"])
+        XCTAssertEqual(transcription["customVocabulary"] as? [String], ["Voxt", "mihomo"])
+    }
+
+    func testGeminiLiveSetupPayloadOmitsEmptyVocabularyAndKeepsAutoDetect() throws {
+        let payload = GeminiLivePayloadSupport.setupPayload(
+            model: "models/gemini-3.5-transcribe-live",
+            hintPayload: ResolvedASRHintPayload(language: nil)
+        )
+
+        let setup = try XCTUnwrap(payload["setup"] as? [String: Any])
+        XCTAssertEqual(setup["model"] as? String, "models/gemini-3.5-transcribe-live")
+
+        let transcription = try XCTUnwrap(setup["inputAudioTranscription"] as? [String: Any])
+        XCTAssertEqual(transcription["languageCodes"] as? [String], [])
+        XCTAssertNil(transcription["customVocabulary"])
+    }
+
+    func testGeminiLiveAudioPayloadUsesPCM16MimeType() throws {
+        let payload = GeminiLivePayloadSupport.audioPayload(Data([0x01, 0x02, 0x03]))
+        let realtime = try XCTUnwrap(payload["realtimeInput"] as? [String: Any])
+        let audio = try XCTUnwrap(realtime["audio"] as? [String: Any])
+        XCTAssertEqual(audio["mimeType"] as? String, "audio/pcm;rate=16000")
+        XCTAssertEqual(audio["data"] as? String, "AQID")
+        XCTAssertEqual(
+            (GeminiLivePayloadSupport.audioStreamEndPayload["realtimeInput"] as? [String: Any])?["audioStreamEnd"] as? Bool,
+            true
+        )
+    }
+
+    func testGeminiLiveTranscriptUpdateReadsBothProtoCasings() {
+        let camel = GeminiLivePayloadSupport.transcriptUpdate(from: [
+            "serverContent": [
+                "interimInputTranscription": ["text": "你好 "],
+                "inputTranscription": ["text": "你好，板爷。"]
+            ]
+        ])
+        XCTAssertEqual(camel.interim, "你好")
+        XCTAssertEqual(camel.final, "你好，板爷。")
+
+        let snake = GeminiLivePayloadSupport.transcriptUpdate(from: [
+            "server_content": ["input_transcription": ["text": "hello"]]
+        ])
+        XCTAssertEqual(snake.final, "hello")
+        XCTAssertNil(snake.interim)
+    }
+
+    func testGeminiLiveSetupCompleteAndErrorDetection() {
+        XCTAssertTrue(GeminiLivePayloadSupport.isSetupComplete(["setupComplete": [:]]))
+        XCTAssertTrue(GeminiLivePayloadSupport.isSetupComplete(["setup_complete": [:]]))
+        XCTAssertFalse(GeminiLivePayloadSupport.isSetupComplete(["serverContent": [:]]))
+        XCTAssertEqual(
+            GeminiLivePayloadSupport.errorMessage(from: ["error": ["message": "API key not valid"]]),
+            "API key not valid"
+        )
+        XCTAssertNil(GeminiLivePayloadSupport.errorMessage(from: ["serverContent": [:]]))
+    }
+
+    func testGeminiLiveTranscriptJoiningSkipsSpacesAroundCJK() {
+        XCTAssertEqual(GeminiLiveTranscriptJoining.join(["今天开会", "讨论了配置。"]), "今天开会讨论了配置。")
+        XCTAssertEqual(GeminiLiveTranscriptJoining.join(["hello there", "how are you"]), "hello there how are you")
+        XCTAssertEqual(GeminiLiveTranscriptJoining.join(["我们用", "mihomo"]), "我们用mihomo")
+        XCTAssertEqual(GeminiLiveTranscriptJoining.join(["", "  ", "only"]), "only")
+    }
 }

--- a/VoxtTests/RemoteModelConfigurationTests.swift
+++ b/VoxtTests/RemoteModelConfigurationTests.swift
@@ -1704,4 +1704,12 @@ final class RemoteModelConfigurationTests: XCTestCase {
         XCTAssertFalse(RemoteASRTextSanitizer.isLikelyIdentifierText("hello world 2026"))
     }
 
+    func testGoogleGeminiASROffersLiveTranscribeModelOnly() {
+        XCTAssertEqual(RemoteASRProvider.googleGeminiASR.suggestedModel, "gemini-3.5-transcribe-live")
+        XCTAssertEqual(
+            RemoteASRProvider.googleGeminiASR.modelOptions.map(\.id),
+            ["gemini-3.5-transcribe-live"]
+        )
+        XCTAssertTrue(RemoteASRProvider.allCases.contains(.googleGeminiASR))
+    }
 }

--- a/docs/RemoteModel.md
+++ b/docs/RemoteModel.md
@@ -94,6 +94,28 @@ Key: `xxxx`
 
 <img width="915" height="681" alt="image" src="https://github.com/user-attachments/assets/1da2f293-df35-4d6a-aa3a-6bc50cab571a" />
 
+### Google Gemini
+
+- Suggested default: `gemini-3.5-transcribe-live`
+- Built-in models: `gemini-3.5-transcribe-live`
+- Overview: Google's live speech-to-text model, reached over the Gemini Live API WebSocket. It auto-detects language across 85+ languages, keeps mid-sentence code-mixing intact, and its SMART mode removes filler words and formats punctuation before the text reaches your cursor.
+
+- [Website](https://ai.google.dev/)
+- [API Docs](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe)
+- [Key Management](https://aistudio.google.com/apikey)
+
+Endpoint: `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent`
+Key: `xxxx`
+
+Important notes:
+
+- Voxt uses this provider for voice input only. File transcription and Meeting mode are not supported, because only the streaming model is wired.
+- The API key is appended to the WebSocket URL at connect time. Leave it out of the endpoint field; a pasted `key` query parameter is stripped.
+- Contextual phrases and dictionary terms are sent as `customVocabulary`, capped at 1000 terms. Google suggests around 100 terms for best results.
+- Language hints follow your selected user languages. Turning off "follow main language" sends an empty list, which is what enables full auto-detection.
+- A live session is capped at 10 minutes. Voxt does not reconnect mid-session, so a single dictation longer than that will be cut short.
+- The endpoint field accepts any `wss://` host, so a relay can be used where `generativelanguage.googleapis.com` is not directly reachable.
+
 ## LLM Models
 
 In Voxt, the remote LLM configuration sheet supports both preset models and custom model IDs. The sections below list the main model ranges that are already built into the app for each provider.

--- a/docs/RemoteModel.zh-CN.md
+++ b/docs/RemoteModel.zh-CN.md
@@ -94,6 +94,28 @@ key：`xxxx`
 
 <img width="915" height="681" alt="image" src="https://github.com/user-attachments/assets/1da2f293-df35-4d6a-aa3a-6bc50cab571a" />
 
+### Google Gemini
+
+- 默认推荐：`gemini-3.5-transcribe-live`
+- 内置模型：`gemini-3.5-transcribe-live`
+- 简介：Google 的实时语音转写模型，通过 Gemini Live API 的 WebSocket 接入。支持 85+ 语言自动检测，保留句中中英混说，SMART 模式会在文本落到光标前去掉口水词并补好标点。
+
+- [官网](https://ai.google.dev/)
+- [api 文档](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe)
+- [key 管理](https://aistudio.google.com/apikey)
+
+端点：`wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent`
+key: `xxxx`
+
+重要说明：
+
+- Voxt 中这一档只用于语音输入，不支持文件转写和会议模式，因为只接了流式模型。
+- API Key 在建立连接时追加到 WebSocket URL 上，不要填进 endpoint；粘贴进来的 `key` 查询参数会被去掉。
+- 上下文短语和词典条目会作为 `customVocabulary` 发送，上限 1000 条，Google 建议 100 条左右效果最好。
+- 语言提示来自你选择的用户语言。关掉“跟随主语言”会发送空列表，那才是完全自动检测。
+- 单次实时会话上限 10 分钟，Voxt 不会中途重连，超过这个长度的一次听写会被截断。
+- endpoint 支持任意 `wss://` 地址，`generativelanguage.googleapis.com` 直连不通时可以填中转地址。
+
 ## LLM 模型
 
 Voxt 的远程 LLM 配置页除了内置预置模型外，也支持手动填写自定义模型 ID；下面先列出每个服务商在 app 中已经预置好的主流模型范围。


### PR DESCRIPTION
<img width="312" height="125" alt="Firefox Developer Edition 2026-08-31 14 55 14" src="https://github.com/user-attachments/assets/783c676c-0250-4036-b87e-f32d3cc3842e" />
<img width="932" height="704" alt="图片" src="https://github.com/user-attachments/assets/07e0906c-5cbe-4e84-a0bd-9b93c6655e92" />


**Diff at a glance** / **改动构成**

| | files / 文件 | lines / 行数 |
|---|---:|---:|
| Business code / 业务代码 | 21 | +909 −10 |
| Tests / 测试 | 3 | +130 −0 |
| Docs / 文档 | 2 | +44 −0 |
| Localization / 本地化 | 3 | +21 −0 |

Of the business code, 344 lines are the new `GeminiLiveStreamingSupport.swift`, 202 are payload and endpoint helpers in `RemoteASRSupport.swift`, 108 are the streaming context and response state, and 100 are the connectivity test. The remaining 155 are one-case-per-switch wiring across 17 files.

业务代码里 344 行是新增的 `GeminiLiveStreamingSupport.swift`，202 行是 `RemoteASRSupport.swift` 中的 payload 与端点解析，108 行是 streaming context 与 response state，100 行是连通性测试。其余 155 行是分散在 17 个文件里的枚举分支接线。

---


### 这个 PR 做了什么

新增 `googleGeminiASR` 这一档远程 ASR，接入 Google 在 2026 年 8 月 26 日发布的 `gemini-3.5-transcribe-live`，走 Gemini Live API 的 WebSocket（`BidiGenerateContent`）。

选它的理由是这个模型对中文语音输入的场景比较合适：85+ 语言自动检测、句中中英混说不会断、SMART 模式在文本落到光标前就去掉口水词并补好标点。免费额度对个人日常听写量基本够用。

### 实现方式

流式部分完全对齐仓库里已有的 StepFun 实时链路，没有引入新的抽象：

- `GeminiLiveStreamingContext` + `GeminiLiveResponseState` 放在 `RemoteASRStreamingContexts.swift`，和 `StepFunStreamingContext` / `AliyunQwenResponseState` 同构
- 音频采集随 socket 一起启动，PCM 先进内存缓冲，收到 `setupComplete` 后一次性排空。握手要几百毫秒，不缓冲就会吃掉第一个音节
- 上行 `realtimeInput`，16 kHz 单声道 PCM16，复用现成的 `makeDoubaoPCM16MonoData`
- `interimInputTranscription` 驱动实时预览，`inputTranscription` 提交分段
- 松手发 `realtimeInput.audioStreamEnd`，然后等定稿

### 几个刻意的取舍

**只接流式。** 一元的 `gemini-3.5-transcribe`（文件式）没有接，文件转写和会议模式会抛一条本地化的错误提示，而不是静默失败。模型下拉里只提供 `gemini-3.5-transcribe-live` 一项。

**服务端自动 VAD**，所以不需要客户端的 commit 协议。这里有个坑：每次说话停顿都会结束一个 turn，所以只有在我们自己发出 `audioStreamEnd` 之后收到的终止事件才算会话真的结束，否则停止录音时的排空窗口里撞上上一轮的 `turnComplete` 会提前判定结束、丢掉尾巴。

**`mode` 固定为 SMART。** 上下文短语和词典条目合并后作为 `customVocabulary` 发送，上限 1000 条（官方建议 100 条左右效果最优）。

**语言提示跟随用户已选语言**，关掉"跟随主语言"时发空数组，那才是完全自动检测加句中混说。

**API Key 只在建立连接时拼到 socket URL 上**，不写进 endpoint 字段、不进日志，用户粘贴进来的 `key` 查询参数会被剥掉。endpoint 字段接受任意 `wss://` 地址，直连不通的网络环境可以填中转。

**分段拼接按 CJK 边界判断是否加空格**，中文输出不会多出零散空格，英文句子之间照常有空格。

**缓冲上限常量重命名。** 原来叫 `stepFunPendingAudioByteLimit`，现在两条实时链路共用，改成 `realtimePendingAudioByteLimit`。这是本 PR 里唯一一处触及既有代码语义的改动。

### 已知限制

- 单次实时会话被 API 限制在 10 分钟，本 PR 没有做中途重连，一次连续说超过这个长度会被截断
- 不支持说话人分离和词级时间戳，流式模型本身没有这两项能力
- 会议模式不支持（和 `glmASR` / `stepFunASR` / `xiaomiMiMoASR` 的处理方式一致）

---


### What this PR does

Adds `googleGeminiASR` as a remote ASR provider backed by `gemini-3.5-transcribe-live`, the live speech-to-text model Google shipped on 2026-08-26, reached over the Gemini Live API WebSocket (`BidiGenerateContent`).

It fits the Chinese voice-input case well: auto-detection across 85+ languages, mid-sentence code-mixing stays intact, and SMART mode removes filler words and formats punctuation before the text reaches the cursor. The free tier covers ordinary personal dictation volume.

### How it is built

The streaming path follows the existing StepFun realtime shape, with no new abstractions:

- `GeminiLiveStreamingContext` and `GeminiLiveResponseState` live in `RemoteASRStreamingContexts.swift`, structurally identical to `StepFunStreamingContext` and `AliyunQwenResponseState`
- Audio capture starts with the socket and buffers PCM in memory until `setupComplete` arrives, then flushes. The handshake takes a few hundred milliseconds, and without the buffer the first syllable is lost
- Chunks go up as `realtimeInput` at 16 kHz mono PCM16, reusing the existing `makeDoubaoPCM16MonoData`
- `interimInputTranscription` drives the live preview, `inputTranscription` commits segments
- Releasing the hotkey sends `realtimeInput.audioStreamEnd`, then waits for the final transcript

### Deliberate decisions

**Streaming only.** The unary `gemini-3.5-transcribe` model is not wired, so file transcription and Meeting mode throw a localized error instead of failing silently. The model picker offers `gemini-3.5-transcribe-live` alone.

**Server-side automatic VAD**, so no client commit protocol is needed. One subtlety: a turn ends on every pause, so only a terminal event arriving after our own `audioStreamEnd` ends the session. Otherwise a stale `turnComplete` landing inside the stop drain window would cut the tail off.

**`mode` is fixed to SMART.** Contextual phrases and dictionary terms are merged into `customVocabulary`, capped at 1000 terms (Google suggests around 100 for best results).

**Language hints follow the selected user languages.** Turning off "follow main language" sends an empty list, which is what enables full auto-detection and code-mixing.

**The API key is appended to the socket URL at connect time only.** It is never stored in the endpoint field or written to logs, and a pasted `key` query parameter is stripped. The endpoint field accepts any `wss://` host, so a relay works where the Google host is not directly reachable.

**Transcript segments join per boundary.** No separator across CJK boundaries, so Chinese output does not gain stray spaces, while English turns still get one.

**One rename.** `stepFunPendingAudioByteLimit` is now shared by two realtime paths, so it became `realtimePendingAudioByteLimit`. That is the only place this PR touches existing behavior.

### Known limitations

- The API caps a live session at 10 minutes. This PR does not reconnect mid-session, so a single dictation longer than that is cut short
- No speaker diarization and no word-level timestamps; the streaming model does not offer either
- Meeting mode is unsupported, handled the same way as `glmASR`, `stepFunASR` and `xiaomiMiMoASR`



close #147
